### PR TITLE
Adds ability to propose infinite and compact dimensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "az"
@@ -22,7 +22,7 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "buoyant"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "crossterm",
  "embedded-graphics",
@@ -44,15 +44,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "crossterm"
-version = "0.27.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
- "libc",
  "mio",
  "parking_lot",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -91,6 +91,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "float-cmp"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,9 +130,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
@@ -148,14 +164,14 @@ checksum = "c3c8dda44ff03a2f238717214da50f65d5a53b45cd213a7370424ffdb6fae815"
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -187,16 +203,29 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -277,26 +306,20 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.48.5"
+name = "windows-sys"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -305,21 +328,15 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -329,21 +346,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -359,21 +364,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -383,21 +376,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "buoyant"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Riley Williams"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -20,7 +20,7 @@ crossterm = ["dep:crossterm", "std"]
 embedded-graphics = ["dep:embedded-graphics-core", "dep:embedded-graphics"]
 
 [dependencies]
-crossterm = { version = "^0.27", optional = true }
+crossterm = { version = "^0.28", optional = true }
 embedded-graphics-core = { version = "^0.4", optional = true }
 embedded-graphics = { version = "^0.8", optional = true }
 heapless = "^0.8"

--- a/README.md
+++ b/README.md
@@ -1,64 +1,76 @@
 # Buoyant
 
 <!--toc:start-->
-
 - [Buoyant](#buoyant)
-  - [Goals](#goals)
+  - [Capabilities](#capabilities)
   - [Layout and rendering](#layout-and-rendering)
   - [Available render targets](#available-render-targets)
   - [Roadmap](#roadmap)
   - [Usage notes](#usage-notes)
   - [License](#license)
   - [Contribution](#contribution)
-  <!--toc:end-->
+<!--toc:end-->
 
-This is a library for writing and rendering SwiftUI-like layouts in Rust.
+This is a library for writing and rendering SwiftUI-like layouts in Rust,
+primarily intended for use on embedded systems.
 
-## Goals
+## Capabilities
 
 - Embedded / no_std support:
   - Zero heap allocation
   - Minimal memory footprint
-  - Immediate mode, CPU rendering
 - Support for both character-based and pixel-based rendering and layout
-- Ability to support a variety of render devices (e.g., terminal,
+- Ability to support a variety of render devices (terminal,
   framebuffer, SPI display, ...)
 
 ## Layout and rendering
 
 Layout code is shared across all pixel types. Views produce a layout
 which can then be rendered to a render target, calling the rendering code
-specific to the render target's pixel type.
+specific to the render target's pixel type. This allows creating support for
+arbitrary render backends.
 
 ## Available render targets
 
+- `embedded-graphics` displays, with "native" fonts and colors.
 - `TextBuffer`: A basic fixed-size `char` buffer. Does not respect graphemes.
   This is primarily useful for testing and debugging.
-
 - `CrossTerm`: Renders colored character-pixels to a terminal using
   the `crossterm` crate.
 
 ## Roadmap
 
-Right now, all the core components exist to build and render static views.
+Right now, core components exist to build and render a wide variety of
+basic static views. In the current state, usability far exceeds manual
+layout using embedded-graphics primitives directly.
 
-These are the planned features, in order of priority:
+These are the currently planned features:
 
-- embedded-graphics trait implementations
-- default pixel rendering for pixel-based render targets
-- More robust Font support
-  - embedded-graphics fonts
-  - Embedded SPI displays with built-in fonts
+### Distinct View and Widget trees
+
 - State management
   - Layout reuse
-  - Animations
+  - Animation
+
 - Interactivity
   - click/tap routing
-  - focus management / keyboard input
+  - focus management + keyboard input
 
-These things would be nice:
+### Rendering
 
-- Unicode / grapheme support for proper text handling outside embedded
+- Canvas view for arbitrary path/shape/raster drawing
+  - The rendering implementation exclusively targets embedded-graphics,
+    but migrating everything to a canvas interface would enable reusing
+    the rendering logic for other backends.
+- Shape stroke/fill
+- Embedded SPI displays with built-in fonts
+- Alpha blending
+  - Rendering is currently write-only, enabling framebufferless rendering
+
+### Text
+
+- Unicode breaking character support for better text wrapping on
+  less resource-constrained devices.
 
 ## Usage notes
 

--- a/examples/crossterm.rs
+++ b/examples/crossterm.rs
@@ -43,7 +43,7 @@ fn main() {
                 &font,
             )
                 .multiline_text_alignment(HorizontalTextAlignment::Trailing)
-                .flex_frame(Some(10), Some(35), None, None, None, None),
+                .flex_frame().with_min_width(10).with_max_width(35),
         ))
             .with_spacing(1)
             .with_alignment(VerticalAlignment::Bottom),
@@ -80,7 +80,7 @@ fn main() {
     println!("View size {}", std::mem::size_of_val(&stack));
     println!("Env size {}", std::mem::size_of_val(&env));
 
-    let layout = stack.layout(target.size(), &env);
+    let layout = stack.layout(target.size().into(), &env);
     stack.render(&mut target, &layout, Point::zero(), &env);
 
     target.flush();
@@ -99,7 +99,7 @@ fn main() {
             Event::Resize(width, height) => {
                 target.clear(blank_color);
                 size = Size::new(width, height);
-                let layout = stack.layout(size, &env);
+                let layout = stack.layout(size.into(), &env);
                 stack.render(&mut target, &layout, Point::zero(), &env);
 
                 target.flush();

--- a/examples/profiler.rs
+++ b/examples/profiler.rs
@@ -11,11 +11,11 @@ use buoyant::{
 fn main() {
     let mut target = FixedTextBuffer::<100, 100>::default();
 
-    target.clear(());
+    target.clear(None);
     let mut size = target.size();
     println!("Size {:?}", size);
 
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
 
     let font = BufferCharacterFont {};
     let stack = VStack::new((
@@ -49,14 +49,14 @@ fn main() {
 
     println!("View size {}", std::mem::size_of_val(&stack));
     println!("Env size {}", std::mem::size_of_val(&env));
-    let sample_layout = stack.layout(size, &env);
+    let sample_layout = stack.layout(size.into(), &env);
     println!("Layout size {}", std::mem::size_of_val(&sample_layout));
 
-    target.clear(());
+    target.clear(None);
     for width in 1..100 {
         for height in 1..100 {
             size = Size::new(width, height);
-            let layout = stack.layout(size, &env);
+            let layout = stack.layout(size.into(), &env);
             stack.render(&mut target, &layout, Point::zero(), &env);
         }
     }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1,3 +1,6 @@
+mod dimension;
+pub use dimension::*;
+
 use core::cmp::max;
 
 #[derive(Debug, PartialEq, Clone, Copy, Default)]

--- a/src/primitives/dimension.rs
+++ b/src/primitives/dimension.rs
@@ -1,0 +1,324 @@
+use crate::layout::ProposedDimensions;
+
+use super::Size;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ProposedDimension {
+    /// An exactly sized offer
+    Exact(u16),
+    /// A request for the most compact size a view can manage
+    Compact,
+    /// An offer of infinite size
+    Infinite,
+}
+
+impl ProposedDimension {
+    /// Returns the most flexible dimension within the proposal
+    /// Magic size of 10 points is applied to views that have no implicit size
+    pub fn resolve_most_flexible(self, minimum: u16, ideal: u16) -> Dimension {
+        match self {
+            ProposedDimension::Compact => Dimension(ideal),
+            ProposedDimension::Exact(d) => Dimension(d.max(minimum)),
+            ProposedDimension::Infinite => Dimension::infinite(),
+        }
+    }
+}
+
+impl From<u16> for ProposedDimension {
+    fn from(value: u16) -> Self {
+        ProposedDimension::Exact(value)
+    }
+}
+
+impl core::ops::Add<u16> for ProposedDimension {
+    type Output = ProposedDimension;
+
+    fn add(self, rhs: u16) -> Self::Output {
+        match self {
+            ProposedDimension::Compact => ProposedDimension::Compact,
+            ProposedDimension::Exact(d) => ProposedDimension::Exact(d + rhs),
+            ProposedDimension::Infinite => ProposedDimension::Infinite,
+        }
+    }
+}
+
+impl core::ops::Sub<u16> for ProposedDimension {
+    type Output = ProposedDimension;
+
+    fn sub(self, rhs: u16) -> Self::Output {
+        match self {
+            ProposedDimension::Compact => ProposedDimension::Compact,
+            ProposedDimension::Exact(d) => ProposedDimension::Exact(d.saturating_sub(rhs)),
+            ProposedDimension::Infinite => ProposedDimension::Infinite,
+        }
+    }
+}
+
+impl core::ops::Mul<u16> for ProposedDimension {
+    type Output = ProposedDimension;
+
+    fn mul(self, rhs: u16) -> Self::Output {
+        match self {
+            ProposedDimension::Compact => ProposedDimension::Compact,
+            ProposedDimension::Exact(d) => ProposedDimension::Exact(d.saturating_mul(rhs)),
+            ProposedDimension::Infinite => ProposedDimension::Infinite,
+        }
+    }
+}
+
+impl core::ops::Div<u16> for ProposedDimension {
+    type Output = ProposedDimension;
+
+    fn div(self, rhs: u16) -> Self::Output {
+        match self {
+            ProposedDimension::Compact => ProposedDimension::Compact,
+            ProposedDimension::Exact(d) => ProposedDimension::Exact(d.saturating_div(rhs)),
+            ProposedDimension::Infinite => ProposedDimension::Infinite,
+        }
+    }
+}
+
+/// The dimension of a single axis
+/// u16::MAX is treated as infinity, and this type mostly exists to prevent accidental panics from
+/// operations overflowing
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Dimension(u16);
+
+impl Dimension {
+    pub const fn infinite() -> Self {
+        Self(u16::MAX)
+    }
+
+    pub const fn is_infinite(self) -> bool {
+        self.0 == u16::MAX
+    }
+}
+
+impl From<Dimension> for u16 {
+    fn from(value: Dimension) -> Self {
+        value.0
+    }
+}
+impl From<Dimension> for i16 {
+    fn from(value: Dimension) -> Self {
+        value.0.try_into().unwrap_or(i16::MAX)
+    }
+}
+
+impl From<Dimension> for u32 {
+    fn from(value: Dimension) -> Self {
+        value.0 as u32
+    }
+}
+
+impl From<u16> for Dimension {
+    fn from(value: u16) -> Self {
+        Self(value)
+    }
+}
+
+impl core::ops::Add for Dimension {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self(self.0.saturating_add(rhs.0))
+    }
+}
+
+impl core::ops::Sub for Dimension {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self(self.0.saturating_sub(rhs.0))
+    }
+}
+
+impl core::ops::Mul for Dimension {
+    type Output = Self;
+    fn mul(self, rhs: Self) -> Self::Output {
+        Self(self.0.saturating_mul(rhs.0))
+    }
+}
+
+impl core::ops::Div for Dimension {
+    type Output = Self;
+
+    fn div(self, rhs: Self) -> Self::Output {
+        Self(self.0.saturating_div(rhs.0))
+    }
+}
+
+impl core::ops::AddAssign for Dimension {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
+    }
+}
+
+impl core::ops::SubAssign for Dimension {
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
+    }
+}
+
+impl core::ops::Add<u16> for Dimension {
+    type Output = Self;
+
+    fn add(self, rhs: u16) -> Self::Output {
+        Self(self.0.saturating_add(rhs))
+    }
+}
+
+impl core::ops::Sub<u16> for Dimension {
+    type Output = Self;
+
+    fn sub(self, rhs: u16) -> Self::Output {
+        Self(self.0.saturating_sub(rhs))
+    }
+}
+
+impl core::ops::Mul<u16> for Dimension {
+    type Output = Self;
+    fn mul(self, rhs: u16) -> Self::Output {
+        Self(self.0.saturating_mul(rhs))
+    }
+}
+
+impl core::ops::Div<u16> for Dimension {
+    type Output = Self;
+
+    fn div(self, rhs: u16) -> Self::Output {
+        Self(self.0.saturating_div(rhs))
+    }
+}
+
+impl core::ops::AddAssign<u16> for Dimension {
+    fn add_assign(&mut self, rhs: u16) {
+        *self = *self + rhs;
+    }
+}
+
+impl core::ops::SubAssign<u16> for Dimension {
+    fn sub_assign(&mut self, rhs: u16) {
+        *self = *self - rhs;
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Dimensions {
+    pub width: Dimension,
+    pub height: Dimension,
+}
+
+impl Dimensions {
+    pub fn new(width: u16, height: u16) -> Self {
+        Self {
+            width: Dimension(width),
+            height: Dimension(height),
+        }
+    }
+
+    pub fn zero() -> Self {
+        Self {
+            width: Dimension(0),
+            height: Dimension(0),
+        }
+    }
+
+    pub fn union(self, other: Self) -> Self {
+        Self {
+            width: self.width.max(other.width),
+            height: self.height.max(other.height),
+        }
+    }
+
+    pub fn intersection(self, other: Self) -> Self {
+        Self {
+            width: self.width.min(other.width),
+            height: self.height.min(other.height),
+        }
+    }
+
+    pub fn intersecting_proposal(self, offer: ProposedDimensions) -> Self {
+        Self {
+            width: match offer.width {
+                ProposedDimension::Compact => self.width,
+                ProposedDimension::Exact(d) => Dimension(self.width.0.min(d)),
+                ProposedDimension::Infinite => self.width,
+            },
+            height: match offer.height {
+                ProposedDimension::Compact => self.height,
+                ProposedDimension::Exact(d) => Dimension(self.height.0.min(d)),
+                ProposedDimension::Infinite => self.height,
+            },
+        }
+    }
+
+    pub fn area(self) -> u16 {
+        (self.width * self.height).0
+    }
+}
+
+impl core::ops::Add for Dimensions {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self {
+            width: self.width + rhs.width,
+            height: self.height + rhs.height,
+        }
+    }
+}
+
+impl core::ops::Add<Size> for Dimensions {
+    type Output = Self;
+
+    fn add(self, rhs: Size) -> Self::Output {
+        Self {
+            width: self.width + rhs.width,
+            height: self.height + rhs.height,
+        }
+    }
+}
+
+impl From<Size> for Dimensions {
+    fn from(value: Size) -> Self {
+        Self {
+            width: Dimension(value.width),
+            height: Dimension(value.height),
+        }
+    }
+}
+
+impl From<Dimensions> for Size {
+    fn from(value: Dimensions) -> Self {
+        Self {
+            width: value.width.into(),
+            height: value.height.into(),
+        }
+    }
+}
+
+#[cfg(feature = "embedded-graphics")]
+impl From<Dimensions> for embedded_graphics_core::geometry::Size {
+    fn from(value: Dimensions) -> Self {
+        embedded_graphics_core::geometry::Size::new(value.width.0 as u32, value.height.0 as u32)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ProposedDimension;
+
+    #[test]
+    fn proposed_dimension_order() {
+        assert_eq!(ProposedDimension::Compact, ProposedDimension::Compact);
+        assert_eq!(ProposedDimension::Exact(0), ProposedDimension::Exact(0));
+        assert_eq!(ProposedDimension::Exact(10), ProposedDimension::Exact(10));
+        assert_eq!(ProposedDimension::Infinite, ProposedDimension::Infinite);
+        assert!(ProposedDimension::Compact > ProposedDimension::Exact(0));
+        assert!(ProposedDimension::Compact > ProposedDimension::Exact(100));
+        assert!(ProposedDimension::Compact < ProposedDimension::Infinite);
+        assert!(ProposedDimension::Exact(0) < ProposedDimension::Infinite);
+        assert!(ProposedDimension::Exact(u16::MAX) < ProposedDimension::Infinite);
+    }
+}

--- a/src/render_target/fixed_text_buffer.rs
+++ b/src/render_target/fixed_text_buffer.rs
@@ -31,17 +31,17 @@ impl<const W: usize, const H: usize> Default for FixedTextBuffer<W, H> {
 }
 
 impl<const W: usize, const H: usize> CharacterRenderTarget for FixedTextBuffer<W, H> {
-    type Color = ();
+    type Color = Option<char>;
 
     fn size(&self) -> Size {
         Size::new(W as u16, H as u16)
     }
 
-    fn draw(&mut self, point: Point, item: char, _color: ()) {
+    fn draw(&mut self, point: Point, item: char, color: Option<char>) {
         let x = point.x as usize;
         let y = point.y as usize;
         if y < H && x < W {
-            self.text[y][x] = item;
+            self.text[y][x] = color.unwrap_or(item);
         }
     }
 }

--- a/src/view.rs
+++ b/src/view.rs
@@ -45,24 +45,8 @@ pub trait LayoutExtensions: Sized {
         )
     }
 
-    fn flex_frame(
-        self,
-        min_width: Option<u16>,
-        max_width: Option<u16>,
-        min_height: Option<u16>,
-        max_height: Option<u16>,
-        horizontal_alignment: Option<crate::layout::HorizontalAlignment>,
-        vertical_alignment: Option<crate::layout::VerticalAlignment>,
-    ) -> FlexFrame<Self> {
-        FlexFrame::new(
-            self,
-            min_width,
-            max_width,
-            min_height,
-            max_height,
-            horizontal_alignment,
-            vertical_alignment,
-        )
+    fn flex_frame(self) -> FlexFrame<Self> {
+        FlexFrame::new(self)
     }
 
     fn priority(self, priority: u16) -> Priority<Self> {

--- a/src/view/conditional_view.rs
+++ b/src/view/conditional_view.rs
@@ -1,5 +1,5 @@
 use crate::{
-    layout::{Layout, ResolvedLayout},
+    layout::{Layout, ProposedDimensions, ResolvedLayout},
     primitives::Point,
     render::CharacterRender,
 };
@@ -33,7 +33,7 @@ impl<U: Layout, V: Layout> Layout for ConditionalView<U, V> {
 
     fn layout(
         &self,
-        offer: crate::primitives::Size,
+        offer: ProposedDimensions,
         env: &impl crate::environment::LayoutEnvironment,
     ) -> ResolvedLayout<Self::Sublayout> {
         if self.condition {
@@ -50,6 +50,22 @@ impl<U: Layout, V: Layout> Layout for ConditionalView<U, V> {
                 sublayouts: ConditionalViewLayout::FalseLayout(child_layout),
                 resolved_size,
             }
+        }
+    }
+
+    fn priority(&self) -> i8 {
+        if self.condition {
+            self.true_view.priority()
+        } else {
+            self.false_view.priority()
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        if self.condition {
+            self.true_view.is_empty()
+        } else {
+            self.false_view.is_empty()
         }
     }
 }

--- a/src/view/empty_view.rs
+++ b/src/view/empty_view.rs
@@ -1,6 +1,6 @@
 use crate::{
-    layout::{Layout, ResolvedLayout},
-    primitives::{Point, Size},
+    layout::{Layout, ProposedDimensions, ResolvedLayout},
+    primitives::{Dimensions, Point},
     render::CharacterRender,
     render_target::CharacterRenderTarget,
 };
@@ -12,17 +12,21 @@ impl Layout for EmptyView {
     type Sublayout = ();
     fn layout(
         &self,
-        _: Size,
+        _: ProposedDimensions,
         _: &impl crate::environment::LayoutEnvironment,
     ) -> ResolvedLayout<Self::Sublayout> {
         ResolvedLayout {
             sublayouts: (),
-            resolved_size: Size::default(),
+            resolved_size: Dimensions::zero(),
         }
     }
 
     fn priority(&self) -> i8 {
         i8::MIN
+    }
+
+    fn is_empty(&self) -> bool {
+        true
     }
 }
 

--- a/src/view/foreach.rs
+++ b/src/view/foreach.rs
@@ -1,9 +1,9 @@
-use core::cmp::{max, min};
+use core::cmp::max;
 
 use crate::{
     environment::{LayoutEnvironment, RenderEnvironment},
-    layout::{HorizontalAlignment, Layout, LayoutDirection, ResolvedLayout},
-    primitives::{Point, Size},
+    layout::{HorizontalAlignment, Layout, LayoutDirection, ProposedDimensions, ResolvedLayout},
+    primitives::{Dimension, Dimensions, Point, ProposedDimension},
     render::CharacterRender,
 };
 
@@ -76,7 +76,11 @@ where
     // This layout implementation trades extra work for lower memory usage as embedded is the
     // primary target environment. Views are repeatedly created for every layout call, but it
     // should be assumed that this is cheap
-    fn layout(&self, offer: Size, env: &impl LayoutEnvironment) -> ResolvedLayout<Self::Sublayout> {
+    fn layout(
+        &self,
+        offer: ProposedDimensions,
+        env: &impl LayoutEnvironment,
+    ) -> ResolvedLayout<Self::Sublayout> {
         let env = &ForEachEnvironment::from(env);
         let mut sublayouts: heapless::Vec<ResolvedLayout<V::Sublayout>, N> = heapless::Vec::new();
 
@@ -88,15 +92,15 @@ where
         //     // TODO: log an error, iterator was too large
         // }
 
-        let mut subview_stages: heapless::Vec<(LayoutStage, i8), N> = heapless::Vec::new();
+        let mut subview_stages: heapless::Vec<(i8, bool), N> = heapless::Vec::new();
         // fill sublayouts with an initial garbage layout
         for item in &items {
             let view = (self.build_view)(item);
             _ = sublayouts.push(view.layout(offer, env));
-            _ = subview_stages.push((LayoutStage::Unsized, view.priority()));
+            _ = subview_stages.push((view.priority(), view.is_empty()));
         }
 
-        let layout_fn = |index: usize, offer: Size| {
+        let layout_fn = |index: usize, offer: ProposedDimensions| {
             let layout = (self.build_view)(&items[index]).layout(offer, env);
             let size = layout.resolved_size;
             sublayouts[index] = layout;
@@ -111,36 +115,74 @@ where
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
-enum LayoutStage {
-    Unsized,
-    Candidate(Size),
-    Final(Size),
-}
-
 fn layout_n<const N: usize>(
-    subviews: &mut heapless::Vec<(LayoutStage, i8), N>,
-    offer: Size,
+    subviews: &mut heapless::Vec<(i8, bool), N>,
+    offer: ProposedDimensions,
     spacing: u16,
-    mut layout_fn: impl FnMut(usize, Size) -> Size,
-) -> Size {
-    let mut remaining_height = offer
-        .height
-        .saturating_sub(spacing * (subviews.len() - 1) as u16);
-
-    loop {
-        // collect the unsized subviews with the max layout priority into a group
-        let mut subviews_indecies: heapless::Vec<usize, N> =
-            heapless::Vec::from_slice(&[0; N]).expect("This can never fail, N vec from N slice");
-        let mut max = i8::MIN;
-        let mut slice_start: usize = 0;
-        let mut slice_len: usize = 0;
-        for (i, (size, priority)) in subviews.iter().enumerate() {
-            // skip sized subviews
-            if *size != LayoutStage::Unsized {
+    mut layout_fn: impl FnMut(usize, ProposedDimensions) -> Dimensions,
+) -> Dimensions {
+    let ProposedDimension::Exact(height) = offer.height else {
+        let mut total_height: Dimension = 0.into();
+        let mut max_width: Dimension = 0.into();
+        let mut non_empty_views: u16 = 0;
+        for (i, (_, is_empty)) in subviews.iter().enumerate() {
+            // layout must be called at least once on every view to avoid panic unwrapping the
+            // resolved layout.
+            // TODO: Allowing layouts to return a cheap "empty" layout could avoid this?
+            let dimensions = layout_fn(i, offer);
+            if *is_empty {
                 continue;
             }
 
+            total_height += dimensions.height;
+            max_width = max(max_width, dimensions.width);
+            non_empty_views += 1;
+        }
+        return Dimensions {
+            width: max_width,
+            height: total_height + spacing * (non_empty_views.saturating_sub(1)),
+        };
+    };
+
+    // compute the "flexibility" of each view on the vertical axis and sort by decreasing
+    // flexibility
+    // Flexibility is defined as the difference between the responses to 0 and infinite height offers
+    let mut flexibilities: [Dimension; N] = [0.into(); N];
+    let mut num_empty_views = 0;
+    for index in 0..subviews.len() {
+        let min_proposal = ProposedDimensions {
+            width: offer.width,
+            height: ProposedDimension::Exact(0),
+        };
+        let minimum_dimension = layout_fn(index, min_proposal);
+        // skip any further work for empty views
+        if subviews[index].1 {
+            num_empty_views += 1;
+            continue;
+        }
+
+        let max_proposal = ProposedDimensions {
+            width: offer.width,
+            height: ProposedDimension::Infinite,
+        };
+        let maximum_dimension = layout_fn(index, max_proposal);
+        flexibilities[index] = maximum_dimension.height - minimum_dimension.height;
+    }
+
+    let mut remaining_height =
+        height.saturating_sub(spacing * (N.saturating_sub(num_empty_views + 1)) as u16);
+    let mut last_priority_group: Option<i8> = None;
+    let mut max_width: Dimension = 0.into();
+    loop {
+        // collect the unsized subviews with the max layout priority into a group
+        let mut subviews_indecies: [usize; N] = [0; N];
+        let mut max = i8::MIN;
+        let mut slice_start: usize = 0;
+        let mut slice_len: usize = 0;
+        for (i, (priority, is_empty)) in subviews.iter().enumerate() {
+            if last_priority_group.is_some_and(|p| p <= *priority) || *is_empty {
+                continue;
+            }
             match max.cmp(priority) {
                 core::cmp::Ordering::Less => {
                     max = *priority;
@@ -152,104 +194,44 @@ fn layout_n<const N: usize>(
                     if slice_len == 0 {
                         slice_start = i;
                     }
+
                     subviews_indecies[slice_start + slice_len] = i;
                     slice_len += 1;
                 }
                 _ => {}
             }
         }
+        last_priority_group = Some(max);
+
         if slice_len == 0 {
             break;
         }
 
-        // Size all the unsized views that are unwilling to shrink
-        let mut group_offer = Size::new(offer.width, remaining_height / slice_len as u16);
-        let mut remainder = remaining_height as usize % slice_len;
+        let group_indecies = &mut subviews_indecies[slice_start..slice_start + slice_len];
+        group_indecies.sort_by_key(|&i| flexibilities[i]);
 
-        // Create a slice of the subviews to be sized
-        let subviews_indecies = &subviews_indecies[slice_start..slice_start + slice_len];
+        let mut remaining_group_size = group_indecies.len() as u16;
 
-        // Loop until no view candidates are invalidated, or no nonfinal candidates are left
-        loop {
-            let mut did_layout_nonfinal_candidate = false;
-            let mut nonfinal_candidate_invalidated = false;
-            for (i, subview_index) in subviews_indecies.iter().enumerate() {
-                if let LayoutStage::Final(_) = subviews[*subview_index].0 {
-                    continue;
-                }
-                // Adjust the offer height to account for the remainder. The initial views will be
-                // offered an extra pixel. This is mostly important for rendering character pixels
-                // where the pixels are large.
-                let adjusted_offer = if i < remainder {
-                    Size::new(group_offer.width, group_offer.height + 1)
-                } else {
-                    group_offer
-                };
-
-                let subview_size = layout_fn(*subview_index, adjusted_offer);
-                if subview_size.height > adjusted_offer.height {
-                    // The subview is unwilling to shrink, reslice the remaining width
-                    subviews[*subview_index].0 = LayoutStage::Final(subview_size);
-                    remaining_height = remaining_height.saturating_sub(subview_size.height);
-                    slice_len -= 1;
-                    // on the last subview, the length will go to zero
-                    group_offer.height = remaining_height
-                        .checked_div(slice_len as u16)
-                        .unwrap_or(group_offer.height);
-                    if slice_len != 0 {
-                        remainder = i + remaining_height as usize % slice_len;
-                    }
-                    if did_layout_nonfinal_candidate {
-                        nonfinal_candidate_invalidated = true;
-                        break;
-                    }
-                } else {
-                    subviews[*subview_index].0 = LayoutStage::Candidate(subview_size);
-                    did_layout_nonfinal_candidate = true;
-                }
-            }
-            if !nonfinal_candidate_invalidated {
-                break;
-            }
-        }
-        // subtract the candidates from the remaining width
-        for index in subviews_indecies.iter() {
-            if let LayoutStage::Candidate(s) = subviews[*index].0 {
-                remaining_height = remaining_height.saturating_sub(s.height);
-            }
-        }
-
-        if remaining_height > 0 {
-            // If there is any remaining height, offer it to each of the candidate views.
-            // The first view is always offered the extra height first...hope this is right
-            for subview_index in subviews_indecies.iter() {
-                if let LayoutStage::Candidate(s) = subviews[*subview_index].0 {
-                    let leftover = s + Size::new(0, remaining_height);
-                    let subview_size = layout_fn(*subview_index, leftover);
-                    remaining_height -= subview_size.height - s.height;
-                    subviews[*subview_index].0 = LayoutStage::Final(subview_size);
-                    // unnecessary?
-                }
-            }
+        for index in group_indecies {
+            let height_fraction =
+                remaining_height / remaining_group_size + remaining_height % remaining_group_size;
+            let size = layout_fn(
+                *index,
+                ProposedDimensions {
+                    width: offer.width,
+                    height: ProposedDimension::Exact(height_fraction),
+                },
+            );
+            remaining_height = remaining_height.saturating_sub(size.height.into());
+            remaining_group_size -= 1;
+            max_width = max_width.max(size.width);
         }
     }
 
-    // At this point all the subviews should have either a final or a candidate size
-    // Calculate the final VStack size
-    let total_child_size = subviews.iter().fold(
-        Size::new(0, offer.height - remaining_height),
-        |acc, (size, _)| match size {
-            LayoutStage::Final(s) | LayoutStage::Candidate(s) => {
-                Size::new(max(acc.width, s.width), acc.height)
-            }
-            _ => unreachable!(),
-        },
-    );
-
-    Size::new(
-        min(offer.width, total_child_size.width),
-        min(offer.height, total_child_size.height),
-    )
+    Dimensions {
+        width: max_width,
+        height: (height.saturating_sub(remaining_height)).into(),
+    }
 }
 
 impl<const N: usize, Pixel: Copy, I: IntoIterator + Copy, V, F> CharacterRender<Pixel>
@@ -274,15 +256,16 @@ where
             let aligned_origin = origin
                 + Point::new(
                     self.alignment.align(
-                        layout.resolved_size.width as i16,
-                        item_layout.resolved_size.width as i16,
+                        layout.resolved_size.width.into(),
+                        item_layout.resolved_size.width.into(),
                     ),
                     height,
                 );
             let view = (self.build_view)(&item);
             view.render(target, item_layout, aligned_origin, env);
 
-            height += item_layout.resolved_size.height as i16;
+            let item_height: i16 = item_layout.resolved_size.height.into();
+            height += item_height;
         }
     }
 }
@@ -309,22 +292,23 @@ where
     ) {
         let env = &ForEachEnvironment::from(env);
 
-        let mut height = 0;
+        let mut height: i16 = 0;
 
         for (item_layout, item) in layout.sublayouts.iter().zip(self.iter.into_iter()) {
             // TODO: defaulting to center alignment
             let aligned_origin = origin
                 + Point::new(
                     self.alignment.align(
-                        layout.resolved_size.width as i16,
-                        item_layout.resolved_size.width as i16,
+                        layout.resolved_size.width.into(),
+                        item_layout.resolved_size.width.into(),
                     ),
                     height,
                 );
             let view = (self.build_view)(&item);
             view.render(target, item_layout, aligned_origin, env);
 
-            height += item_layout.resolved_size.height as i16;
+            let item_height: i16 = item_layout.resolved_size.height.into();
+            height += item_height;
         }
     }
 }

--- a/src/view/foreach.rs
+++ b/src/view/foreach.rs
@@ -208,7 +208,7 @@ fn layout_n<const N: usize>(
         }
 
         let group_indecies = &mut subviews_indecies[slice_start..slice_start + slice_len];
-        group_indecies.sort_by_key(|&i| flexibilities[i]);
+        group_indecies.sort_unstable_by_key(|&i| flexibilities[i]);
 
         let mut remaining_group_size = group_indecies.len() as u16;
 

--- a/src/view/hstack.rs
+++ b/src/view/hstack.rs
@@ -1,9 +1,9 @@
-use core::cmp::{max, min};
+use core::cmp::max;
 
 use crate::{
     environment::{LayoutEnvironment, RenderEnvironment},
-    layout::{Layout, LayoutDirection, ResolvedLayout, VerticalAlignment},
-    primitives::{Point, Size},
+    layout::{Layout, LayoutDirection, ProposedDimensions, ResolvedLayout, VerticalAlignment},
+    primitives::{Dimension, Dimensions, Point, ProposedDimension},
     render::CharacterRender,
     render_target::CharacterRenderTarget,
 };
@@ -73,20 +73,24 @@ impl<T> HStack<T> {
 impl<U: Layout, V: Layout> Layout for HStack<(U, V)> {
     type Sublayout = (ResolvedLayout<U::Sublayout>, ResolvedLayout<V::Sublayout>);
 
-    fn layout(&self, offer: Size, env: &impl LayoutEnvironment) -> ResolvedLayout<Self::Sublayout> {
+    fn layout(
+        &self,
+        offer: ProposedDimensions,
+        env: &impl LayoutEnvironment,
+    ) -> ResolvedLayout<Self::Sublayout> {
         const N: usize = 2;
         let mut c0: Option<ResolvedLayout<U::Sublayout>> = None;
         let mut c1: Option<ResolvedLayout<V::Sublayout>> = None;
 
         let env = HorizontalEnvironment::from(env);
 
-        let mut f0 = |size: Size| {
+        let mut f0 = |size: ProposedDimensions| {
             let layout = self.items.0.layout(size, &env);
             let size = layout.resolved_size;
             c0 = Some(layout);
             size
         };
-        let mut f1 = |size: Size| {
+        let mut f1 = |size: ProposedDimensions| {
             let layout = self.items.1.layout(size, &env);
             let size = layout.resolved_size;
             c1 = Some(layout);
@@ -94,9 +98,9 @@ impl<U: Layout, V: Layout> Layout for HStack<(U, V)> {
         };
 
         // precalculate priority to avoid multiple dynamic dispatch calls
-        let mut subviews: [(LayoutStage, LayoutFn, i8); N] = [
-            (LayoutStage::Unsized, &mut f0, self.items.0.priority()),
-            (LayoutStage::Unsized, &mut f1, self.items.1.priority()),
+        let mut subviews: [(LayoutFn, i8, bool); N] = [
+            (&mut f0, self.items.0.priority(), self.items.0.is_empty()),
+            (&mut f1, self.items.1.priority(), self.items.1.is_empty()),
         ];
         let total_size = layout_n(&mut subviews, offer, self.spacing);
         ResolvedLayout {
@@ -113,7 +117,11 @@ impl<U: Layout, V: Layout, W: Layout> Layout for HStack<(U, V, W)> {
         ResolvedLayout<W::Sublayout>,
     );
 
-    fn layout(&self, offer: Size, env: &impl LayoutEnvironment) -> ResolvedLayout<Self::Sublayout> {
+    fn layout(
+        &self,
+        offer: ProposedDimensions,
+        env: &impl LayoutEnvironment,
+    ) -> ResolvedLayout<Self::Sublayout> {
         const N: usize = 3;
         let mut c0: Option<ResolvedLayout<U::Sublayout>> = None;
         let mut c1: Option<ResolvedLayout<V::Sublayout>> = None;
@@ -121,19 +129,19 @@ impl<U: Layout, V: Layout, W: Layout> Layout for HStack<(U, V, W)> {
 
         let env = HorizontalEnvironment::from(env);
 
-        let mut f0 = |size: Size| {
+        let mut f0 = |size: ProposedDimensions| {
             let layout = self.items.0.layout(size, &env);
             let size = layout.resolved_size;
             c0 = Some(layout);
             size
         };
-        let mut f1 = |size: Size| {
+        let mut f1 = |size: ProposedDimensions| {
             let layout = self.items.1.layout(size, &env);
             let size = layout.resolved_size;
             c1 = Some(layout);
             size
         };
-        let mut f2 = |size: Size| {
+        let mut f2 = |size: ProposedDimensions| {
             let layout = self.items.2.layout(size, &env);
             let size = layout.resolved_size;
             c2 = Some(layout);
@@ -141,10 +149,10 @@ impl<U: Layout, V: Layout, W: Layout> Layout for HStack<(U, V, W)> {
         };
 
         // precalculate priority to avoid multiple dynamic dispatch calls
-        let mut subviews: [(LayoutStage, LayoutFn, i8); N] = [
-            (LayoutStage::Unsized, &mut f0, self.items.0.priority()),
-            (LayoutStage::Unsized, &mut f1, self.items.1.priority()),
-            (LayoutStage::Unsized, &mut f2, self.items.2.priority()),
+        let mut subviews: [(LayoutFn, i8, bool); N] = [
+            (&mut f0, self.items.0.priority(), self.items.0.is_empty()),
+            (&mut f1, self.items.1.priority(), self.items.1.is_empty()),
+            (&mut f2, self.items.2.priority(), self.items.2.is_empty()),
         ];
         let total_size = layout_n(&mut subviews, offer, self.spacing);
         ResolvedLayout {
@@ -154,144 +162,129 @@ impl<U: Layout, V: Layout, W: Layout> Layout for HStack<(U, V, W)> {
     }
 }
 
-type LayoutFn<'a> = &'a mut dyn FnMut(Size) -> Size;
+type LayoutFn<'a> = &'a mut dyn FnMut(ProposedDimensions) -> Dimensions;
 
 fn layout_n<const N: usize>(
-    subviews: &mut [(LayoutStage, LayoutFn, i8); N],
-    offer: Size,
+    subviews: &mut [(LayoutFn, i8, bool); N],
+    offer: ProposedDimensions,
     spacing: u16,
-) -> Size {
-    let mut remaining_width = offer.width.saturating_sub(spacing * (N - 1) as u16);
-
-    loop {
-        // collect the unsized subviews with the max layout priority into a group
-        let mut subviews_indecies: [usize; N] = [0; N];
-        let mut max = i8::MIN;
-        let mut slice_start: usize = 0;
-        let mut slice_len: usize = 0;
-        for (i, (size, _, priority)) in subviews.iter().enumerate() {
-            // skip sized subviews
-            if *size != LayoutStage::Unsized {
+) -> Dimensions {
+    let ProposedDimension::Exact(width) = offer.width else {
+        let mut total_width: Dimension = 0.into();
+        let mut max_height: Dimension = 0.into();
+        let mut non_empty_views: u16 = 0;
+        for (layout_fn, _, is_empty) in subviews {
+            // layout must be called at least once on every view to avoid panic unwrapping the
+            // resolved layout.
+            // TODO: Allowing layouts to return a cheap "empty" layout could avoid this?
+            let dimensions = layout_fn(offer);
+            if *is_empty {
                 continue;
             }
 
+            total_width += dimensions.width;
+            max_height = max(max_height, dimensions.height);
+            non_empty_views += 1;
+        }
+        return Dimensions {
+            width: total_width + spacing * (non_empty_views.saturating_sub(1)),
+            height: max_height,
+        };
+    };
+
+    // TODO: Include the minimum width, this is more important than the flexibility
+    // if it exceeds the slice size the view is offered.
+    // compute the "flexibility" of each view on the horizontal axis and sort by increasing
+    // flexibility
+    // Flexibility is defined as the difference between the responses to 0 and infinite width offers
+    let mut flexibilities: [Dimension; N] = [0.into(); N];
+    let mut num_empty_views = 0;
+    for index in 0..N {
+        let min_proposal = ProposedDimensions {
+            width: ProposedDimension::Exact(0),
+            height: offer.height,
+        };
+        let minimum_dimension = subviews[index].0(min_proposal);
+        // skip any further work for empty views
+        if subviews[index].2 {
+            num_empty_views += 1;
+            continue;
+        }
+
+        let max_proposal = ProposedDimensions {
+            width: ProposedDimension::Infinite,
+            height: offer.height,
+        };
+        let maximum_dimension = subviews[index].0(max_proposal);
+        flexibilities[index] = maximum_dimension.width - minimum_dimension.width;
+    }
+
+    let mut remaining_width =
+        width.saturating_sub(spacing * (N.saturating_sub(num_empty_views + 1)) as u16);
+    let mut last_priority_group: Option<i8> = None;
+    let mut max_height: Dimension = 0.into();
+
+    loop {
+        // collect the unsized subviews with the max layout priority into a group
+        let mut subviews_indices: [usize; N] = [0; N];
+        let mut max = i8::MIN;
+        let mut slice_start: usize = 0;
+        let mut slice_len: usize = 0;
+        for (i, (_, priority, is_empty)) in subviews.iter().enumerate() {
+            if last_priority_group.is_some_and(|p| p <= *priority) || *is_empty {
+                continue;
+            }
             match max.cmp(priority) {
                 core::cmp::Ordering::Less => {
                     max = *priority;
                     slice_start = i;
                     slice_len = 1;
-                    subviews_indecies[slice_start] = i;
+                    subviews_indices[slice_start] = i;
                 }
                 core::cmp::Ordering::Equal => {
                     if slice_len == 0 {
                         slice_start = i;
                     }
-                    subviews_indecies[slice_start + slice_len] = i;
+
+                    subviews_indices[slice_start + slice_len] = i;
                     slice_len += 1;
                 }
                 _ => {}
             }
         }
+        last_priority_group = Some(max);
+
         if slice_len == 0 {
             break;
         }
 
-        // Size all the unsized views that are unwilling to shrink
-        let mut group_offer = Size::new(remaining_width / slice_len as u16, offer.height);
-        let mut remainder = remaining_width as usize % slice_len;
+        let group_indices = &mut subviews_indices[slice_start..slice_start + slice_len];
+        group_indices.sort_by_key(|&i| flexibilities[i]);
 
-        // Create a slice of the subviews to be sized
-        let subviews_indecies = &subviews_indecies[slice_start..slice_start + slice_len];
+        let mut remaining_group_size = group_indices.len() as u16;
 
-        // Loop until no view candidates are invalidated, or no nonfinal candidates are left
-        loop {
-            let mut did_layout_nonfinal_candidate = false;
-            let mut nonfinal_candidate_invalidated = false;
-            for (i, subview_index) in subviews_indecies.iter().enumerate() {
-                if let LayoutStage::Final(_) = subviews[*subview_index].0 {
-                    continue;
-                }
-                // Adjust the offer width to account for the remainder. The initial views will be
-                // offered an extra pixel. This is mostly important for rendering character pixels
-                // where the pixels are large.
-                let adjusted_offer = if i < remainder {
-                    Size::new(group_offer.width + 1, group_offer.height)
-                } else {
-                    group_offer
-                };
-
-                let subview_size = subviews.get_mut(*subview_index).unwrap().1(adjusted_offer);
-                if subview_size.width > adjusted_offer.width {
-                    // The subview is unwilling to shrink, reslice the remaining width
-                    subviews[*subview_index].0 = LayoutStage::Final(subview_size);
-                    remaining_width = remaining_width.saturating_sub(subview_size.width);
-                    slice_len -= 1;
-                    // on the last subview, the length will go to zero
-                    group_offer.width = remaining_width
-                        .checked_div(slice_len as u16)
-                        .unwrap_or(group_offer.width);
-                    if slice_len != 0 {
-                        remainder = i + remaining_width as usize % slice_len;
-                    }
-
-                    if did_layout_nonfinal_candidate {
-                        nonfinal_candidate_invalidated = true;
-                        break;
-                    }
-                } else {
-                    subviews[*subview_index].0 = LayoutStage::Candidate(subview_size);
-                    did_layout_nonfinal_candidate = true;
-                }
-            }
-            if !nonfinal_candidate_invalidated {
-                break;
-            }
-        }
-        // subtract the candidates from the remaining width
-        for subview_index in subviews_indecies.iter() {
-            if let LayoutStage::Candidate(s) = subviews[*subview_index].0 {
-                remaining_width = remaining_width.saturating_sub(s.width);
-            }
-        }
-
-        if remaining_width > 0 {
-            // If there is any remaining width, offer it to each of the candidate views.
-            // The first view is always offered the extra width first...hope this is right
-            for subview_index in subviews_indecies.iter() {
-                if let LayoutStage::Candidate(s) = subviews[*subview_index].0 {
-                    let leftover = s + Size::new(remaining_width, 0);
-                    let subview_size = subviews.get_mut(*subview_index).unwrap().1(leftover);
-                    remaining_width -= subview_size.width - s.width;
-                    subviews[*subview_index].0 = LayoutStage::Final(subview_size);
-                    // unnecessary?
-                }
-            }
+        for index in group_indices {
+            let width_fraction =
+                remaining_width / remaining_group_size + remaining_width % remaining_group_size;
+            let size = subviews[*index].0(ProposedDimensions {
+                width: ProposedDimension::Exact(width_fraction),
+                height: offer.height,
+            });
+            remaining_width = remaining_width.saturating_sub(size.width.into());
+            remaining_group_size -= 1;
+            max_height = max_height.max(size.height);
         }
     }
 
-    // At this point all the subviews should have either a final or a candidate size
-    // Calculate the final HStack size
-    let total_child_size = subviews.iter().fold(
-        Size::new(offer.width - remaining_width, 0),
-        |acc, (size, _, _)| match size {
-            LayoutStage::Final(s) | LayoutStage::Candidate(s) => {
-                Size::new(acc.width, max(acc.height, s.height))
-            }
-            _ => unreachable!(),
-        },
-    );
+    // Prevent stack from reporting oversize, even if the children misbehave
+    if let ProposedDimension::Exact(offer_height) = offer.height {
+        max_height = max_height.min(offer_height.into());
+    }
 
-    Size::new(
-        min(offer.width, total_child_size.width),
-        min(offer.height, total_child_size.height),
-    )
-}
-
-#[derive(Copy, Clone, Debug, PartialEq)]
-enum LayoutStage {
-    Unsized,
-    Candidate(Size),
-    Final(Size),
+    Dimensions {
+        width: (width.saturating_sub(remaining_width)).into(),
+        height: max_height,
+    }
 }
 
 // -- Character Render
@@ -311,30 +304,35 @@ where
         let env = HorizontalEnvironment::from(env);
         let mut width = 0;
 
-        let offset = Point::new(
-            width,
-            self.alignment.align(
-                layout.resolved_size.height as i16,
-                layout.sublayouts.0.resolved_size.height as i16,
-            ),
-        );
+        if !self.items.0.is_empty() {
+            let offset = Point::new(
+                width,
+                self.alignment.align(
+                    layout.resolved_size.height.into(),
+                    layout.sublayouts.0.resolved_size.height.into(),
+                ),
+            );
 
-        self.items
-            .0
-            .render(target, &layout.sublayouts.0, origin + offset, &env);
+            self.items
+                .0
+                .render(target, &layout.sublayouts.0, origin + offset, &env);
 
-        width += (layout.sublayouts.0.resolved_size.width + self.spacing) as i16;
-        let offset = Point::new(
-            width,
-            self.alignment.align(
-                layout.resolved_size.height as i16,
-                layout.sublayouts.1.resolved_size.height as i16,
-            ),
-        );
+            width += (u16::from(layout.sublayouts.0.resolved_size.width) + self.spacing) as i16;
+        }
 
-        self.items
-            .1
-            .render(target, &layout.sublayouts.1, origin + offset, &env);
+        if !self.items.1.is_empty() {
+            let offset = Point::new(
+                width,
+                self.alignment.align(
+                    layout.resolved_size.height.into(),
+                    layout.sublayouts.1.resolved_size.height.into(),
+                ),
+            );
+
+            self.items
+                .1
+                .render(target, &layout.sublayouts.1, origin + offset, &env);
+        }
     }
 }
 
@@ -354,43 +352,51 @@ where
         let env = HorizontalEnvironment::from(env);
         let mut width = 0;
 
-        let offset = Point::new(
-            width,
-            self.alignment.align(
-                layout.resolved_size.height as i16,
-                layout.sublayouts.0.resolved_size.height as i16,
-            ),
-        );
+        if !self.items.0.is_empty() {
+            let offset = Point::new(
+                width,
+                self.alignment.align(
+                    layout.resolved_size.height.into(),
+                    layout.sublayouts.0.resolved_size.height.into(),
+                ),
+            );
 
-        self.items
-            .0
-            .render(target, &layout.sublayouts.0, origin + offset, &env);
+            self.items
+                .0
+                .render(target, &layout.sublayouts.0, origin + offset, &env);
 
-        width += (layout.sublayouts.0.resolved_size.width + self.spacing) as i16;
-        let offset = Point::new(
-            width,
-            self.alignment.align(
-                layout.resolved_size.height as i16,
-                layout.sublayouts.1.resolved_size.height as i16,
-            ),
-        );
+            width += (u16::from(layout.sublayouts.0.resolved_size.width) + self.spacing) as i16;
+        }
 
-        self.items
-            .1
-            .render(target, &layout.sublayouts.1, origin + offset, &env);
+        if !self.items.1.is_empty() {
+            let offset = Point::new(
+                width,
+                self.alignment.align(
+                    layout.resolved_size.height.into(),
+                    layout.sublayouts.1.resolved_size.height.into(),
+                ),
+            );
 
-        width += (layout.sublayouts.1.resolved_size.width + self.spacing) as i16;
-        let offset = Point::new(
-            width,
-            self.alignment.align(
-                layout.resolved_size.height as i16,
-                layout.sublayouts.2.resolved_size.height as i16,
-            ),
-        );
+            self.items
+                .1
+                .render(target, &layout.sublayouts.1, origin + offset, &env);
 
-        self.items
-            .2
-            .render(target, &layout.sublayouts.2, origin + offset, &env);
+            width += (u16::from(layout.sublayouts.1.resolved_size.width) + self.spacing) as i16;
+        }
+
+        if !self.items.2.is_empty() {
+            let offset = Point::new(
+                width,
+                self.alignment.align(
+                    layout.resolved_size.height.into(),
+                    layout.sublayouts.2.resolved_size.height.into(),
+                ),
+            );
+
+            self.items
+                .2
+                .render(target, &layout.sublayouts.2, origin + offset, &env);
+        }
     }
 }
 
@@ -416,30 +422,35 @@ where
         let env = HorizontalEnvironment::from(env);
         let mut width = 0;
 
-        let offset = Point::new(
-            width,
-            self.alignment.align(
-                layout.resolved_size.height as i16,
-                layout.sublayouts.0.resolved_size.height as i16,
-            ),
-        );
+        if !self.items.0.is_empty() {
+            let offset = Point::new(
+                width,
+                self.alignment.align(
+                    layout.resolved_size.height.into(),
+                    layout.sublayouts.0.resolved_size.height.into(),
+                ),
+            );
 
-        self.items
-            .0
-            .render(target, &layout.sublayouts.0, origin + offset, &env);
+            self.items
+                .0
+                .render(target, &layout.sublayouts.0, origin + offset, &env);
 
-        width += (layout.sublayouts.0.resolved_size.width + self.spacing) as i16;
-        let offset = Point::new(
-            width,
-            self.alignment.align(
-                layout.resolved_size.height as i16,
-                layout.sublayouts.1.resolved_size.height as i16,
-            ),
-        );
+            width += (u16::from(layout.sublayouts.0.resolved_size.width) + self.spacing) as i16;
+        }
 
-        self.items
-            .1
-            .render(target, &layout.sublayouts.1, origin + offset, &env);
+        if !self.items.1.is_empty() {
+            let offset = Point::new(
+                width,
+                self.alignment.align(
+                    layout.resolved_size.height.into(),
+                    layout.sublayouts.1.resolved_size.height.into(),
+                ),
+            );
+
+            self.items
+                .1
+                .render(target, &layout.sublayouts.1, origin + offset, &env);
+        }
     }
 }
 
@@ -461,42 +472,50 @@ where
         let env = HorizontalEnvironment::from(env);
         let mut width = 0;
 
-        let offset = Point::new(
-            width,
-            self.alignment.align(
-                layout.resolved_size.height as i16,
-                layout.sublayouts.0.resolved_size.height as i16,
-            ),
-        );
+        if !self.items.0.is_empty() {
+            let offset = Point::new(
+                width,
+                self.alignment.align(
+                    layout.resolved_size.height.into(),
+                    layout.sublayouts.0.resolved_size.height.into(),
+                ),
+            );
 
-        self.items
-            .0
-            .render(target, &layout.sublayouts.0, origin + offset, &env);
+            self.items
+                .0
+                .render(target, &layout.sublayouts.0, origin + offset, &env);
 
-        width += (layout.sublayouts.0.resolved_size.width + self.spacing) as i16;
-        let offset = Point::new(
-            width,
-            self.alignment.align(
-                layout.resolved_size.height as i16,
-                layout.sublayouts.1.resolved_size.height as i16,
-            ),
-        );
+            width += (u16::from(layout.sublayouts.0.resolved_size.width) + self.spacing) as i16;
+        }
 
-        self.items
-            .1
-            .render(target, &layout.sublayouts.1, origin + offset, &env);
+        if !self.items.1.is_empty() {
+            let offset = Point::new(
+                width,
+                self.alignment.align(
+                    layout.resolved_size.height.into(),
+                    layout.sublayouts.1.resolved_size.height.into(),
+                ),
+            );
 
-        width += (layout.sublayouts.1.resolved_size.width + self.spacing) as i16;
-        let offset = Point::new(
-            width,
-            self.alignment.align(
-                layout.resolved_size.height as i16,
-                layout.sublayouts.2.resolved_size.height as i16,
-            ),
-        );
+            self.items
+                .1
+                .render(target, &layout.sublayouts.1, origin + offset, &env);
 
-        self.items
-            .2
-            .render(target, &layout.sublayouts.2, origin + offset, &env);
+            width += (u16::from(layout.sublayouts.1.resolved_size.width) + self.spacing) as i16;
+        }
+
+        if !self.items.2.is_empty() {
+            let offset = Point::new(
+                width,
+                self.alignment.align(
+                    layout.resolved_size.height.into(),
+                    layout.sublayouts.2.resolved_size.height.into(),
+                ),
+            );
+
+            self.items
+                .2
+                .render(target, &layout.sublayouts.2, origin + offset, &env);
+        }
     }
 }

--- a/src/view/hstack.rs
+++ b/src/view/hstack.rs
@@ -259,7 +259,9 @@ fn layout_n<const N: usize>(
         }
 
         let group_indices = &mut subviews_indices[slice_start..slice_start + slice_len];
-        group_indices.sort_by_key(|&i| flexibilities[i]);
+        // unstable variant is no-alloc, we'll see what instability issues this creates during
+        // frame animation...
+        group_indices.sort_unstable_by_key(|&i| flexibilities[i]);
 
         let mut remaining_group_size = group_indices.len() as u16;
 

--- a/src/view/modifier/fixed_frame.rs
+++ b/src/view/modifier/fixed_frame.rs
@@ -1,7 +1,7 @@
 use crate::{
     environment::{LayoutEnvironment, RenderEnvironment},
-    layout::{HorizontalAlignment, Layout, ResolvedLayout, VerticalAlignment},
-    primitives::{Point, Size},
+    layout::{HorizontalAlignment, Layout, ProposedDimensions, ResolvedLayout, VerticalAlignment},
+    primitives::{Dimension, Dimensions, Point, ProposedDimension},
     render::CharacterRender,
     render_target::CharacterRenderTarget,
 };
@@ -44,16 +44,32 @@ impl<T> PartialEq for FixedFrame<T> {
 impl<V: Layout> Layout for FixedFrame<V> {
     type Sublayout = ResolvedLayout<V::Sublayout>;
 
-    fn layout(&self, offer: Size, env: &impl LayoutEnvironment) -> ResolvedLayout<Self::Sublayout> {
-        let modified_offer = Size::new(
-            self.width.unwrap_or(offer.width),
-            self.height.unwrap_or(offer.height),
-        );
+    fn layout(
+        &self,
+        offer: ProposedDimensions,
+        env: &impl LayoutEnvironment,
+    ) -> ResolvedLayout<Self::Sublayout> {
+        let modified_offer = ProposedDimensions {
+            width: self
+                .width
+                .map(ProposedDimension::Exact)
+                .unwrap_or(offer.width),
+            height: self
+                .height
+                .map(ProposedDimension::Exact)
+                .unwrap_or(offer.height),
+        };
         let child_layout = self.child.layout(modified_offer, env);
-        let resolved_size = Size::new(
-            self.width.unwrap_or(child_layout.resolved_size.width),
-            self.height.unwrap_or(child_layout.resolved_size.height),
-        );
+        let resolved_size = Dimensions {
+            width: self
+                .width
+                .map(Dimension::from)
+                .unwrap_or(child_layout.resolved_size.width),
+            height: self
+                .height
+                .map(Dimension::from)
+                .unwrap_or(child_layout.resolved_size.height),
+        };
         ResolvedLayout {
             sublayouts: child_layout,
             resolved_size,
@@ -75,12 +91,12 @@ where
         let new_origin = origin
             + Point::new(
                 self.horizontal_alignment.unwrap_or_default().align(
-                    layout.resolved_size.width as i16,
-                    layout.sublayouts.resolved_size.width as i16,
+                    layout.resolved_size.width.into(),
+                    layout.sublayouts.resolved_size.width.into(),
                 ),
                 self.vertical_alignment.unwrap_or_default().align(
-                    layout.resolved_size.height as i16,
-                    layout.sublayouts.resolved_size.height as i16,
+                    layout.resolved_size.height.into(),
+                    layout.sublayouts.resolved_size.height.into(),
                 ),
             );
 
@@ -108,12 +124,12 @@ where
         let new_origin = origin
             + Point::new(
                 self.horizontal_alignment.unwrap_or_default().align(
-                    layout.resolved_size.width as i16,
-                    layout.sublayouts.resolved_size.width as i16,
+                    layout.resolved_size.width.into(),
+                    layout.sublayouts.resolved_size.width.into(),
                 ),
                 self.vertical_alignment.unwrap_or_default().align(
-                    layout.resolved_size.height as i16,
-                    layout.sublayouts.resolved_size.height as i16,
+                    layout.resolved_size.height.into(),
+                    layout.sublayouts.resolved_size.height.into(),
                 ),
             );
 

--- a/src/view/modifier/flex_frame.rs
+++ b/src/view/modifier/flex_frame.rs
@@ -1,7 +1,7 @@
 use crate::{
     environment::{LayoutEnvironment, RenderEnvironment},
-    layout::{HorizontalAlignment, Layout, ResolvedLayout, VerticalAlignment},
-    primitives::{Point, Size},
+    layout::{HorizontalAlignment, Layout, ProposedDimensions, ResolvedLayout, VerticalAlignment},
+    primitives::{Dimension, Dimensions, Point, ProposedDimension},
     render::CharacterRender,
     render_target::CharacterRenderTarget,
 };
@@ -9,77 +9,173 @@ use crate::{
 pub struct FlexFrame<T> {
     child: T,
     min_width: Option<u16>,
-    max_width: Option<u16>,
+    ideal_width: Option<u16>,
+    max_width: Option<Dimension>,
     min_height: Option<u16>,
-    max_height: Option<u16>,
-    horizontal_alignment: Option<HorizontalAlignment>,
-    vertical_alignment: Option<VerticalAlignment>,
+    ideal_height: Option<u16>,
+    max_height: Option<Dimension>,
+    horizontal_alignment: HorizontalAlignment,
+    vertical_alignment: VerticalAlignment,
 }
 
 impl<T> FlexFrame<T> {
-    pub fn new(
-        child: T,
-        min_width: Option<u16>,
-        max_width: Option<u16>,
-        min_height: Option<u16>,
-        max_height: Option<u16>,
-        horizontal_alignment: Option<HorizontalAlignment>,
-        vertical_alignment: Option<VerticalAlignment>,
-    ) -> Self {
+    pub fn new(child: T) -> Self {
         Self {
             child,
-            min_width,
-            max_width,
-            min_height,
-            max_height,
-            horizontal_alignment,
-            vertical_alignment,
+            min_width: None,
+            ideal_width: None,
+            max_width: None,
+            min_height: None,
+            ideal_height: None,
+            max_height: None,
+            horizontal_alignment: HorizontalAlignment::default(),
+            vertical_alignment: VerticalAlignment::default(),
         }
+    }
+
+    pub fn with_min_width(mut self, min_width: u16) -> Self {
+        self.min_width = Some(min_width);
+        self
+    }
+
+    pub fn with_ideal_width(mut self, ideal_width: u16) -> Self {
+        self.ideal_width = Some(ideal_width);
+        self
+    }
+
+    pub fn with_max_width(mut self, max_width: u16) -> Self {
+        self.max_width = Some(max_width.into());
+        self
+    }
+
+    pub fn with_infinite_max_width(mut self) -> Self {
+        self.max_width = Some(Dimension::infinite());
+        self
+    }
+
+    pub fn with_min_height(mut self, min_height: u16) -> Self {
+        self.min_height = Some(min_height);
+        self
+    }
+
+    pub fn with_ideal_height(mut self, ideal_height: u16) -> Self {
+        self.ideal_height = Some(ideal_height);
+        self
+    }
+
+    pub fn with_max_height(mut self, max_height: u16) -> Self {
+        self.max_height = Some(max_height.into());
+        self
+    }
+
+    pub fn with_infinite_max_height(mut self) -> Self {
+        self.max_height = Some(Dimension::infinite());
+        self
+    }
+
+    pub fn with_horizontal_alignment(mut self, alignment: HorizontalAlignment) -> Self {
+        self.horizontal_alignment = alignment;
+        self
+    }
+
+    pub fn with_vertical_alignment(mut self, alignment: VerticalAlignment) -> Self {
+        self.vertical_alignment = alignment;
+        self
     }
 }
 
-impl<T> PartialEq for FlexFrame<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.min_width == other.min_width
-            && self.max_width == other.max_width
-            && self.min_height == other.min_height
-            && self.max_height == other.max_height
-            && self.horizontal_alignment == other.horizontal_alignment
-            && self.vertical_alignment == other.vertical_alignment
-    }
+fn clamp_optional<T: Ord + Copy>(mut value: T, min: Option<T>, max: Option<T>) -> T {
+    value = value.min(max.unwrap_or(value));
+    value.max(min.unwrap_or(value))
 }
 
 impl<V: Layout> Layout for FlexFrame<V> {
     type Sublayout = ResolvedLayout<V::Sublayout>;
 
-    fn layout(&self, offer: Size, env: &impl LayoutEnvironment) -> ResolvedLayout<Self::Sublayout> {
-        let min_width = self.min_width.unwrap_or(0);
-        let max_width = self.max_width.unwrap_or(offer.width);
-        let min_height = self.min_height.unwrap_or(0);
-        let max_height = self.max_height.unwrap_or(offer.height);
+    fn layout(
+        &self,
+        offer: ProposedDimensions,
+        env: &impl LayoutEnvironment,
+    ) -> ResolvedLayout<Self::Sublayout> {
+        let sublayout_width_offer = match offer.width {
+            ProposedDimension::Exact(d) => ProposedDimension::Exact(clamp_optional(
+                d,
+                self.min_width,
+                self.max_width.map(|d| d.into()),
+            )),
+            ProposedDimension::Compact => match self.ideal_width {
+                Some(ideal_width) => ProposedDimension::Exact(
+                    self.min_width.map_or(ideal_width, |w| w.max(ideal_width)),
+                ),
+                None => ProposedDimension::Compact,
+            },
+            ProposedDimension::Infinite => match self.max_width {
+                Some(max_width) if max_width.is_infinite() => ProposedDimension::Infinite,
+                Some(max_width) => ProposedDimension::Exact(max_width.into()),
+                None => ProposedDimension::Infinite,
+            },
+        };
 
-        let modified_offer = Size::new(
-            offer.width.min(max_width).max(min_width),
-            offer.height.min(max_height).max(min_height),
-        );
-        let child_layout = self.child.layout(modified_offer, env);
+        let sublayout_height_offer = match offer.height {
+            ProposedDimension::Exact(d) => ProposedDimension::Exact(clamp_optional(
+                d,
+                self.min_height,
+                self.max_height.map(|d| d.into()),
+            )),
+            ProposedDimension::Compact => match self.ideal_height {
+                Some(ideal_height) => ProposedDimension::Exact(
+                    self.min_height
+                        .map_or(ideal_height, |h| h.max(ideal_height)),
+                ),
+                None => ProposedDimension::Compact,
+            },
+            ProposedDimension::Infinite => match self.max_height {
+                Some(max_height) if max_height.is_infinite() => ProposedDimension::Infinite,
+                Some(max_height) => ProposedDimension::Exact(max_height.into()),
+                None => ProposedDimension::Infinite,
+            },
+        };
 
-        let width = self
+        let sublayout_offer = ProposedDimensions {
+            width: sublayout_width_offer,
+            height: sublayout_height_offer,
+        };
+
+        let sublayout = self.child.layout(sublayout_offer, env);
+
+        // restrict self size to min/max regardless of what the sublayout returns
+        let sublayout_width = sublayout.resolved_size.width;
+        let sublayout_height = sublayout.resolved_size.height;
+
+        let w = self
             .max_width
-            .unwrap_or(child_layout.resolved_size.width)
-            .min(offer.width)
-            .max(self.min_width.unwrap_or(child_layout.resolved_size.width));
-        let height = self
-            .max_height
-            .unwrap_or(child_layout.resolved_size.height)
-            .min(offer.height)
-            .max(self.min_height.unwrap_or(child_layout.resolved_size.height));
+            .unwrap_or(sublayout_width)
+            .min(greatest_possible(sublayout_width_offer, sublayout_width))
+            .max(self.min_width.map_or(sublayout_width, |f| f.into()));
 
-        let resolved_size = Size::new(width, height);
+        let h = self
+            .max_height
+            .unwrap_or(sublayout_height)
+            .min(greatest_possible(sublayout_height_offer, sublayout_height))
+            .max(self.min_height.map_or(sublayout_height, |f| f.into()));
+
+        let resolved_size = Dimensions {
+            width: w,
+            height: h,
+        };
+
         ResolvedLayout {
-            sublayouts: child_layout,
+            sublayouts: sublayout,
             resolved_size,
         }
+    }
+}
+
+fn greatest_possible(proposal: ProposedDimension, ideal: Dimension) -> Dimension {
+    match proposal {
+        ProposedDimension::Exact(d) => d.into(),
+        ProposedDimension::Compact => ideal,
+        ProposedDimension::Infinite => Dimension::infinite(),
     }
 }
 
@@ -96,13 +192,13 @@ where
     ) {
         let new_origin = origin
             + Point::new(
-                self.horizontal_alignment.unwrap_or_default().align(
-                    layout.resolved_size.width as i16,
-                    layout.sublayouts.resolved_size.width as i16,
+                self.horizontal_alignment.align(
+                    layout.resolved_size.width.into(),
+                    layout.sublayouts.resolved_size.width.into(),
                 ),
-                self.vertical_alignment.unwrap_or_default().align(
-                    layout.resolved_size.height as i16,
-                    layout.sublayouts.resolved_size.height as i16,
+                self.vertical_alignment.align(
+                    layout.resolved_size.height.into(),
+                    layout.sublayouts.resolved_size.height.into(),
                 ),
             );
 
@@ -129,13 +225,13 @@ where
     ) {
         let new_origin = origin
             + Point::new(
-                self.horizontal_alignment.unwrap_or_default().align(
-                    layout.resolved_size.width as i16,
-                    layout.sublayouts.resolved_size.width as i16,
+                self.horizontal_alignment.align(
+                    layout.resolved_size.width.into(),
+                    layout.sublayouts.resolved_size.width.into(),
                 ),
-                self.vertical_alignment.unwrap_or_default().align(
-                    layout.resolved_size.height as i16,
-                    layout.sublayouts.resolved_size.height as i16,
+                self.vertical_alignment.align(
+                    layout.resolved_size.height.into(),
+                    layout.sublayouts.resolved_size.height.into(),
                 ),
             );
 

--- a/src/view/modifier/foreground_color.rs
+++ b/src/view/modifier/foreground_color.rs
@@ -1,7 +1,7 @@
 use crate::{
     environment::{LayoutEnvironment, RenderEnvironment},
-    layout::{Layout, ResolvedLayout},
-    primitives::{Point, Size},
+    layout::{Layout, ProposedDimensions, ResolvedLayout},
+    primitives::Point,
     render::CharacterRender,
     render_target::CharacterRenderTarget,
 };
@@ -22,7 +22,11 @@ impl<V, Color: Copy> ForegroundStyle<V, Color> {
 impl<Inner: Layout, Color: Copy> Layout for ForegroundStyle<Inner, Color> {
     type Sublayout = Inner::Sublayout;
 
-    fn layout(&self, offer: Size, env: &impl LayoutEnvironment) -> ResolvedLayout<Self::Sublayout> {
+    fn layout(
+        &self,
+        offer: ProposedDimensions,
+        env: &impl LayoutEnvironment,
+    ) -> ResolvedLayout<Self::Sublayout> {
         let modified_env = ForegroundStyleEnv {
             color: self.style,
             wrapped_env: env,

--- a/src/view/modifier/padding.rs
+++ b/src/view/modifier/padding.rs
@@ -1,6 +1,6 @@
 use crate::{
     environment::{LayoutEnvironment, RenderEnvironment},
-    layout::{Layout, ResolvedLayout},
+    layout::{Layout, ProposedDimensions, ResolvedLayout},
     primitives::{Point, Size},
     render::CharacterRender,
     render_target::CharacterRenderTarget,
@@ -29,11 +29,15 @@ impl<T> PartialEq for Padding<T> {
 impl<V: Layout> Layout for Padding<V> {
     type Sublayout = ResolvedLayout<V::Sublayout>;
 
-    fn layout(&self, offer: Size, env: &impl LayoutEnvironment) -> ResolvedLayout<Self::Sublayout> {
-        let padded_offer = Size::new(
-            offer.width.saturating_sub(2 * self.padding),
-            offer.height.saturating_sub(2 * self.padding),
-        );
+    fn layout(
+        &self,
+        offer: ProposedDimensions,
+        env: &impl LayoutEnvironment,
+    ) -> ResolvedLayout<Self::Sublayout> {
+        let padded_offer = ProposedDimensions {
+            width: offer.width - (2 * self.padding),
+            height: offer.height - (2 * self.padding),
+        };
         let child_layout = self.child.layout(padded_offer, env);
         let padding_size =
             child_layout.resolved_size + Size::new(2 * self.padding, 2 * self.padding);

--- a/src/view/modifier/priority.rs
+++ b/src/view/modifier/priority.rs
@@ -1,3 +1,11 @@
+use crate::{
+    environment::{LayoutEnvironment, RenderEnvironment},
+    layout::{Layout, ProposedDimensions, ResolvedLayout},
+    primitives::Point,
+    render::CharacterRender,
+    render_target::CharacterRenderTarget,
+};
+
 /// A view that adds padding around a child view.
 /// When the space offered to the padding is less than 2* the padding, the padding will
 /// not be truncated and will return a size larger than the offer.
@@ -21,7 +29,11 @@ impl<T> PartialEq for Priority<T> {
 impl<V: Layout> Layout for Priority<V> {
     type Sublayout = V::Sublayout;
 
-    fn layout(&self, offer: Size, env: &impl LayoutEnvironment) -> ResolvedLayout<Self::Sublayout> {
+    fn layout(
+        &self,
+        offer: ProposedDimensions,
+        env: &impl LayoutEnvironment,
+    ) -> ResolvedLayout<Self::Sublayout> {
         self.child.layout(offer, env)
     }
 }
@@ -43,14 +55,6 @@ where
 
 #[cfg(feature = "embedded-graphics")]
 use embedded_graphics::draw_target::DrawTarget;
-
-use crate::{
-    environment::{LayoutEnvironment, RenderEnvironment},
-    layout::{Layout, ResolvedLayout},
-    primitives::{Point, Size},
-    render::CharacterRender,
-    render_target::CharacterRenderTarget,
-};
 
 #[cfg(feature = "embedded-graphics")]
 impl<Pixel, View: Layout> crate::render::PixelRender<Pixel> for Priority<View>

--- a/src/view/shape/circle.rs
+++ b/src/view/shape/circle.rs
@@ -1,6 +1,6 @@
 use crate::{
-    layout::{Layout, ResolvedLayout},
-    primitives::{Point, Size},
+    layout::{Layout, ProposedDimensions, ResolvedLayout},
+    primitives::{Dimensions, Point},
 };
 
 #[derive(Debug, Copy, Clone, PartialEq, Default)]
@@ -11,13 +11,13 @@ impl Layout for Circle {
 
     fn layout(
         &self,
-        offer: Size,
+        offer: ProposedDimensions,
         _: &impl crate::environment::LayoutEnvironment,
     ) -> ResolvedLayout<Self::Sublayout> {
-        let minimum_dimension = offer.width.min(offer.height);
+        let minimum_dimension = offer.width.min(offer.height).resolve_most_flexible(0, 10);
         ResolvedLayout {
             sublayouts: (),
-            resolved_size: Size {
+            resolved_size: Dimensions {
                 width: minimum_dimension,
                 height: minimum_dimension,
             },
@@ -43,7 +43,7 @@ impl<P: embedded_graphics_core::pixelcolor::PixelColor> crate::render::PixelRend
             .build();
         _ = embedded_graphics::primitives::Circle::new(
             origin.into(),
-            layout.resolved_size.width as u32,
+            layout.resolved_size.width.into(),
         )
         .draw_styled(&style, target);
     }

--- a/src/view/shape/rectangle.rs
+++ b/src/view/shape/rectangle.rs
@@ -1,6 +1,6 @@
 use crate::{
-    layout::{Layout, ResolvedLayout},
-    primitives::{Point, Size},
+    layout::{Layout, ProposedDimensions, ResolvedLayout},
+    primitives::Point,
     render::CharacterRender,
     render_target::CharacterRenderTarget,
 };
@@ -19,12 +19,12 @@ impl Layout for Rectangle {
 
     fn layout(
         &self,
-        offer: Size,
+        offer: ProposedDimensions,
         _: &impl crate::environment::LayoutEnvironment,
     ) -> ResolvedLayout<Self::Sublayout> {
         ResolvedLayout {
             sublayouts: (),
-            resolved_size: offer,
+            resolved_size: offer.resolve_most_flexible(0, 10),
         }
     }
 }
@@ -40,8 +40,8 @@ impl<P: Copy> CharacterRender<P> for Rectangle {
         let width = layout.resolved_size.width;
         let height = layout.resolved_size.height;
         let color = env.foreground_color();
-        for y in 0..height as i16 {
-            for x in 0..width as i16 {
+        for y in 0..height.into() {
+            for x in 0..width.into() {
                 target.draw(origin + Point::new(x, y), ' ', color);
             }
         }
@@ -67,8 +67,8 @@ impl<P: embedded_graphics_core::pixelcolor::PixelColor> crate::render::PixelRend
         let width = layout.resolved_size.width;
         let height = layout.resolved_size.height;
         let color = env.foreground_color();
-        for y in 0..height as i16 {
-            for x in 0..width as i16 {
+        for y in 0..height.into() {
+            for x in 0..width.into() {
                 let point = origin + Point::new(x, y);
                 _ = target.draw_iter(core::iter::once(embedded_graphics::Pixel(
                     point.into(),

--- a/src/view/shape/rounded_rectangle.rs
+++ b/src/view/shape/rounded_rectangle.rs
@@ -1,6 +1,6 @@
 use crate::{
-    layout::{Layout, ResolvedLayout},
-    primitives::{Point, Size},
+    layout::{Layout, ProposedDimensions, ResolvedLayout},
+    primitives::Point,
 };
 
 #[derive(Debug, Copy, Clone, PartialEq, Default)]
@@ -19,12 +19,12 @@ impl Layout for RoundedRectangle {
 
     fn layout(
         &self,
-        offer: Size,
+        offer: ProposedDimensions,
         _: &impl crate::environment::LayoutEnvironment,
     ) -> ResolvedLayout<Self::Sublayout> {
         ResolvedLayout {
             sublayouts: (),
-            resolved_size: offer,
+            resolved_size: offer.resolve_most_flexible(0, 10),
         }
     }
 }

--- a/src/view/spacer.rs
+++ b/src/view/spacer.rs
@@ -1,7 +1,7 @@
 use crate::{
     environment::{LayoutEnvironment, RenderEnvironment},
-    layout::{Layout, LayoutDirection, ResolvedLayout},
-    primitives::{Point, Size},
+    layout::{Layout, LayoutDirection, ProposedDimensions, ResolvedLayout},
+    primitives::{Dimensions, Point},
     render::CharacterRender,
     render_target::CharacterRenderTarget,
 };
@@ -13,14 +13,20 @@ pub struct Spacer {
 
 impl Layout for Spacer {
     type Sublayout = ();
-    fn layout(&self, offer: Size, env: &impl LayoutEnvironment) -> ResolvedLayout<()> {
+    fn layout(
+        &self,
+        offer: ProposedDimensions,
+        env: &impl LayoutEnvironment,
+    ) -> ResolvedLayout<()> {
         let size = match env.layout_direction() {
-            LayoutDirection::Horizontal => {
-                Size::new(core::cmp::max(offer.width, self.min_length), 0)
-            }
-            LayoutDirection::Vertical => {
-                Size::new(0, core::cmp::max(offer.height, self.min_length))
-            }
+            LayoutDirection::Horizontal => Dimensions {
+                width: offer.width.resolve_most_flexible(0, self.min_length),
+                height: 0.into(),
+            },
+            LayoutDirection::Vertical => Dimensions {
+                width: 0.into(),
+                height: offer.height.resolve_most_flexible(0, self.min_length),
+            },
         };
         ResolvedLayout {
             sublayouts: (),

--- a/src/view/vstack.rs
+++ b/src/view/vstack.rs
@@ -219,12 +219,7 @@ fn layout_n<const N: usize>(
         height.saturating_sub(spacing * (N.saturating_sub(num_empty_views + 1)) as u16);
     let mut last_priority_group: Option<i8> = None;
     let mut max_width: Dimension = 0.into();
-    // let mut n = 0;
     loop {
-        // n += 1;
-        // if n > N {
-        //     break;
-        // }
         // collect the unsized subviews with the max layout priority into a group
         let mut subviews_indecies: [usize; N] = [0; N];
         let mut max = i8::MIN;

--- a/src/view/vstack.rs
+++ b/src/view/vstack.rs
@@ -254,7 +254,7 @@ fn layout_n<const N: usize>(
         }
 
         let group_indecies = &mut subviews_indecies[slice_start..slice_start + slice_len];
-        group_indecies.sort_by_key(|&i| flexibilities[i]);
+        group_indecies.sort_unstable_by_key(|&i| flexibilities[i]);
 
         let mut remaining_group_size = group_indecies.len() as u16;
 

--- a/src/view/zstack.rs
+++ b/src/view/zstack.rs
@@ -1,7 +1,7 @@
 use crate::{
     environment::{LayoutEnvironment, RenderEnvironment},
-    layout::{HorizontalAlignment, Layout, ResolvedLayout, VerticalAlignment},
-    primitives::{Point, Size},
+    layout::{HorizontalAlignment, Layout, ProposedDimensions, ResolvedLayout, VerticalAlignment},
+    primitives::Point,
     render::CharacterRender,
     render_target::CharacterRenderTarget,
 };
@@ -48,14 +48,18 @@ impl<U, V> ZStack<(U, V)> {
 impl<U: Layout, V: Layout> Layout for ZStack<(U, V)> {
     type Sublayout = (ResolvedLayout<U::Sublayout>, ResolvedLayout<V::Sublayout>);
 
-    fn layout(&self, offer: Size, env: &impl LayoutEnvironment) -> ResolvedLayout<Self::Sublayout> {
+    fn layout(
+        &self,
+        offer: ProposedDimensions,
+        env: &impl LayoutEnvironment,
+    ) -> ResolvedLayout<Self::Sublayout> {
         let layout0 = self.items.0.layout(offer, env);
         let layout1 = self.items.1.layout(offer, env);
         let size = layout0.resolved_size.union(layout1.resolved_size);
 
         ResolvedLayout {
             sublayouts: (layout0, layout1),
-            resolved_size: size.intersection(offer),
+            resolved_size: size.intersecting_proposal(offer),
         }
     }
 }
@@ -75,12 +79,12 @@ where
         let new_origin = origin
             + Point::new(
                 self.horizontal_alignment.align(
-                    layout.resolved_size.width as i16,
-                    layout.sublayouts.0.resolved_size.width as i16,
+                    layout.resolved_size.width.into(),
+                    layout.sublayouts.0.resolved_size.width.into(),
                 ),
                 self.vertical_alignment.align(
-                    layout.resolved_size.height as i16,
-                    layout.sublayouts.0.resolved_size.height as i16,
+                    layout.resolved_size.height.into(),
+                    layout.sublayouts.0.resolved_size.height.into(),
                 ),
             );
 
@@ -91,12 +95,12 @@ where
         let new_origin = origin
             + Point::new(
                 self.horizontal_alignment.align(
-                    layout.resolved_size.width as i16,
-                    layout.sublayouts.1.resolved_size.width as i16,
+                    layout.resolved_size.width.into(),
+                    layout.sublayouts.1.resolved_size.width.into(),
                 ),
                 self.vertical_alignment.align(
-                    layout.resolved_size.height as i16,
-                    layout.sublayouts.1.resolved_size.height as i16,
+                    layout.resolved_size.height.into(),
+                    layout.sublayouts.1.resolved_size.height.into(),
                 ),
             );
         self.items
@@ -125,12 +129,12 @@ where
         let new_origin = origin
             + Point::new(
                 self.horizontal_alignment.align(
-                    layout.resolved_size.width as i16,
-                    layout.sublayouts.0.resolved_size.width as i16,
+                    layout.resolved_size.width.into(),
+                    layout.sublayouts.0.resolved_size.width.into(),
                 ),
                 self.vertical_alignment.align(
-                    layout.resolved_size.height as i16,
-                    layout.sublayouts.0.resolved_size.height as i16,
+                    layout.resolved_size.height.into(),
+                    layout.sublayouts.0.resolved_size.height.into(),
                 ),
             );
 
@@ -141,12 +145,12 @@ where
         let new_origin = origin
             + Point::new(
                 self.horizontal_alignment.align(
-                    layout.resolved_size.width as i16,
-                    layout.sublayouts.1.resolved_size.width as i16,
+                    layout.resolved_size.width.into(),
+                    layout.sublayouts.1.resolved_size.width.into(),
                 ),
                 self.vertical_alignment.align(
-                    layout.resolved_size.height as i16,
-                    layout.sublayouts.1.resolved_size.height as i16,
+                    layout.resolved_size.height.into(),
+                    layout.sublayouts.1.resolved_size.height.into(),
                 ),
             );
         self.items

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,6 +1,7 @@
 use buoyant::{
     environment::{LayoutEnvironment, RenderEnvironment},
     layout::{Alignment, LayoutDirection},
+    render_target::FixedTextBuffer,
 };
 
 pub struct TestEnv<Color> {
@@ -56,4 +57,12 @@ impl<C> TestEnv<C> {
         self.alignment = alignment;
         self
     }
+}
+
+pub fn collect_text<const W: usize, const H: usize>(buffer: &FixedTextBuffer<W, H>) -> String {
+    buffer
+        .text
+        .iter()
+        .map(|chars| chars.iter().collect::<String>())
+        .collect::<String>()
 }

--- a/tests/conditional_view.rs
+++ b/tests/conditional_view.rs
@@ -22,18 +22,18 @@ fn test_conditional_view_layout() {
     let env = TestEnv::default();
 
     let view = make_view(true);
-    let layout = view.layout(buffer.size(), &env);
-    assert_eq!(layout.resolved_size, Size::new(4, 2));
+    let layout = view.layout(buffer.size().into(), &env);
+    assert_eq!(layout.resolved_size, Size::new(4, 2).into());
     view.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "true ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "!!!  ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "     ");
 
-    buffer.clear(());
+    buffer.clear(None);
 
     let view = make_view(false);
-    let layout = view.layout(buffer.size(), &env);
-    assert_eq!(layout.resolved_size, Size::new(1, 1));
+    let layout = view.layout(buffer.size().into(), &env);
+    assert_eq!(layout.resolved_size, Size::new(1, 1).into());
     view.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "f    ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "     ");

--- a/tests/fixed_frame.rs
+++ b/tests/fixed_frame.rs
@@ -1,8 +1,8 @@
 use buoyant::{
     environment::DefaultEnvironment,
     font::BufferCharacterFont,
-    layout::{HorizontalAlignment, Layout, VerticalAlignment},
-    primitives::{Point, Size},
+    layout::{HorizontalAlignment, Layout, ProposedDimensions, VerticalAlignment},
+    primitives::{Dimensions, Point, ProposedDimension, Size},
     render::CharacterRender,
     render_target::{CharacterRenderTarget, FixedTextBuffer},
     view::{LayoutExtensions, Text},
@@ -15,23 +15,25 @@ fn test_fixed_width() {
     let env = DefaultEnvironment::new(());
 
     assert_eq!(
-        content.layout(Size::new(1, 1), &env).resolved_size,
-        Size::new(2, 1)
+        content.layout(Size::new(1, 1).into(), &env).resolved_size,
+        Dimensions::new(2, 1)
     );
 
     assert_eq!(
-        content.layout(Size::new(20, 123), &env).resolved_size,
-        Size::new(2, 3)
+        content
+            .layout(Size::new(20, 123).into(), &env)
+            .resolved_size,
+        Dimensions::new(2, 3)
     );
 
     assert_eq!(
-        content.layout(Size::new(100, 1), &env).resolved_size,
-        Size::new(2, 1)
+        content.layout(Size::new(100, 1).into(), &env).resolved_size,
+        Dimensions::new(2, 1)
     );
 
     assert_eq!(
-        content.layout(Size::new(1, 6), &env).resolved_size,
-        Size::new(2, 3)
+        content.layout(Size::new(1, 6).into(), &env).resolved_size,
+        Dimensions::new(2, 3)
     );
 }
 
@@ -41,20 +43,88 @@ fn test_fixed_height() {
     let content = Text::str("123456", &font).frame(None, Some(2), None, None);
     let env = DefaultEnvironment::new(());
     assert_eq!(
-        content.layout(Size::new(1, 1), &env).resolved_size,
-        Size::new(1, 2)
+        content.layout(Size::new(1, 1).into(), &env).resolved_size,
+        Dimensions::new(1, 2)
     );
     assert_eq!(
-        content.layout(Size::new(20, 123), &env).resolved_size,
-        Size::new(6, 2)
+        content
+            .layout(Size::new(20, 123).into(), &env)
+            .resolved_size,
+        Dimensions::new(6, 2)
     );
     assert_eq!(
-        content.layout(Size::new(100, 1), &env).resolved_size,
-        Size::new(6, 2)
+        content.layout(Size::new(100, 1).into(), &env).resolved_size,
+        Dimensions::new(6, 2)
     );
     assert_eq!(
-        content.layout(Size::new(2, 6), &env).resolved_size,
-        Size::new(2, 2)
+        content.layout(Size::new(2, 6).into(), &env).resolved_size,
+        Dimensions::new(2, 2)
+    );
+}
+
+#[test]
+fn test_fixed_frame_compact_width_height() {
+    let font = BufferCharacterFont {};
+    let content = Text::str("123456", &font).frame(Some(2), Some(2), None, None);
+    let env = DefaultEnvironment::new(());
+
+    assert_eq!(
+        content
+            .layout(
+                ProposedDimensions {
+                    width: ProposedDimension::Compact,
+                    height: ProposedDimension::Compact
+                },
+                &env
+            )
+            .resolved_size,
+        Dimensions::new(2, 2)
+    );
+
+    assert_eq!(
+        content
+            .layout(
+                ProposedDimensions {
+                    width: ProposedDimension::Exact(2),
+                    height: ProposedDimension::Exact(2)
+                },
+                &env
+            )
+            .resolved_size,
+        Dimensions::new(2, 2)
+    );
+
+    assert_eq!(
+        content
+            .layout(
+                ProposedDimensions {
+                    width: ProposedDimension::Exact(3),
+                    height: ProposedDimension::Exact(3)
+                },
+                &env
+            )
+            .resolved_size,
+        Dimensions::new(2, 2)
+    );
+}
+
+#[test]
+fn test_fixed_frame_infinite_width_height() {
+    let font = BufferCharacterFont {};
+    let content = Text::str("123456", &font).frame(Some(25), Some(25), None, None);
+    let env = DefaultEnvironment::new(());
+
+    assert_eq!(
+        content
+            .layout(
+                ProposedDimensions {
+                    width: ProposedDimension::Infinite,
+                    height: ProposedDimension::Infinite
+                },
+                &env
+            )
+            .resolved_size,
+        Dimensions::new(25, 25)
     );
 }
 
@@ -67,9 +137,9 @@ fn test_render_frame_top_leading_alignment() {
         Some(HorizontalAlignment::Leading),
         Some(VerticalAlignment::Top),
     );
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = content.layout(buffer.size(), &env);
+    let layout = content.layout(buffer.size().into(), &env);
     content.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "aa    ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "bb    ");
@@ -83,9 +153,9 @@ fn test_render_frame_top_center_alignment() {
     let font = BufferCharacterFont {};
     let content =
         Text::str("aa\nbb\ncc", &font).frame(Some(6), Some(5), None, Some(VerticalAlignment::Top));
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = content.layout(buffer.size(), &env);
+    let layout = content.layout(buffer.size().into(), &env);
     content.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "  aa  ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "  bb  ");
@@ -103,9 +173,9 @@ fn test_render_frame_top_trailing_alignment() {
         Some(HorizontalAlignment::Trailing),
         Some(VerticalAlignment::Top),
     );
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = content.layout(buffer.size(), &env);
+    let layout = content.layout(buffer.size().into(), &env);
     content.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "    aa");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "    bb");
@@ -123,9 +193,9 @@ fn test_render_frame_center_leading_alignment() {
         Some(HorizontalAlignment::Leading),
         None,
     );
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = content.layout(buffer.size(), &env);
+    let layout = content.layout(buffer.size().into(), &env);
     content.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "aa    ");
@@ -138,9 +208,9 @@ fn test_render_frame_center_leading_alignment() {
 fn test_render_frame_center_center_alignment() {
     let font = BufferCharacterFont {};
     let content = Text::str("aa\nbb\ncc", &font).frame(Some(6), Some(5), None, None);
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = content.layout(buffer.size(), &env);
+    let layout = content.layout(buffer.size().into(), &env);
     content.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "  aa  ");
@@ -158,9 +228,9 @@ fn test_render_frame_center_trailing_alignment() {
         Some(HorizontalAlignment::Trailing),
         None,
     );
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = content.layout(buffer.size(), &env);
+    let layout = content.layout(buffer.size().into(), &env);
     content.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "    aa");
@@ -178,9 +248,9 @@ fn test_render_frame_bottom_leading_alignment() {
         Some(HorizontalAlignment::Leading),
         Some(VerticalAlignment::Bottom),
     );
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = content.layout(buffer.size(), &env);
+    let layout = content.layout(buffer.size().into(), &env);
     content.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "      ");
@@ -198,9 +268,9 @@ fn test_render_frame_bottom_center_alignment() {
         None,
         Some(VerticalAlignment::Bottom),
     );
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = content.layout(buffer.size(), &env);
+    let layout = content.layout(buffer.size().into(), &env);
     content.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "      ");
@@ -218,9 +288,9 @@ fn test_render_frame_bottom_trailing_alignment() {
         Some(HorizontalAlignment::Trailing),
         Some(VerticalAlignment::Bottom),
     );
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = content.layout(buffer.size(), &env);
+    let layout = content.layout(buffer.size().into(), &env);
     content.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "      ");

--- a/tests/flex_frame.rs
+++ b/tests/flex_frame.rs
@@ -8,103 +8,113 @@ use buoyant::{
     view::{LayoutExtensions, Text},
 };
 
+use buoyant::layout::ProposedDimensions;
+use buoyant::primitives::ProposedDimension;
+use buoyant::view::Rectangle;
+
 #[test]
 fn test_min() {
     let font = BufferCharacterFont {};
-    let content = Text::str("123456", &font).flex_frame(Some(2), None, Some(2), None, None, None);
+    let content = Text::str("123456", &font)
+        .flex_frame()
+        .with_min_width(2)
+        .with_min_height(2);
 
     let env = DefaultEnvironment::new(());
 
     assert_eq!(
-        content.layout(Size::new(1, 1), &env).resolved_size,
-        Size::new(2, 2)
+        content.layout(Size::new(1, 1).into(), &env).resolved_size,
+        Size::new(2, 2).into()
     );
 
     assert_eq!(
-        content.layout(Size::new(1, 123), &env).resolved_size,
-        Size::new(2, 3)
+        content.layout(Size::new(1, 123).into(), &env).resolved_size,
+        Size::new(2, 3).into()
     );
 
     assert_eq!(
-        content.layout(Size::new(100, 1), &env).resolved_size,
-        Size::new(6, 2)
+        content.layout(Size::new(100, 1).into(), &env).resolved_size,
+        Size::new(6, 2).into()
     );
 
     assert_eq!(
-        content.layout(Size::new(1, 6), &env).resolved_size,
-        Size::new(2, 3)
+        content.layout(Size::new(1, 6).into(), &env).resolved_size,
+        Size::new(2, 3).into()
     );
 }
 
 #[test]
 fn test_max() {
     let font = BufferCharacterFont {};
-    let content = Text::str("123456", &font).flex_frame(None, Some(2), None, Some(2), None, None);
+    let content = Text::str("123456", &font)
+        .flex_frame()
+        .with_max_width(2)
+        .with_max_height(2);
 
     let env = DefaultEnvironment::new(());
 
     assert_eq!(
-        content.layout(Size::new(2, 1), &env).resolved_size,
-        Size::new(2, 1)
+        content.layout(Size::new(2, 1).into(), &env).resolved_size,
+        Size::new(2, 1).into()
     );
 
     assert_eq!(
-        content.layout(Size::new(1, 123), &env).resolved_size,
-        Size::new(1, 2)
+        content.layout(Size::new(1, 123).into(), &env).resolved_size,
+        Size::new(1, 2).into()
     );
 
     assert_eq!(
-        content.layout(Size::new(100, 1), &env).resolved_size,
-        Size::new(2, 1)
+        content.layout(Size::new(100, 1).into(), &env).resolved_size,
+        Size::new(2, 1).into()
     );
 
     assert_eq!(
-        content.layout(Size::new(1, 6), &env).resolved_size,
-        Size::new(1, 2)
+        content.layout(Size::new(1, 6).into(), &env).resolved_size,
+        Size::new(1, 2).into()
     );
 }
 
 #[test]
 fn test_min_max() {
     let font = BufferCharacterFont {};
-    let content = Text::str("xxx|xxx|xxx|xxx|abcdefg", &font).flex_frame(
-        Some(2),
-        Some(4),
-        Some(2),
-        Some(4),
-        None,
-        None,
-    );
+    let content = Text::str("xxx|xxx|xxx|xxx|abcdefg", &font)
+        .flex_frame()
+        .with_min_width(2)
+        .with_max_width(4)
+        .with_min_height(2)
+        .with_max_height(4);
 
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
 
     assert_eq!(
-        content.layout(Size::new(2, 1), &env).resolved_size,
-        Size::new(2, 2)
-    );
-
-    assert_eq!(
-        content.layout(Size::new(1, 123), &env).resolved_size,
-        Size::new(2, 4)
+        content.layout(Size::new(2, 1).into(), &env).resolved_size,
+        Size::new(2, 2).into()
     );
 
     assert_eq!(
-        content.layout(Size::new(100, 1), &env).resolved_size,
-        Size::new(4, 2)
+        content.layout(Size::new(1, 123).into(), &env).resolved_size,
+        Size::new(2, 4).into()
     );
 
     assert_eq!(
-        content.layout(Size::new(1, 6), &env).resolved_size,
-        Size::new(2, 4)
+        content.layout(Size::new(100, 1).into(), &env).resolved_size,
+        Size::new(4, 2).into()
     );
 
     assert_eq!(
-        content.layout(Size::new(1000, 1000), &env).resolved_size,
-        Size::new(4, 4)
+        content.layout(Size::new(1, 6).into(), &env).resolved_size,
+        Size::new(2, 4).into()
+    );
+
+    assert_eq!(
+        content
+            .layout(Size::new(1000, 1000).into(), &env)
+            .resolved_size,
+        Size::new(4, 4).into()
     );
 
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = content.layout(buffer.size(), &env);
+    let layout = content.layout(buffer.size().into(), &env);
     content.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "xxx|  ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "xxx|  ");
@@ -116,17 +126,15 @@ fn test_min_max() {
 #[test]
 fn test_render_min_flex_frame_top_leading_alignment() {
     let font = BufferCharacterFont {};
-    let content = Text::str("aa\nbb\ncc", &font).flex_frame(
-        Some(6),
-        None,
-        Some(5),
-        None,
-        Some(HorizontalAlignment::Leading),
-        Some(VerticalAlignment::Top),
-    );
-    let env = DefaultEnvironment::new(());
+    let content = Text::str("aa\nbb\ncc", &font)
+        .flex_frame()
+        .with_min_width(6)
+        .with_min_height(5)
+        .with_horizontal_alignment(HorizontalAlignment::Leading)
+        .with_vertical_alignment(VerticalAlignment::Top);
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = content.layout(buffer.size(), &env);
+    let layout = content.layout(buffer.size().into(), &env);
     content.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "aa    ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "bb    ");
@@ -138,17 +146,14 @@ fn test_render_min_flex_frame_top_leading_alignment() {
 #[test]
 fn test_render_min_flex_frame_top_center_alignment() {
     let font = BufferCharacterFont {};
-    let content = Text::str("aa\nbb\ncc", &font).flex_frame(
-        Some(6),
-        None,
-        Some(5),
-        None,
-        None,
-        Some(VerticalAlignment::Top),
-    );
-    let env = DefaultEnvironment::new(());
+    let content = Text::str("aa\nbb\ncc", &font)
+        .flex_frame()
+        .with_min_width(6)
+        .with_min_height(5)
+        .with_vertical_alignment(VerticalAlignment::Top);
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = content.layout(buffer.size(), &env);
+    let layout = content.layout(buffer.size().into(), &env);
     content.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "  aa  ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "  bb  ");
@@ -160,17 +165,15 @@ fn test_render_min_flex_frame_top_center_alignment() {
 #[test]
 fn test_render_min_flex_frame_top_trailing_alignment() {
     let font = BufferCharacterFont {};
-    let content = Text::str("aa\nbb\ncc", &font).flex_frame(
-        Some(6),
-        None,
-        Some(5),
-        None,
-        Some(HorizontalAlignment::Trailing),
-        Some(VerticalAlignment::Top),
-    );
-    let env = DefaultEnvironment::new(());
+    let content = Text::str("aa\nbb\ncc", &font)
+        .flex_frame()
+        .with_min_width(6)
+        .with_min_height(5)
+        .with_horizontal_alignment(HorizontalAlignment::Trailing)
+        .with_vertical_alignment(VerticalAlignment::Top);
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = content.layout(buffer.size(), &env);
+    let layout = content.layout(buffer.size().into(), &env);
     content.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "    aa");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "    bb");
@@ -182,17 +185,14 @@ fn test_render_min_flex_frame_top_trailing_alignment() {
 #[test]
 fn test_render_min_flex_frame_center_leading_alignment() {
     let font = BufferCharacterFont {};
-    let content = Text::str("aa\nbb\ncc", &font).flex_frame(
-        Some(6),
-        None,
-        Some(5),
-        None,
-        Some(HorizontalAlignment::Leading),
-        None,
-    );
-    let env = DefaultEnvironment::new(());
+    let content = Text::str("aa\nbb\ncc", &font)
+        .flex_frame()
+        .with_min_width(6)
+        .with_min_height(5)
+        .with_horizontal_alignment(HorizontalAlignment::Leading);
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = content.layout(buffer.size(), &env);
+    let layout = content.layout(buffer.size().into(), &env);
     content.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "aa    ");
@@ -204,11 +204,13 @@ fn test_render_min_flex_frame_center_leading_alignment() {
 #[test]
 fn test_render_min_flex_frame_center_center_alignment() {
     let font = BufferCharacterFont {};
-    let content =
-        Text::str("aa\nbb\ncc", &font).flex_frame(Some(6), None, Some(5), None, None, None);
-    let env = DefaultEnvironment::new(());
+    let content = Text::str("aa\nbb\ncc", &font)
+        .flex_frame()
+        .with_min_width(6)
+        .with_min_height(5);
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = content.layout(buffer.size(), &env);
+    let layout = content.layout(buffer.size().into(), &env);
     content.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "  aa  ");
@@ -220,17 +222,14 @@ fn test_render_min_flex_frame_center_center_alignment() {
 #[test]
 fn test_render_min_flex_frame_center_trailing_alignment() {
     let font = BufferCharacterFont {};
-    let content = Text::str("aa\nbb\ncc", &font).flex_frame(
-        Some(6),
-        None,
-        Some(5),
-        None,
-        Some(HorizontalAlignment::Trailing),
-        None,
-    );
-    let env = DefaultEnvironment::new(());
+    let content = Text::str("aa\nbb\ncc", &font)
+        .flex_frame()
+        .with_min_width(6)
+        .with_min_height(5)
+        .with_horizontal_alignment(HorizontalAlignment::Trailing);
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = content.layout(buffer.size(), &env);
+    let layout = content.layout(buffer.size().into(), &env);
     content.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "    aa");
@@ -242,17 +241,16 @@ fn test_render_min_flex_frame_center_trailing_alignment() {
 #[test]
 fn test_render_min_flex_frame_bottom_leading_alignment() {
     let font = BufferCharacterFont {};
-    let content = Text::str("aa\nbb\ncc", &font).flex_frame(
-        Some(6),
-        None,
-        Some(5),
-        None,
-        Some(HorizontalAlignment::Leading),
-        Some(VerticalAlignment::Bottom),
-    );
-    let env = DefaultEnvironment::new(());
+    let content = Text::str("aa\nbb\ncc", &font)
+        .flex_frame()
+        .with_min_width(6)
+        .with_min_height(5)
+        .with_horizontal_alignment(HorizontalAlignment::Leading)
+        .with_vertical_alignment(VerticalAlignment::Bottom);
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = content.layout(buffer.size(), &env);
+    let layout = content.layout(buffer.size().into(), &env);
+    assert_eq!(layout.resolved_size, Size::new(6, 5).into());
     content.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "      ");
@@ -264,17 +262,14 @@ fn test_render_min_flex_frame_bottom_leading_alignment() {
 #[test]
 fn test_render_min_flex_frame_bottom_center_alignment() {
     let font = BufferCharacterFont {};
-    let content = Text::str("aa\nbb\ncc", &font).flex_frame(
-        Some(6),
-        None,
-        Some(5),
-        None,
-        None,
-        Some(VerticalAlignment::Bottom),
-    );
-    let env = DefaultEnvironment::new(());
+    let content = Text::str("aa\nbb\ncc", &font)
+        .flex_frame()
+        .with_min_width(6)
+        .with_min_height(5)
+        .with_vertical_alignment(VerticalAlignment::Bottom);
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = content.layout(buffer.size(), &env);
+    let layout = content.layout(buffer.size().into(), &env);
     content.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "      ");
@@ -286,17 +281,15 @@ fn test_render_min_flex_frame_bottom_center_alignment() {
 #[test]
 fn test_render_min_flex_frame_bottom_trailing_alignment() {
     let font = BufferCharacterFont {};
-    let content = Text::str("aa\nbb\ncc", &font).flex_frame(
-        Some(6),
-        None,
-        Some(5),
-        None,
-        Some(HorizontalAlignment::Trailing),
-        Some(VerticalAlignment::Bottom),
-    );
-    let env = DefaultEnvironment::new(());
+    let content = Text::str("aa\nbb\ncc", &font)
+        .flex_frame()
+        .with_min_width(6)
+        .with_min_height(5)
+        .with_horizontal_alignment(HorizontalAlignment::Trailing)
+        .with_vertical_alignment(VerticalAlignment::Bottom);
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = content.layout(buffer.size(), &env);
+    let layout = content.layout(buffer.size().into(), &env);
     content.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "      ");
@@ -308,18 +301,16 @@ fn test_render_min_flex_frame_bottom_trailing_alignment() {
 #[test]
 fn test_render_infinite_width_height_fills_space() {
     let font = BufferCharacterFont {};
-    let content = Text::str("aa\nbb\ncc", &font).flex_frame(
-        None,
-        Some(u16::MAX),
-        None,
-        Some(u16::MAX),
-        Some(HorizontalAlignment::Center),
-        Some(VerticalAlignment::Center),
-    );
-    let env = DefaultEnvironment::new(());
+    let content = Text::str("aa\nbb\ncc", &font)
+        .flex_frame()
+        .with_infinite_max_width()
+        .with_infinite_max_height()
+        .with_horizontal_alignment(HorizontalAlignment::Center)
+        .with_vertical_alignment(VerticalAlignment::Center);
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = content.layout(buffer.size(), &env);
-    assert_eq!(layout.resolved_size, Size::new(6, 5));
+    let layout = content.layout(buffer.size().into(), &env);
+    assert_eq!(layout.resolved_size, Size::new(6, 5).into());
     content.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "  aa  ");
@@ -331,22 +322,373 @@ fn test_render_infinite_width_height_fills_space() {
 #[test]
 fn test_render_oversize_mix() {
     let font = BufferCharacterFont {};
-    let content = Text::str("aa\nbb\ncc", &font).flex_frame(
-        Some(8),
-        Some(u16::MAX),
-        Some(8),
-        Some(u16::MAX),
-        Some(HorizontalAlignment::Center),
-        Some(VerticalAlignment::Center),
-    );
-    let env = DefaultEnvironment::new(());
+    let content = Text::str("aa\nbb\ncc", &font)
+        .flex_frame()
+        .with_min_width(8)
+        .with_max_width(u16::MAX)
+        .with_min_height(8)
+        .with_max_height(u16::MAX)
+        .with_horizontal_alignment(HorizontalAlignment::Center)
+        .with_vertical_alignment(VerticalAlignment::Center);
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = content.layout(buffer.size(), &env);
-    assert_eq!(layout.resolved_size, Size::new(8, 8));
+    let layout = content.layout(buffer.size().into(), &env);
+    assert_eq!(layout.resolved_size, Size::new(8, 8).into());
     content.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "   aa ");
     assert_eq!(buffer.text[3].iter().collect::<String>(), "   bb ");
     assert_eq!(buffer.text[4].iter().collect::<String>(), "   cc ");
+}
+
+#[test]
+fn test_compact() {
+    let env = DefaultEnvironment::new(());
+    let content = Rectangle
+        .flex_frame()
+        .with_ideal_width(8)
+        .with_ideal_height(4)
+        .with_min_width(2)
+        .with_min_height(2);
+
+    let layout = content.layout(
+        ProposedDimensions {
+            width: ProposedDimension::Compact,
+            height: ProposedDimension::Compact,
+        },
+        &env,
+    );
+    assert_eq!(layout.resolved_size.width, 8.into());
+    assert_eq!(layout.resolved_size.height, 4.into());
+}
+
+#[test]
+fn test_infinite() {
+    let env = DefaultEnvironment::new(());
+    let content = Rectangle.flex_frame().with_min_width(2).with_min_height(2);
+
+    let layout = content.layout(
+        ProposedDimensions {
+            width: ProposedDimension::Infinite,
+            height: ProposedDimension::Infinite,
+        },
+        &env,
+    );
+    // Rectangle defaults to a 10x10 size if not constrained.
+    assert!(layout.resolved_size.width.is_infinite());
+    assert!(layout.resolved_size.height.is_infinite());
+}
+
+#[test]
+fn test_infinite_width_only() {
+    let env = DefaultEnvironment::new(());
+    let content = Rectangle.flex_frame().with_min_width(4); // no ideal or max
+    let layout = content.layout(
+        ProposedDimensions {
+            width: ProposedDimension::Infinite,
+            height: ProposedDimension::Exact(6),
+        },
+        &env,
+    );
+    assert!(layout.resolved_size.width.is_infinite());
+    assert_eq!(layout.resolved_size.height, 6.into());
+}
+
+#[test]
+fn test_infinite_width_with_min_ideal() {
+    let env = DefaultEnvironment::new(());
+    let content = Rectangle.flex_frame().with_min_width(2).with_ideal_width(8);
+    let layout = content.layout(
+        ProposedDimensions {
+            width: ProposedDimension::Infinite,
+            height: ProposedDimension::Compact,
+        },
+        &env,
+    );
+    // Rectangle's infinite offer leads to child returning infinite, then min ensures at least 2.
+    assert!(layout.resolved_size.width.is_infinite());
+    // For height with Compact, child's default is 10, no min => 10
+    assert_eq!(layout.resolved_size.height, 10.into());
+
+    let layout2 = content.layout(
+        ProposedDimensions {
+            width: ProposedDimension::Infinite,
+            height: ProposedDimension::Exact(2),
+        },
+        &env,
+    );
+    assert!(layout2.resolved_size.width.is_infinite());
+    assert_eq!(layout2.resolved_size.height, 2.into());
+}
+
+#[test]
+fn test_infinite_height_only() {
+    let env = DefaultEnvironment::new(());
+    let content = Rectangle.flex_frame().with_min_height(5);
+    let layout = content.layout(
+        ProposedDimensions {
+            width: ProposedDimension::Exact(7),
+            height: ProposedDimension::Infinite,
+        },
+        &env,
+    );
+    assert_eq!(layout.resolved_size.width, 7.into());
+    assert!(layout.resolved_size.height.is_infinite());
+
+    let layout2 = content.layout(
+        ProposedDimensions {
+            width: ProposedDimension::Exact(5),
+            height: ProposedDimension::Infinite,
+        },
+        &env,
+    );
+    assert_eq!(layout2.resolved_size.width, 5.into());
+    assert!(layout2.resolved_size.height.is_infinite());
+}
+
+#[test]
+fn test_infinite_height_with_min_ideal() {
+    let env = DefaultEnvironment::new(());
+    let content = Rectangle
+        .flex_frame()
+        .with_min_height(2)
+        .with_ideal_height(4);
+    let layout = content.layout(
+        ProposedDimensions {
+            width: ProposedDimension::Compact,
+            height: ProposedDimension::Infinite,
+        },
+        &env,
+    );
+    // For height = infinite, child returns infinite; flex frame ensures at least 2 => u16::MAX
+    assert!(layout.resolved_size.height.is_infinite());
+    // For width with Compact, child's default is 10, no min => 10
+    assert_eq!(layout.resolved_size.width, 10.into());
+
+    let layout2 = content.layout(
+        ProposedDimensions {
+            width: ProposedDimension::Exact(3),
+            height: ProposedDimension::Infinite,
+        },
+        &env,
+    );
+    assert_eq!(layout2.resolved_size.width, 3.into());
+    assert!(layout2.resolved_size.height.is_infinite());
+}
+
+#[test]
+fn test_min_greater_than_ideal_height() {
+    let env = DefaultEnvironment::new(());
+    let content = Rectangle
+        .flex_frame()
+        .with_min_height(10)
+        .with_ideal_height(5);
+    let layout = content.layout(
+        ProposedDimensions {
+            width: ProposedDimension::Exact(8),
+            height: ProposedDimension::Compact,
+        },
+        &env,
+    );
+    // min is bigger than ideal, so 10 should be used
+    assert_eq!(layout.resolved_size.height, 10.into());
+}
+
+#[test]
+fn test_max_smaller_than_min_ideal_height() {
+    let env = DefaultEnvironment::new(());
+    let content = Rectangle
+        .flex_frame()
+        .with_min_height(4)
+        .with_ideal_height(6)
+        .with_max_height(3);
+    let layout = content.layout(
+        ProposedDimensions {
+            width: ProposedDimension::Compact,
+            height: ProposedDimension::Infinite,
+        },
+        &env,
+    );
+    // max is 3, but min/ideal are 4/6; when max is smaller, the paradox is resolved by using min
+    assert_eq!(layout.resolved_size.height, 4.into());
+}
+
+#[test]
+fn test_min_greater_than_ideal_width() {
+    let env = DefaultEnvironment::new(());
+    let content = Rectangle
+        .flex_frame()
+        .with_min_width(12)
+        .with_ideal_width(6);
+    let layout = content.layout(
+        ProposedDimensions {
+            width: ProposedDimension::Compact,
+            height: ProposedDimension::Exact(5),
+        },
+        &env,
+    );
+    // min is bigger than ideal, so 12 should be used
+    assert_eq!(layout.resolved_size.width, 12.into());
+}
+
+#[test]
+fn test_max_smaller_than_min_ideal_width() {
+    let env = DefaultEnvironment::new(());
+    let content = Rectangle
+        .flex_frame()
+        .with_min_width(5)
+        .with_ideal_width(8)
+        .with_max_width(3);
+    let layout = content.layout(
+        ProposedDimensions {
+            width: ProposedDimension::Infinite,
+            height: ProposedDimension::Compact,
+        },
+        &env,
+    );
+    // max is 3, but min/ideal are 5/8; when max is smaller, the paradox is resolved by using min
+    assert_eq!(layout.resolved_size.width, 5.into());
+}
+
+#[test]
+fn test_infinite_max_width() {
+    let env = DefaultEnvironment::new(());
+    let content = Rectangle.flex_frame().with_infinite_max_width();
+
+    // With Infinite offer
+    let layout = content.layout(
+        ProposedDimensions {
+            width: ProposedDimension::Infinite,
+            height: ProposedDimension::Exact(5),
+        },
+        &env,
+    );
+    assert!(layout.resolved_size.width.is_infinite());
+    assert_eq!(layout.resolved_size.height, 5.into());
+
+    // With Exact offer
+    let layout = content.layout(
+        ProposedDimensions {
+            width: ProposedDimension::Exact(15),
+            height: ProposedDimension::Exact(5),
+        },
+        &env,
+    );
+    assert_eq!(layout.resolved_size.width, 15.into());
+    assert_eq!(layout.resolved_size.height, 5.into());
+
+    // With Compact offer and no constraints
+    let layout = content.layout(
+        ProposedDimensions {
+            width: ProposedDimension::Compact,
+            height: ProposedDimension::Exact(5),
+        },
+        &env,
+    );
+    assert_eq!(layout.resolved_size.width, 10.into()); // Default magic value
+    assert_eq!(layout.resolved_size.height, 5.into());
+}
+
+#[test]
+fn test_infinite_max_width_with_min_ideal() {
+    let env = DefaultEnvironment::new(());
+    let content = Rectangle
+        .flex_frame()
+        .with_infinite_max_width()
+        .with_min_width(5)
+        .with_ideal_width(8);
+
+    // With Compact offer, should use ideal
+    let layout = content.layout(
+        ProposedDimensions {
+            width: ProposedDimension::Compact,
+            height: ProposedDimension::Exact(5),
+        },
+        &env,
+    );
+    assert_eq!(layout.resolved_size.width, 8.into());
+    assert_eq!(layout.resolved_size.height, 5.into());
+
+    // With Exact offer below min
+    let layout = content.layout(
+        ProposedDimensions {
+            width: ProposedDimension::Exact(3),
+            height: ProposedDimension::Exact(5),
+        },
+        &env,
+    );
+    assert_eq!(layout.resolved_size.width, 5.into()); // Uses min
+    assert_eq!(layout.resolved_size.height, 5.into());
+}
+
+#[test]
+fn test_infinite_max_height() {
+    let env = DefaultEnvironment::new(());
+    let content = Rectangle.flex_frame().with_infinite_max_height();
+
+    // With Infinite offer
+    let layout = content.layout(
+        ProposedDimensions {
+            width: ProposedDimension::Exact(5),
+            height: ProposedDimension::Infinite,
+        },
+        &env,
+    );
+    assert_eq!(layout.resolved_size.width, 5.into());
+    assert!(layout.resolved_size.height.is_infinite());
+
+    // With Exact offer
+    let layout = content.layout(
+        ProposedDimensions {
+            width: ProposedDimension::Exact(5),
+            height: ProposedDimension::Exact(15),
+        },
+        &env,
+    );
+    assert_eq!(layout.resolved_size.width, 5.into());
+    assert_eq!(layout.resolved_size.height, 15.into());
+
+    // With Compact offer and no constraints
+    let layout = content.layout(
+        ProposedDimensions {
+            width: ProposedDimension::Exact(5),
+            height: ProposedDimension::Compact,
+        },
+        &env,
+    );
+    assert_eq!(layout.resolved_size.width, 5.into());
+    assert_eq!(layout.resolved_size.height, 10.into()); // Default magic value
+}
+
+#[test]
+fn test_infinite_max_height_with_min_ideal() {
+    let env = DefaultEnvironment::new(());
+    let content = Rectangle
+        .flex_frame()
+        .with_infinite_max_height()
+        .with_min_height(5)
+        .with_ideal_height(8);
+
+    // With Compact offer, should use ideal
+    let layout = content.layout(
+        ProposedDimensions {
+            width: ProposedDimension::Exact(5),
+            height: ProposedDimension::Compact,
+        },
+        &env,
+    );
+    assert_eq!(layout.resolved_size.width, 5.into());
+    assert_eq!(layout.resolved_size.height, 8.into());
+
+    // With Exact offer below min
+    let layout = content.layout(
+        ProposedDimensions {
+            width: ProposedDimension::Exact(5),
+            height: ProposedDimension::Exact(3),
+        },
+        &env,
+    );
+    assert_eq!(layout.resolved_size.width, 5.into());
+    assert_eq!(layout.resolved_size.height, 5.into()); // Uses min
 }

--- a/tests/foreach.rs
+++ b/tests/foreach.rs
@@ -49,9 +49,9 @@ fn foreach_with_inner_wrapping_hstack() {
         ))
         .with_alignment(VerticalAlignment::Bottom)
     });
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<10, 5>::default();
-    let layout = view.layout(buffer.size(), &env);
+    let layout = view.layout(buffer.size().into(), &env);
     view.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "Alice   99");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "Bob      2");
@@ -91,9 +91,9 @@ fn foreach_leading_aligned() {
             .with_spacing(1)
     })
     .with_alignment(HorizontalAlignment::Leading);
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<10, 5>::default();
-    let layout = view.layout(buffer.size(), &env);
+    let layout = view.layout(buffer.size().into(), &env);
     view.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "Alice 99  ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "Bob 2     ");
@@ -133,9 +133,9 @@ fn foreach_trailing_aligned() {
             .with_spacing(1)
     })
     .with_alignment(HorizontalAlignment::Trailing);
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<10, 5>::default();
-    let layout = view.layout(buffer.size(), &env);
+    let layout = view.layout(buffer.size().into(), &env);
     view.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), " Alice 99 ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "    Bob 2 ");

--- a/tests/hstack.rs
+++ b/tests/hstack.rs
@@ -2,12 +2,13 @@ use std::iter::zip;
 
 use buoyant::environment::DefaultEnvironment;
 use buoyant::font::BufferCharacterFont;
-use buoyant::layout::{Layout, VerticalAlignment};
-use buoyant::primitives::{Point, Size};
+use buoyant::layout::{Layout, ProposedDimensions, VerticalAlignment};
+use buoyant::primitives::{Dimensions, Point, ProposedDimension, Size};
 use buoyant::render::CharacterRender;
 use buoyant::render_target::{CharacterRenderTarget, FixedTextBuffer};
 use buoyant::view::{
-    CharacterRenderExtensions, Divider, HStack, LayoutExtensions, Rectangle, Spacer, Text,
+    CharacterRenderExtensions, Divider, EmptyView, HStack, LayoutExtensions, Rectangle, Spacer,
+    Text,
 };
 
 #[test]
@@ -15,8 +16,8 @@ fn test_greedy_layout_2() {
     let hstack = HStack::new((Spacer::default(), Spacer::default()));
     let offer = Size::new(100, 100);
     let env = DefaultEnvironment::new(());
-    let layout = hstack.layout(offer, &env);
-    assert_eq!(layout.resolved_size, Size::new(100, 0));
+    let layout = hstack.layout(offer.into(), &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(100, 0));
 }
 
 #[test]
@@ -24,8 +25,8 @@ fn test_oversized_layout_2() {
     let vstack = HStack::new((Divider::default().padding(2), Spacer::default()));
     let offer = Size::new(10, 0);
     let env = DefaultEnvironment::new(());
-    let layout = vstack.layout(offer, &env);
-    assert_eq!(layout.resolved_size, Size::new(10, 0));
+    let layout = vstack.layout(offer.into(), &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(10, 0));
 }
 
 #[test]
@@ -37,8 +38,8 @@ fn test_oversized_layout_3() {
     ));
     let offer = Size::new(10, 0);
     let env = DefaultEnvironment::new(());
-    let layout = vstack.layout(offer, &env);
-    assert_eq!(layout.resolved_size, Size::new(10, 0));
+    let layout = vstack.layout(offer.into(), &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(10, 0));
 }
 
 #[test]
@@ -47,8 +48,8 @@ fn test_undersized_layout_2() {
     let hstack = HStack::new((Text::str("123", &font), Text::str("4567", &font))).with_spacing(1);
     let offer = Size::new(50, 1);
     let env = DefaultEnvironment::new(());
-    let layout = hstack.layout(offer, &env);
-    assert_eq!(layout.resolved_size, Size::new(8, 1));
+    let layout = hstack.layout(offer.into(), &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(8, 1));
 }
 
 #[test]
@@ -56,8 +57,8 @@ fn test_horizontal_render_2() {
     let font = BufferCharacterFont {};
     let hstack = HStack::new((Text::str("123", &font), Text::str("4567", &font))).with_spacing(1);
     let mut buffer = FixedTextBuffer::<9, 1>::default();
-    let env = DefaultEnvironment::new(());
-    let layout = hstack.layout(buffer.size(), &env);
+    let env = DefaultEnvironment::new(None);
+    let layout = hstack.layout(buffer.size().into(), &env);
     hstack.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "123 4567 ");
 }
@@ -71,9 +72,9 @@ fn test_undersized_layout_3_left_pad() {
         Spacer::default(),
     ));
     let offer = Size::new(10, 1);
-    let env = DefaultEnvironment::new(());
-    let layout = hstack.layout(offer, &env);
-    assert_eq!(layout.resolved_size, Size::new(10, 1));
+    let env = DefaultEnvironment::new(None);
+    let layout = hstack.layout(offer.into(), &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(10, 1));
     let mut buffer = FixedTextBuffer::<10, 1>::default();
     hstack.render(&mut buffer, &layout, Point::zero(), &env);
 
@@ -89,9 +90,9 @@ fn test_undersized_layout_3_right_pad_space() {
     ))
     .with_spacing(1);
     let offer = Size::new(10, 1);
-    let env = DefaultEnvironment::new(());
-    let layout = hstack.layout(offer, &env);
-    assert_eq!(layout.resolved_size, Size::new(10, 1));
+    let env = DefaultEnvironment::new(None);
+    let layout = hstack.layout(offer.into(), &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(10, 1));
     let mut buffer = FixedTextBuffer::<10, 1>::default();
     hstack.render(&mut buffer, &layout, Point::zero(), &env);
 
@@ -109,9 +110,9 @@ fn test_oversized_layout_3_leading_pad_space() {
     ))
     .with_spacing(1);
     let offer = Size::new(10, 1);
-    let env = DefaultEnvironment::new(());
-    let layout = hstack.layout(offer, &env);
-    assert_eq!(layout.resolved_size, Size::new(10, 1));
+    let env = DefaultEnvironment::new(None);
+    let layout = hstack.layout(offer.into(), &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(10, 1));
     let mut buffer = FixedTextBuffer::<10, 1>::default();
     hstack.render(&mut buffer, &layout, Point::zero(), &env);
 
@@ -127,9 +128,9 @@ fn test_undersized_layout_3_middle_pad() {
         Text::str("5678", &font),
     ));
     let offer = Size::new(10, 1);
-    let env = DefaultEnvironment::new(());
-    let layout = hstack.layout(offer, &env);
-    assert_eq!(layout.resolved_size, Size::new(10, 1));
+    let env = DefaultEnvironment::new(None);
+    let layout = hstack.layout(offer.into(), &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(10, 1));
     let mut buffer = FixedTextBuffer::<10, 1>::default();
     hstack.render(&mut buffer, &layout, Point::zero(), &env);
 
@@ -147,9 +148,9 @@ fn test_oversized_layout_3_middle_pad_space() {
     ))
     .with_spacing(1);
     let offer = Size::new(10, 1);
-    let env = DefaultEnvironment::new(());
-    let layout = hstack.layout(offer, &env);
-    assert_eq!(layout.resolved_size, Size::new(10, 1));
+    let env = DefaultEnvironment::new(None);
+    let layout = hstack.layout(offer.into(), &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(10, 1));
     let mut buffer = FixedTextBuffer::<10, 1>::default();
     hstack.render(&mut buffer, &layout, Point::zero(), &env);
 
@@ -167,9 +168,9 @@ fn test_oversized_layout_3_trailing_pad_space() {
     ))
     .with_spacing(1);
     let offer = Size::new(10, 1);
-    let env = DefaultEnvironment::new(());
-    let layout = hstack.layout(offer, &env);
-    assert_eq!(layout.resolved_size, Size::new(10, 1));
+    let env = DefaultEnvironment::new(None);
+    let layout = hstack.layout(offer.into(), &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(10, 1));
     let mut buffer = FixedTextBuffer::<10, 1>::default();
     hstack.render(&mut buffer, &layout, Point::zero(), &env);
 
@@ -185,28 +186,28 @@ fn test_layout_3_remainder_allocation() {
         Text::str("bbb", &font),
         Text::str("ccc", &font),
     ));
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<10, 1>::default();
     let offer = Size::new(7, 1);
-    let layout = hstack.layout(offer, &env);
+    let layout = hstack.layout(offer.into(), &env);
     hstack.render(&mut buffer, &layout, Point::zero(), &env);
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "aaabbcc   ");
 
     let offer = Size::new(8, 1);
-    let layout = hstack.layout(offer, &env);
+    let layout = hstack.layout(offer.into(), &env);
     hstack.render(&mut buffer, &layout, Point::zero(), &env);
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "aaabbbcc  ");
 
     let offer = Size::new(9, 1);
-    let layout = hstack.layout(offer, &env);
+    let layout = hstack.layout(offer.into(), &env);
     hstack.render(&mut buffer, &layout, Point::zero(), &env);
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "aaabbbccc ");
 
     let offer = Size::new(10, 1);
-    let layout = hstack.layout(offer, &env);
+    let layout = hstack.layout(offer.into(), &env);
     hstack.render(&mut buffer, &layout, Point::zero(), &env);
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "aaabbbccc ");
@@ -223,9 +224,9 @@ fn test_layout_3_vertical_alignment_bottom() {
     ))
     .with_alignment(VerticalAlignment::Bottom)
     .with_spacing(1);
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = hstack.layout(buffer.size(), &env);
+    let layout = hstack.layout(buffer.size().into(), &env);
     hstack.render(&mut buffer, &layout, Point::zero(), &env);
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "   |  ");
@@ -246,9 +247,9 @@ fn test_layout_3_vertical_alignment_center() {
     ))
     .with_alignment(VerticalAlignment::Center)
     .with_spacing(1);
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = hstack.layout(buffer.size(), &env);
+    let layout = hstack.layout(buffer.size().into(), &env);
     hstack.render(&mut buffer, &layout, Point::zero(), &env);
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "   |  ");
@@ -269,9 +270,9 @@ fn test_layout_3_vertical_alignment_top() {
     ))
     .with_alignment(VerticalAlignment::Top)
     .with_spacing(1);
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = hstack.layout(buffer.size(), &env);
+    let layout = hstack.layout(buffer.size().into(), &env);
     hstack.render(&mut buffer, &layout, Point::zero(), &env);
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "aa | c");
@@ -293,10 +294,10 @@ fn test_minimal_offer_extra_space_1() {
     .with_alignment(VerticalAlignment::Top)
     .with_spacing(1);
 
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<19, 5>::default();
 
-    let layout = hstack.layout(buffer.size(), &env);
+    let layout = hstack.layout(buffer.size().into(), &env);
 
     hstack.render(&mut buffer, &layout, Point::zero(), &env);
 
@@ -312,22 +313,150 @@ fn test_minimal_offer_extra_space_1() {
     });
 }
 
-#[ignore = "This test is currently failing because extra space is allocated only to the first view"]
 #[test]
 fn test_layout_3_extra_space_allocation() {
-    // The VStack should attempt to lay out the views into the full width of the offer.
+    // The HStack should attempt to lay out the views into the full width of the offer.
     let font = BufferCharacterFont {};
     let hstack = HStack::new((
-        Rectangle.foreground_color(()),
+        Rectangle.foreground_color(Some('x')),
         Text::str("T", &font),
-        Rectangle.foreground_color(()),
+        Rectangle.foreground_color(Some('+')),
     ))
     .with_spacing(0);
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<9, 3>::default();
-    let layout = hstack.layout(buffer.size(), &env);
+    let layout = hstack.layout(buffer.size().into(), &env);
     hstack.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "xxxx ++++");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "xxxxT++++");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "xxxx ++++");
+}
+
+fn view(
+    max_width_1: u16,
+    max_width_2: u16,
+    max_width_3: u16,
+) -> impl CharacterRender<Option<char>> {
+    HStack::new((
+        Rectangle
+            .foreground_color(Some('x'))
+            .flex_frame()
+            .with_min_width(3)
+            .with_max_width(max_width_1),
+        Rectangle
+            .foreground_color(Some('-'))
+            .flex_frame()
+            .with_min_width(2)
+            .with_max_width(max_width_2),
+        Rectangle
+            .foreground_color(Some('+'))
+            .flex_frame()
+            .with_min_width(4)
+            .with_max_width(max_width_3),
+    ))
+}
+
+#[ignore = "This test is correct, but putting off implementation fix for now"]
+#[test]
+fn stack_fits_subviews_regardless_of_flexibility_order() {
+    let env = DefaultEnvironment::new(None);
+    let mut buffer = FixedTextBuffer::<9, 1>::default();
+    for w1 in 1..12 {
+        for w2 in 1..12 {
+            for w3 in 1..12 {
+                let view = view(w1, w2, w3);
+                let layout = view.layout(buffer.size().into(), &env);
+                view.render(&mut buffer, &layout, Point::zero(), &env);
+                // This is the only arrangement that fits
+                assert_eq!(buffer.text[0].iter().collect::<String>(), "xxx--++++");
+            }
+        }
+    }
+}
+
+#[test]
+fn empty_view_does_not_create_extra_spacing() {
+    // The HStack should attempt to lay out the views into the full width of the offer.
+    let font = BufferCharacterFont {};
+    let hstack = HStack::new((Text::str("aaa", &font), EmptyView, Text::str("ccc", &font)))
+        .with_alignment(VerticalAlignment::Top)
+        .with_spacing(2);
+    let env = DefaultEnvironment::new(None);
+    let mut buffer = FixedTextBuffer::<6, 5>::default();
+    let layout = hstack.layout(buffer.size().into(), &env);
+    hstack.render(&mut buffer, &layout, Point::zero(), &env);
+
+    assert_eq!(buffer.text[0].iter().collect::<String>(), "aa  cc");
+    assert_eq!(buffer.text[1].iter().collect::<String>(), "a   c ");
+    assert_eq!(buffer.text[2].iter().collect::<String>(), "      ");
+    assert_eq!(buffer.text[3].iter().collect::<String>(), "      ");
+    assert_eq!(buffer.text[4].iter().collect::<String>(), "      ");
+}
+
+#[test]
+fn infinite_width_offer_results_in_sum_of_subview_widths() {
+    let hstack = HStack::new((
+        Rectangle.frame(Some(8), Some(3), None, None),
+        Rectangle.frame(Some(40), Some(1), None, None),
+        Rectangle.frame(Some(200), Some(8), None, None),
+    ))
+    .with_spacing(1);
+    let offer = ProposedDimensions {
+        width: ProposedDimension::Infinite,
+        height: ProposedDimension::Exact(10),
+    };
+    let env = DefaultEnvironment::new(());
+    let layout = hstack.layout(offer, &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(248 + 2, 8));
+}
+
+#[test]
+fn compact_width_offer_results_in_sum_of_subview_widths() {
+    let hstack = HStack::new((
+        Rectangle.frame(Some(8), Some(3), None, None),
+        Rectangle.frame(Some(40), Some(1), None, None),
+        Rectangle.frame(Some(200), Some(8), None, None),
+    ))
+    .with_spacing(1);
+    let offer = ProposedDimensions {
+        width: ProposedDimension::Compact,
+        height: ProposedDimension::Exact(10),
+    };
+    let env = DefaultEnvironment::new(());
+    let layout = hstack.layout(offer, &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(248 + 2, 8));
+}
+
+#[test]
+fn infinite_width_offer_results_in_sum_of_subview_widths_minus_empties() {
+    let hstack = HStack::new((
+        Rectangle.frame(Some(8), Some(3), None, None),
+        EmptyView,
+        Rectangle.frame(Some(200), Some(8), None, None),
+    ))
+    .with_spacing(1);
+    let offer = ProposedDimensions {
+        width: ProposedDimension::Infinite,
+        height: ProposedDimension::Exact(10),
+    };
+    let env = DefaultEnvironment::new(());
+    let layout = hstack.layout(offer, &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(208 + 1, 8));
+}
+
+#[test]
+fn compact_width_offer_results_in_sum_of_subview_widths_minus_empties() {
+    let hstack = HStack::new((
+        Rectangle.frame(Some(8), Some(3), None, None),
+        EmptyView,
+        Rectangle.frame(Some(200), Some(8), None, None),
+    ))
+    .with_spacing(1);
+    let offer = ProposedDimensions {
+        width: ProposedDimension::Compact,
+        height: ProposedDimension::Exact(10),
+    };
+    let env = DefaultEnvironment::new(());
+    let layout = hstack.layout(offer, &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(208 + 1, 8));
 }

--- a/tests/padding.rs
+++ b/tests/padding.rs
@@ -4,7 +4,7 @@ use buoyant::{
     environment::DefaultEnvironment,
     font::BufferCharacterFont,
     layout::Layout,
-    primitives::{Point, Size},
+    primitives::{Dimensions, Point, Size},
     render::CharacterRender,
     render_target::{CharacterRenderTarget, FixedTextBuffer},
     view::{Divider, HorizontalTextAlignment, LayoutExtensions, Rectangle, Spacer, Text, VStack},
@@ -24,10 +24,10 @@ fn test_clipped_text_trails_correctly() {
         Divider::default(),
     ));
 
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<30, 7>::default();
 
-    let layout = text.layout(buffer.size(), &env);
+    let layout = text.layout(buffer.size().into(), &env);
 
     text.render(&mut buffer, &layout, Point::zero(), &env);
 
@@ -52,7 +52,7 @@ fn test_padding_is_oversized_for_oversized_child() {
     let env = DefaultEnvironment::new(());
 
     assert_eq!(
-        text.layout(Size::new(1, 1), &env).resolved_size,
-        Size::new(14, 14)
+        text.layout(Size::new(1, 1).into(), &env).resolved_size,
+        Dimensions::new(14, 14)
     );
 }

--- a/tests/spacer.rs
+++ b/tests/spacer.rs
@@ -1,10 +1,10 @@
 use buoyant::font::BufferCharacterFont;
-use buoyant::layout::{Layout, LayoutDirection};
-use buoyant::primitives::{Point, Size};
+use buoyant::layout::{Layout, LayoutDirection, ProposedDimensions};
+use buoyant::primitives::{Dimension, Dimensions, Point, ProposedDimension, Size};
 use buoyant::render::CharacterRender;
 use buoyant::render_target::{CharacterRenderTarget, FixedTextBuffer};
-use buoyant::view::{HStack, Spacer, Text};
-use common::TestEnv;
+use buoyant::view::{HStack, Spacer, Text, VStack};
+use common::{collect_text, TestEnv};
 
 mod common;
 
@@ -13,8 +13,8 @@ fn test_horizontal_layout() {
     let spacer = Spacer::default();
     let offer = Size::new(10, 10);
     let env = TestEnv::colorless().with_direction(LayoutDirection::Horizontal);
-    let layout = spacer.layout(offer, &env);
-    assert_eq!(layout.resolved_size, Size::new(10, 0));
+    let layout = spacer.layout(offer.into(), &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(10, 0));
 }
 
 #[test]
@@ -22,17 +22,115 @@ fn test_vertical_layout() {
     let spacer = Spacer::default();
     let offer = Size::new(10, 10);
     let env = TestEnv::colorless().with_direction(LayoutDirection::Vertical);
-    let layout = spacer.layout(offer, &env);
-    assert_eq!(layout.resolved_size, Size::new(0, 10));
+    let layout = spacer.layout(offer.into(), &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(0, 10));
 }
 
 #[test]
-fn test_render_fills_stack() {
+fn test_horizontal_layout_zero() {
+    let spacer = Spacer::default();
+    let offer = Size::new(0, 10);
+    let env = TestEnv::colorless().with_direction(LayoutDirection::Horizontal);
+    let layout = spacer.layout(offer.into(), &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(0, 0));
+}
+
+#[test]
+fn test_vertical_layout_zero() {
+    let spacer = Spacer::default();
+    let offer = Size::new(10, 0);
+    let env = TestEnv::colorless().with_direction(LayoutDirection::Vertical);
+    let layout = spacer.layout(offer.into(), &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(0, 0));
+}
+
+#[test]
+fn test_horizontal_layout_infinite_width() {
+    let spacer = Spacer::default();
+    let offer = ProposedDimensions {
+        width: ProposedDimension::Infinite,
+        height: ProposedDimension::Exact(10),
+    };
+    let env = TestEnv::colorless().with_direction(LayoutDirection::Horizontal);
+    let layout = spacer.layout(offer, &env);
+    assert_eq!(
+        layout.resolved_size,
+        Dimensions {
+            width: Dimension::infinite(),
+            height: 0.into()
+        }
+    );
+}
+
+#[test]
+fn test_horizontal_layout_compact_width() {
+    let spacer = Spacer::default();
+    let offer = ProposedDimensions {
+        width: ProposedDimension::Compact,
+        height: ProposedDimension::Exact(10),
+    };
+
+    let env = TestEnv::colorless().with_direction(LayoutDirection::Horizontal);
+    let layout = spacer.layout(offer, &env);
+    assert_eq!(
+        layout.resolved_size,
+        Dimensions {
+            width: 0.into(),
+            height: 0.into()
+        }
+    );
+}
+
+#[test]
+fn test_vertical_layout_infinite_height() {
+    let spacer = Spacer::default();
+    let offer = ProposedDimensions {
+        width: ProposedDimension::Exact(10),
+        height: ProposedDimension::Infinite,
+    };
+
+    let env = TestEnv::colorless().with_direction(LayoutDirection::Vertical);
+    let layout = spacer.layout(offer, &env);
+    assert_eq!(
+        layout.resolved_size,
+        Dimensions {
+            width: 0.into(),
+            height: Dimension::infinite()
+        }
+    );
+}
+
+#[test]
+fn test_vertical_layout_compact_height() {
+    let spacer = Spacer::default();
+    let offer = ProposedDimensions {
+        width: ProposedDimension::Exact(10),
+        height: ProposedDimension::Compact,
+    };
+
+    let env = TestEnv::colorless().with_direction(LayoutDirection::Vertical);
+    let layout = spacer.layout(offer, &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(0, 0));
+}
+
+#[test]
+fn test_render_fills_hstack() {
     let font = BufferCharacterFont {};
     let hstack = HStack::new((Spacer::default(), Text::str("67", &font))).with_spacing(1);
     let mut buffer = FixedTextBuffer::<9, 1>::default();
     let env = TestEnv::default().with_direction(LayoutDirection::Horizontal);
-    let layout = hstack.layout(buffer.size(), &env);
+    let layout = hstack.layout(buffer.size().into(), &env);
     hstack.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "       67");
+}
+
+#[test]
+fn test_render_fills_vstack() {
+    let font = BufferCharacterFont {};
+    let vstack = VStack::new((Spacer::default(), Text::str("67", &font))).with_spacing(1);
+    let mut buffer = FixedTextBuffer::<1, 9>::default();
+    let env = TestEnv::default().with_direction(LayoutDirection::Horizontal);
+    let layout = vstack.layout(buffer.size().into(), &env);
+    vstack.render(&mut buffer, &layout, Point::zero(), &env);
+    assert_eq!(collect_text(&buffer), "       67");
 }

--- a/tests/vstack.rs
+++ b/tests/vstack.rs
@@ -1,38 +1,34 @@
 use buoyant::environment::DefaultEnvironment;
 use buoyant::font::BufferCharacterFont;
-use buoyant::layout::{HorizontalAlignment, Layout, VerticalAlignment};
-use buoyant::primitives::{Point, Size};
+use buoyant::layout::{HorizontalAlignment, Layout, ProposedDimensions, VerticalAlignment};
+use buoyant::primitives::{Dimensions, Point, ProposedDimension, Size};
 use buoyant::render::CharacterRender;
 use buoyant::render_target::{CharacterRenderTarget as _, FixedTextBuffer};
 use buoyant::view::{
-    CharacterRenderExtensions, Divider, HStack, HorizontalTextAlignment, LayoutExtensions,
-    Rectangle, Spacer, Text, VStack,
+    CharacterRenderExtensions, Divider, EmptyView, HStack, HorizontalTextAlignment,
+    LayoutExtensions, Rectangle, Spacer, Text, VStack,
 };
 
-fn collect_text<const W: usize, const H: usize>(buffer: &FixedTextBuffer<W, H>) -> String {
-    buffer
-        .text
-        .iter()
-        .map(|chars| chars.iter().collect::<String>())
-        .collect::<String>()
-}
+mod common;
+use common::collect_text;
 
 #[test]
 fn test_greedy_layout_2() {
     let vstack = VStack::new((Spacer::default(), Spacer::default()));
     let offer = Size::new(100, 100);
     let env = DefaultEnvironment::new(());
-    let layout = vstack.layout(offer, &env);
-    assert_eq!(layout.resolved_size, Size::new(0, 100));
+    let layout = vstack.layout(offer.into(), &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(0, 100));
 }
 
+/// The Stack should never exceed the offer size.
 #[test]
 fn test_oversized_layout_2() {
     let vstack = VStack::new((Divider::default().padding(2), Spacer::default()));
     let offer = Size::new(0, 10);
     let env = DefaultEnvironment::new(());
-    let layout = vstack.layout(offer, &env);
-    assert_eq!(layout.resolved_size, Size::new(0, 10));
+    let layout = vstack.layout(offer.into(), &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(0, 10));
 }
 
 #[test]
@@ -44,8 +40,76 @@ fn test_oversized_layout_3() {
     ));
     let offer = Size::new(0, 10);
     let env = DefaultEnvironment::new(());
+    let layout = vstack.layout(offer.into(), &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(0, 10));
+}
+
+#[test]
+fn infinite_height_offer_results_in_sum_of_subview_heights() {
+    let vstack = VStack::new((
+        Rectangle.frame(Some(3), Some(8), None, None),
+        Rectangle.frame(Some(1), Some(40), None, None),
+        Rectangle.frame(Some(8), Some(200), None, None),
+    ))
+    .with_spacing(1);
+    let offer = ProposedDimensions {
+        width: ProposedDimension::Exact(10),
+        height: ProposedDimension::Infinite,
+    };
+    let env = DefaultEnvironment::new(());
     let layout = vstack.layout(offer, &env);
-    assert_eq!(layout.resolved_size, Size::new(0, 10));
+    assert_eq!(layout.resolved_size, Dimensions::new(8, 248 + 2));
+}
+
+#[test]
+fn compact_height_offer_results_in_sum_of_subview_heights() {
+    let vstack = VStack::new((
+        Rectangle.frame(Some(3), Some(8), None, None),
+        Rectangle.frame(Some(1), Some(40), None, None),
+        Rectangle.frame(Some(8), Some(200), None, None),
+    ))
+    .with_spacing(1);
+    let offer = ProposedDimensions {
+        width: ProposedDimension::Exact(10),
+        height: ProposedDimension::Compact,
+    };
+    let env = DefaultEnvironment::new(());
+    let layout = vstack.layout(offer, &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(8, 248 + 2));
+}
+
+#[test]
+fn infinite_height_offer_results_in_sum_of_subview_heights_minus_empties() {
+    let vstack = VStack::new((
+        Rectangle.frame(Some(3), Some(8), None, None),
+        EmptyView,
+        Rectangle.frame(Some(8), Some(200), None, None),
+    ))
+    .with_spacing(1);
+    let offer = ProposedDimensions {
+        width: ProposedDimension::Exact(10),
+        height: ProposedDimension::Infinite,
+    };
+    let env = DefaultEnvironment::new(());
+    let layout = vstack.layout(offer, &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(8, 208 + 1));
+}
+
+#[test]
+fn compact_height_offer_results_in_sum_of_subview_heights_minus_empties() {
+    let vstack = VStack::new((
+        Rectangle.frame(Some(3), Some(8), None, None),
+        EmptyView,
+        Rectangle.frame(Some(8), Some(200), None, None),
+    ))
+    .with_spacing(1);
+    let offer = ProposedDimensions {
+        width: ProposedDimension::Exact(10),
+        height: ProposedDimension::Compact,
+    };
+    let env = DefaultEnvironment::new(());
+    let layout = vstack.layout(offer, &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(8, 208 + 1));
 }
 
 #[test]
@@ -57,9 +121,9 @@ fn test_undersized_layout_3_bottom_pad() {
         Spacer::default(),
     ));
     let offer = Size::new(1, 10);
-    let env = DefaultEnvironment::new(());
-    let layout = vstack.layout(offer, &env);
-    assert_eq!(layout.resolved_size, Size::new(1, 10));
+    let env = DefaultEnvironment::new(None);
+    let layout = vstack.layout(offer.into(), &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(1, 10));
     let mut buffer = FixedTextBuffer::<1, 10>::default();
     vstack.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "1");
@@ -84,9 +148,9 @@ fn test_undersized_layout_3_right_pad_space() {
     ))
     .with_spacing(1);
     let offer = Size::new(1, 10);
-    let env = DefaultEnvironment::new(());
-    let layout = vstack.layout(offer, &env);
-    assert_eq!(layout.resolved_size, Size::new(1, 10));
+    let env = DefaultEnvironment::new(None);
+    let layout = vstack.layout(offer.into(), &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(1, 10));
     let mut buffer = FixedTextBuffer::<1, 10>::default();
     vstack.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(collect_text(&buffer), "  234 5678");
@@ -103,9 +167,9 @@ fn test_oversized_layout_3_right_pad_space() {
     ))
     .with_spacing(1);
     let offer = Size::new(1, 10);
-    let env = DefaultEnvironment::new(());
-    let layout = vstack.layout(offer, &env);
-    assert_eq!(layout.resolved_size, Size::new(1, 10));
+    let env = DefaultEnvironment::new(None);
+    let layout = vstack.layout(offer.into(), &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(1, 10));
     let mut buffer = FixedTextBuffer::<1, 10>::default();
     vstack.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(collect_text(&buffer), " 234 56789");
@@ -122,9 +186,9 @@ fn test_oversized_layout_3_middle_pad_space() {
     ))
     .with_spacing(1);
     let offer = Size::new(1, 10);
-    let env = DefaultEnvironment::new(());
-    let layout = vstack.layout(offer, &env);
-    assert_eq!(layout.resolved_size, Size::new(1, 10));
+    let env = DefaultEnvironment::new(None);
+    let layout = vstack.layout(offer.into(), &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(1, 10));
     let mut buffer = FixedTextBuffer::<1, 10>::default();
     vstack.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(collect_text(&buffer), "234  56789");
@@ -141,9 +205,9 @@ fn test_oversized_layout_3_trailing_pad_space() {
     ))
     .with_spacing(1);
     let offer = Size::new(1, 10);
-    let env = DefaultEnvironment::new(());
-    let layout = vstack.layout(offer, &env);
-    assert_eq!(layout.resolved_size, Size::new(1, 10));
+    let env = DefaultEnvironment::new(None);
+    let layout = vstack.layout(offer.into(), &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(1, 10));
     let mut buffer = FixedTextBuffer::<1, 10>::default();
     vstack.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(collect_text(&buffer), "234 56789 ");
@@ -158,14 +222,15 @@ fn test_undersized_layout_3_middle_pad() {
         Text::str("5678", &font),
     ));
     let offer = Size::new(1, 10);
-    let env = DefaultEnvironment::new(());
-    let layout = vstack.layout(offer, &env);
-    assert_eq!(layout.resolved_size, Size::new(1, 10));
+    let env = DefaultEnvironment::new(None);
+    let layout = vstack.layout(offer.into(), &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(1, 10));
     let mut buffer = FixedTextBuffer::<1, 10>::default();
     vstack.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(collect_text(&buffer), "234   5678");
 }
 
+#[ignore = "Not sure if I care about exactly which view gets the extra space first, just that it is all allocated"]
 #[test]
 fn test_layout_3_remainder_allocation() {
     // The VStack should attempt to lay out the views into the full width of the offer.
@@ -175,27 +240,44 @@ fn test_layout_3_remainder_allocation() {
         Text::str("bbb", &font),
         Text::str("ccc", &font),
     ));
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<1, 10>::default();
     let offer = Size::new(1, 7);
-    let layout = vstack.layout(offer, &env);
+    let layout = vstack.layout(offer.into(), &env);
     vstack.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(collect_text(&buffer), "aaabbcc   ");
 
     let offer = Size::new(1, 8);
-    let layout = vstack.layout(offer, &env);
+    let layout = vstack.layout(offer.into(), &env);
     vstack.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(collect_text(&buffer), "aaabbbcc  ");
 
     let offer = Size::new(1, 9);
-    let layout = vstack.layout(offer, &env);
+    let layout = vstack.layout(offer.into(), &env);
     vstack.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(collect_text(&buffer), "aaabbbccc ");
 
     let offer = Size::new(1, 10);
-    let layout = vstack.layout(offer, &env);
+    let layout = vstack.layout(offer.into(), &env);
     vstack.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(collect_text(&buffer), "aaabbbccc ");
+}
+
+#[test]
+fn test_layout_3_remainder_allocation_sizing_only() {
+    // The VStack should attempt to lay out the views into the full width of the offer.
+    let font = BufferCharacterFont {};
+    let vstack = VStack::new((
+        Text::str("aaa", &font),
+        Text::str("bbb", &font),
+        Text::str("ccc", &font),
+    ));
+    let env = DefaultEnvironment::new(());
+    for height in 1..9 {
+        let offer = Size::new(1, height);
+        let layout = vstack.layout(offer.into(), &env);
+        assert_eq!(layout.resolved_size, Dimensions::new(1, height));
+    }
 }
 
 #[test]
@@ -209,9 +291,9 @@ fn test_layout_3_horizontal_alignment_trailing() {
     ))
     .with_alignment(HorizontalAlignment::Trailing)
     .with_spacing(1);
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 7>::default();
-    let layout = vstack.layout(buffer.size(), &env);
+    let layout = vstack.layout(buffer.size().into(), &env);
     vstack.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "   aaa");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "      ");
@@ -233,9 +315,9 @@ fn test_layout_3_alignment_center() {
         Text::str("cccc", &font),
     ))
     .with_alignment(HorizontalAlignment::Center);
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<7, 5>::default();
-    let layout = vstack.layout(buffer.size(), &env);
+    let layout = vstack.layout(buffer.size().into(), &env);
     vstack.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "  aaa  ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "-------");
@@ -255,9 +337,9 @@ fn test_layout_3_alignment_leading() {
     ))
     .with_alignment(HorizontalAlignment::Leading)
     .with_spacing(1);
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = vstack.layout(buffer.size(), &env);
+    let layout = vstack.layout(buffer.size().into(), &env);
     vstack.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "aaa   ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "      ");
@@ -275,9 +357,9 @@ fn test_layout_direction_is_set_inner_hstack() {
         HStack::new((Divider::default(), Spacer::default())),
         Divider::default(),
     ));
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = vstack.layout(buffer.size(), &env);
+    let layout = vstack.layout(buffer.size().into(), &env);
     vstack.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "------");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "|     ");
@@ -293,9 +375,9 @@ fn test_layout_direction_is_set_inner_vstack() {
         VStack::new((Divider::default(), Spacer::default())),
         Divider::default(),
     ));
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = hstack.layout(buffer.size(), &env);
+    let layout = hstack.layout(buffer.size().into(), &env);
     hstack.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "|----|");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "|    |");
@@ -341,32 +423,31 @@ fn test_flexible_layout_fills_frame_10k() {
     for width in 1..100 {
         for height in 1..100 {
             let size = Size::new(width, height);
-            let layout = stack.layout(size, &env);
-            assert_eq!(size, layout.resolved_size);
+            let layout = stack.layout(size.into(), &env);
+            assert_eq!(size, layout.resolved_size.into());
         }
     }
 }
 
-#[ignore = "This test is currently failing because extra space is allocated only to the first view"]
 #[test]
 fn test_layout_3_extra_space_allocation() {
     // The VStack should attempt to lay out the views into the full width of the offer.
     let font = BufferCharacterFont {};
     let vstack = VStack::new((
-        Rectangle.foreground_color(()),
-        Text::str("Texty text", &font),
-        Rectangle.foreground_color(()),
+        Rectangle.foreground_color(Some('x')),
+        Text::str("Text text", &font).multiline_text_alignment(HorizontalTextAlignment::Center),
+        Rectangle.foreground_color(Some('+')),
     ))
     .with_spacing(0);
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 10>::default();
-    let layout = vstack.layout(buffer.size(), &env);
+    let layout = vstack.layout(buffer.size().into(), &env);
     vstack.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "xxxxxx");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "xxxxxx");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "xxxxxx");
     assert_eq!(buffer.text[3].iter().collect::<String>(), "xxxxxx");
-    assert_eq!(buffer.text[4].iter().collect::<String>(), "Texty ");
+    assert_eq!(buffer.text[4].iter().collect::<String>(), " Text ");
     assert_eq!(buffer.text[5].iter().collect::<String>(), " text ");
     assert_eq!(buffer.text[6].iter().collect::<String>(), "++++++");
     assert_eq!(buffer.text[7].iter().collect::<String>(), "++++++");
@@ -374,4 +455,21 @@ fn test_layout_3_extra_space_allocation() {
     assert_eq!(buffer.text[9].iter().collect::<String>(), "++++++");
     // multiline text alignment applies within the frame of the text
     // the leading c is correct
+}
+
+#[test]
+fn empty_view_does_not_recieve_spacing() {
+    // The VStack should attempt to lay out the views into the full width of the offer.
+    let font = BufferCharacterFont {};
+    let vstack =
+        VStack::new((Text::str("a", &font), EmptyView, Text::str("c", &font))).with_spacing(1);
+    let env = DefaultEnvironment::new(None);
+    let mut buffer = FixedTextBuffer::<7, 5>::default();
+    let layout = vstack.layout(buffer.size().into(), &env);
+    vstack.render(&mut buffer, &layout, Point::zero(), &env);
+    assert_eq!(buffer.text[0].iter().collect::<String>(), "a      ");
+    assert_eq!(buffer.text[1].iter().collect::<String>(), "       ");
+    assert_eq!(buffer.text[2].iter().collect::<String>(), "c      ");
+    assert_eq!(buffer.text[3].iter().collect::<String>(), "       ");
+    assert_eq!(buffer.text[4].iter().collect::<String>(), "       ");
 }

--- a/tests/zstack.rs
+++ b/tests/zstack.rs
@@ -1,7 +1,7 @@
 use buoyant::environment::DefaultEnvironment;
 use buoyant::font::BufferCharacterFont;
 use buoyant::layout::{HorizontalAlignment, Layout, VerticalAlignment};
-use buoyant::primitives::{Point, Size};
+use buoyant::primitives::{Dimensions, Point, Size};
 use buoyant::render::CharacterRender;
 use buoyant::render_target::{CharacterRenderTarget as _, FixedTextBuffer};
 use buoyant::view::{Divider, LayoutExtensions, Spacer, Text, ZStack};
@@ -11,8 +11,8 @@ fn test_layout_fills_two() {
     let stack = ZStack::two(Spacer::default(), Divider::default());
     let offer = Size::new(100, 42);
     let env = DefaultEnvironment::new(());
-    let layout = stack.layout(offer, &env);
-    assert_eq!(layout.resolved_size, Size::new(100, 42));
+    let layout = stack.layout(offer.into(), &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(100, 42));
 }
 
 #[test]
@@ -20,17 +20,17 @@ fn test_oversized_layout_2() {
     let stack = ZStack::two(Divider::default().padding(2), Spacer::default());
     let offer = Size::new(0, 10);
     let env = DefaultEnvironment::new(());
-    let layout = stack.layout(offer, &env);
-    assert_eq!(layout.resolved_size, Size::new(0, 10));
+    let layout = stack.layout(offer.into(), &env);
+    assert_eq!(layout.resolved_size, Dimensions::new(0, 10));
 }
 
 #[test]
 fn test_render_two_centered_overlap() {
     let font = BufferCharacterFont {};
     let stack = ZStack::two(Text::str("aa\nbb\ncc", &font), Text::str("test", &font));
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = stack.layout(buffer.size(), &env);
+    let layout = stack.layout(buffer.size().into(), &env);
     stack.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), " aa   ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "test  ");
@@ -43,9 +43,9 @@ fn test_render_two_centered_overlap() {
 fn test_render_two_centered() {
     let font = BufferCharacterFont {};
     let stack = ZStack::two(Text::str("test", &font), Text::str("aa\nbb\ncc", &font));
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = stack.layout(buffer.size(), &env);
+    let layout = stack.layout(buffer.size().into(), &env);
     stack.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), " aa   ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "tbbt  ");
@@ -62,9 +62,9 @@ fn test_render_two_top_center_alignment() {
         Text::str("xxx", &font),
     )
     .vertical_alignment(VerticalAlignment::Top);
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = stack.layout(buffer.size(), &env);
+    let layout = stack.layout(buffer.size().into(), &env);
     stack.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "axxxa ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "b b b ");
@@ -82,9 +82,9 @@ fn test_render_two_top_leading_alignment() {
     )
     .vertical_alignment(VerticalAlignment::Top)
     .horizontal_alignment(HorizontalAlignment::Leading);
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = stack.layout(buffer.size(), &env);
+    let layout = stack.layout(buffer.size().into(), &env);
     stack.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "xxx a ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "b b b ");
@@ -102,9 +102,9 @@ fn test_render_two_top_trailing_alignment() {
     )
     .vertical_alignment(VerticalAlignment::Top)
     .horizontal_alignment(HorizontalAlignment::Trailing);
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = stack.layout(buffer.size(), &env);
+    let layout = stack.layout(buffer.size().into(), &env);
     stack.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "a xxx ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "b b b ");
@@ -121,9 +121,9 @@ fn test_render_two_center_leading_alignment() {
         Text::str("xxx", &font),
     )
     .horizontal_alignment(HorizontalAlignment::Leading);
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = stack.layout(buffer.size(), &env);
+    let layout = stack.layout(buffer.size().into(), &env);
     stack.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "a a a ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "xxx b ");
@@ -140,9 +140,9 @@ fn test_render_two_center_trailing_alignment() {
         Text::str("xxx", &font),
     )
     .horizontal_alignment(HorizontalAlignment::Trailing);
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = stack.layout(buffer.size(), &env);
+    let layout = stack.layout(buffer.size().into(), &env);
     stack.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "a a a ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "b xxx ");
@@ -160,9 +160,9 @@ fn test_render_two_bottom_leading_alignment() {
     )
     .vertical_alignment(VerticalAlignment::Bottom)
     .horizontal_alignment(HorizontalAlignment::Leading);
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = stack.layout(buffer.size(), &env);
+    let layout = stack.layout(buffer.size().into(), &env);
     stack.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "a a a ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "b b b ");
@@ -179,9 +179,9 @@ fn test_render_two_bottom_center_alignment() {
         Text::str("xxx", &font),
     )
     .vertical_alignment(VerticalAlignment::Bottom);
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = stack.layout(buffer.size(), &env);
+    let layout = stack.layout(buffer.size().into(), &env);
     stack.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "a a a ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "b b b ");
@@ -199,9 +199,9 @@ fn test_render_two_bottom_trailing_alignment() {
     )
     .vertical_alignment(VerticalAlignment::Bottom)
     .horizontal_alignment(HorizontalAlignment::Trailing);
-    let env = DefaultEnvironment::new(());
+    let env = DefaultEnvironment::new(None);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
-    let layout = stack.layout(buffer.size(), &env);
+    let layout = stack.layout(buffer.size().into(), &env);
     stack.render(&mut buffer, &layout, Point::zero(), &env);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "a a a ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "b b b ");


### PR DESCRIPTION
## Layout Dimension Proposals

- Refactors view layout to allow infinite and compact proposals. This is equivalent to SwiftUI's Double.infinity and nil proposals.
- u16 is still used as the dimension base type, as most embedded devices perform floating point math at least 100x slower. The `Dimension` newtype implements arithmetic using saturating operations on u16 to help avoid overflow, and at least so far this seems to be a reasonable solution.
- A new `fn is_empty` has been added to `Layout` which indicates to a parent container that a view should not be included in layout or rendering. This is primarily useful for containers that add spacing between child views, as they no longer add what appears to be double-spacing where the missing child is.

## Stack Layout

Stacks now propose 0 and infinite dimensions to all their children to determine child flexibility before sorting them and running final layout as a single pass. I think this is only partially correct, and I've created a test case (currently ignored) that illustrates one way it doesn't result in optimal layouts. I suspect the solution is to first lay out views with a minimum width greater than the slice offer before laying out views in order of greatest to least flexibility. But still not convinced this is optimal.

## Considerations

Other libraries implement a secondary function to determine view flexibility. This is 2 of the 3 layout calls, and there is certainly a cheaper way to implement this as the current layout function is also responsible for creating the entire layout size tree during the pass.

SwiftUI uses a layout cache to let views retain information between passes, and splits view layout into a sizing and placement pass. Adding some prints to SwiftUI layout, it looks like the cache may be reused for the entirety of a view's lifetime. The next step is probably to create a hybrid of the two where there is a cheap path for flexibility and a more expensive path that includes placement. Placement in Buoyant currently happens in the render pass to save some bytes, but we'll end up needing to compute placement during layout anyways to will enable frame animations.

## Sneaky changes
- flex_frame modifier is split into `.with_[min|max|ideal]_[width|height]` and `with_[horizontal|vertical]_alignment` so it wouldn't be (even more) comically long.