### PR TITLE
Geometry Groups

### DIFF
--- a/examples/crossterm.rs
+++ b/examples/crossterm.rs
@@ -1,4 +1,5 @@
 use buoyant::font::CharacterBufferFont;
+use buoyant::primitives::Point;
 use buoyant::render::CharacterRender;
 use buoyant::render::CharacterRenderTarget;
 use buoyant::render::Renderable;
@@ -127,6 +128,7 @@ fn render_view(
             }),
             background: None,
         },
+        Point::zero(),
     );
     target.flush();
 }

--- a/examples/profiler.rs
+++ b/examples/profiler.rs
@@ -1,3 +1,4 @@
+use buoyant::primitives::Point;
 use buoyant::render::{CharacterRender as _, CharacterRenderTarget};
 use buoyant::{
     environment::DefaultEnvironment,
@@ -60,7 +61,7 @@ fn main() {
         for height in 1..100 {
             size = Size::new(width, height);
             let tree = make_render_tree(&stack, size);
-            tree.render(&mut target, &' ');
+            tree.render(&mut target, &' ', Point::zero());
         }
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -55,10 +55,6 @@ impl<C, T: NullRender + Layout> Renderable<C> for T {
     }
 }
 
-pub struct CoordinateTransform {
-    pub offset: Point,
-}
-
 #[cfg(feature = "embedded-graphics")]
 use embedded_graphics::prelude::PixelColor;
 #[cfg(feature = "embedded-graphics")]

--- a/src/render.rs
+++ b/src/render.rs
@@ -11,6 +11,7 @@ mod capsule;
 mod circle;
 pub mod collections;
 mod conditional_tree;
+mod offset;
 mod one_of;
 mod owned_text;
 mod rect;
@@ -22,6 +23,7 @@ pub use animate::Animate;
 pub use capsule::Capsule;
 pub use circle::Circle;
 pub use conditional_tree::{ConditionalTree, Subtree};
+pub use offset::Offset;
 pub use one_of::{OneOf2, OneOf3};
 pub use owned_text::OwnedText;
 pub use rect::Rect;
@@ -53,6 +55,10 @@ impl<C, T: NullRender + Layout> Renderable<C> for T {
     }
 }
 
+pub struct CoordinateTransform {
+    pub offset: Point,
+}
+
 #[cfg(feature = "embedded-graphics")]
 use embedded_graphics::prelude::PixelColor;
 #[cfg(feature = "embedded-graphics")]
@@ -62,7 +68,12 @@ use embedded_graphics_core::draw_target::DrawTarget;
 #[cfg(feature = "embedded-graphics")]
 pub trait EmbeddedGraphicsRender<Color: PixelColor>: Sized + Clone {
     /// Render the view to the screen
-    fn render(&self, render_target: &mut impl DrawTarget<Color = Color>, style: &Color);
+    fn render(
+        &self,
+        render_target: &mut impl DrawTarget<Color = Color>,
+        style: &Color,
+        offset: Point,
+    );
 
     /// Render view and all subviews, animating from a source view to a target view
     fn render_animated(
@@ -70,21 +81,22 @@ pub trait EmbeddedGraphicsRender<Color: PixelColor>: Sized + Clone {
         source: &Self,
         target: &Self,
         style: &Color,
-        config: &AnimationDomain,
+        offset: Point,
+        domain: &AnimationDomain,
     ) {
-        let intermediate = Self::join(source.clone(), target.clone(), config);
+        let intermediate = Self::join(source.clone(), target.clone(), domain);
         // TODO: interpolate styles
-        intermediate.render(render_target, style);
+        intermediate.render(render_target, style, offset);
     }
 
     /// Produces a new tree by consuming and interpolating between two partially animated trees
-    fn join(source: Self, target: Self, config: &AnimationDomain) -> Self;
+    fn join(source: Self, target: Self, domain: &AnimationDomain) -> Self;
 }
 
 #[cfg(feature = "embedded-graphics")]
 impl<C: PixelColor> EmbeddedGraphicsRender<C> for () {
     /// Render the view to the screen
-    fn render(&self, _render_target: &mut impl DrawTarget<Color = C>, _style: &C) {}
+    fn render(&self, _render_target: &mut impl DrawTarget<Color = C>, _style: &C, _offset: Point) {}
 
     /// Render view and all subviews, animating from a source view to a target view
     fn render_animated(
@@ -92,17 +104,24 @@ impl<C: PixelColor> EmbeddedGraphicsRender<C> for () {
         _source: &Self,
         _target: &Self,
         _style: &C,
-        _config: &AnimationDomain,
+        _offset: Point,
+        _domain: &AnimationDomain,
     ) {
     }
 
     /// Produces a new tree by consuming and interpolating between two partially animated trees
-    fn join(_source: Self, _target: Self, _config: &AnimationDomain) -> Self {}
+    fn join(_source: Self, _target: Self, _domain: &AnimationDomain) -> Self {}
 }
 
 impl<C> CharacterRender<C> for () {
     /// Render the view to the screen
-    fn render(&self, _render_target: &mut impl CharacterRenderTarget<Color = C>, _style: &C) {}
+    fn render(
+        &self,
+        _render_target: &mut impl CharacterRenderTarget<Color = C>,
+        _style: &C,
+        _offset: Point,
+    ) {
+    }
 
     /// Render view and all subviews, animating from a source view to a target view
     fn render_animated(
@@ -110,12 +129,13 @@ impl<C> CharacterRender<C> for () {
         _source: &Self,
         _target: &Self,
         _style: &C,
-        _config: &AnimationDomain,
+        _offset: Point,
+        _domain: &AnimationDomain,
     ) {
     }
 
     /// Produces a new tree by consuming and interpolating between two partially animated trees
-    fn join(_source: Self, _target: Self, _config: &AnimationDomain) -> Self {}
+    fn join(_source: Self, _target: Self, _domain: &AnimationDomain) -> Self {}
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -162,7 +182,12 @@ pub trait CharacterRenderTarget {
 /// A view that can be rendered to an `embedded_graphics` target
 pub trait CharacterRender<Color>: Sized + Clone {
     /// Render the view to the screen
-    fn render(&self, render_target: &mut impl CharacterRenderTarget<Color = Color>, style: &Color);
+    fn render(
+        &self,
+        render_target: &mut impl CharacterRenderTarget<Color = Color>,
+        style: &Color,
+        offset: Point,
+    );
 
     /// Render view and all subviews, animating from a source view to a target view
     fn render_animated(
@@ -170,11 +195,12 @@ pub trait CharacterRender<Color>: Sized + Clone {
         source: &Self,
         target: &Self,
         style: &Color,
+        offset: Point,
         domain: &AnimationDomain,
     ) {
         let intermediate = Self::join(source.clone(), target.clone(), domain);
         // TODO: interpolate styles
-        intermediate.render(render_target, style);
+        intermediate.render(render_target, style, offset);
     }
 
     /// Produces a new tree by consuming and interpolating between two partially animated trees

--- a/src/render.rs
+++ b/src/render.rs
@@ -81,7 +81,6 @@ pub trait EmbeddedGraphicsRender<Color: PixelColor>: Sized + Clone {
         domain: &AnimationDomain,
     ) {
         let intermediate = Self::join(source.clone(), target.clone(), domain);
-        // TODO: interpolate styles
         intermediate.render(render_target, style, offset);
     }
 
@@ -195,7 +194,6 @@ pub trait CharacterRender<Color>: Sized + Clone {
         domain: &AnimationDomain,
     ) {
         let intermediate = Self::join(source.clone(), target.clone(), domain);
-        // TODO: interpolate styles
         intermediate.render(render_target, style, offset);
     }
 

--- a/src/render/animate.rs
+++ b/src/render/animate.rs
@@ -1,6 +1,7 @@
 use core::time::Duration;
 
 use crate::{
+    primitives::Point,
     render::{AnimationDomain, CharacterRender},
     Animation,
 };
@@ -36,8 +37,9 @@ impl<C, T: CharacterRender<C>, U: PartialEq + Clone> CharacterRender<C> for Anim
         &self,
         render_target: &mut impl crate::render::CharacterRenderTarget<Color = C>,
         style: &C,
+        offset: Point,
     ) {
-        self.subtree.render(render_target, style);
+        self.subtree.render(render_target, style, offset);
     }
 
     fn render_animated(
@@ -45,6 +47,7 @@ impl<C, T: CharacterRender<C>, U: PartialEq + Clone> CharacterRender<C> for Anim
         source: &Self,
         target: &Self,
         style: &C,
+        offset: Point,
         domain: &AnimationDomain,
     ) {
         let (end_time, duration) = if source.value != target.value {
@@ -84,6 +87,7 @@ impl<C, T: CharacterRender<C>, U: PartialEq + Clone> CharacterRender<C> for Anim
             &source.subtree,
             &target.subtree,
             style,
+            offset,
             &subdomain,
         );
     }
@@ -143,7 +147,10 @@ impl<C, T: CharacterRender<C>, U: PartialEq + Clone> CharacterRender<C> for Anim
 mod embedded_graphics_impl {
     use core::time::Duration;
 
-    use crate::render::{AnimationDomain, EmbeddedGraphicsRender};
+    use crate::{
+        primitives::Point,
+        render::{AnimationDomain, EmbeddedGraphicsRender},
+    };
 
     use embedded_graphics::prelude::PixelColor;
     use embedded_graphics_core::draw_target::DrawTarget;
@@ -153,8 +160,8 @@ mod embedded_graphics_impl {
     impl<C: PixelColor, T: EmbeddedGraphicsRender<C>, U: PartialEq + Clone>
         EmbeddedGraphicsRender<C> for Animate<T, U>
     {
-        fn render(&self, render_target: &mut impl DrawTarget<Color = C>, style: &C) {
-            self.subtree.render(render_target, style);
+        fn render(&self, render_target: &mut impl DrawTarget<Color = C>, style: &C, offset: Point) {
+            self.subtree.render(render_target, style, offset);
         }
 
         fn render_animated(
@@ -162,6 +169,7 @@ mod embedded_graphics_impl {
             source: &Self,
             target: &Self,
             style: &C,
+            offset: Point,
             domain: &AnimationDomain,
         ) {
             let (end_time, duration) = if source.value != target.value {
@@ -201,6 +209,7 @@ mod embedded_graphics_impl {
                 &source.subtree,
                 &target.subtree,
                 style,
+                offset,
                 &subdomain,
             );
         }

--- a/src/render/capsule.rs
+++ b/src/render/capsule.rs
@@ -29,10 +29,11 @@ mod embedded_graphics_impl {
 
     use super::Capsule;
     impl<C: PixelColor> EmbeddedGraphicsRender<C> for Capsule {
-        fn render(&self, render_target: &mut impl DrawTarget<Color = C>, style: &C) {
+        fn render(&self, render_target: &mut impl DrawTarget<Color = C>, style: &C, offset: Point) {
+            let top_left = (self.origin + offset).into();
             let radius = self.size.height.min(self.size.width) / 2;
             let rectangle = embedded_graphics::primitives::Rectangle {
-                top_left: self.origin.into(),
+                top_left,
                 size: self.size.into(),
             };
 
@@ -46,11 +47,11 @@ mod embedded_graphics_impl {
             .draw_styled(&PrimitiveStyle::with_fill(*style), render_target);
         }
 
-        fn join(source: Self, target: Self, config: &AnimationDomain) -> Self {
-            let x = i16::interpolate(source.origin.x, target.origin.x, config.factor);
-            let y = i16::interpolate(source.origin.y, target.origin.y, config.factor);
-            let w = u16::interpolate(source.size.width, target.size.width, config.factor);
-            let h = u16::interpolate(source.size.height, target.size.height, config.factor);
+        fn join(source: Self, target: Self, domain: &AnimationDomain) -> Self {
+            let x = i16::interpolate(source.origin.x, target.origin.x, domain.factor);
+            let y = i16::interpolate(source.origin.y, target.origin.y, domain.factor);
+            let w = u16::interpolate(source.size.width, target.size.width, domain.factor);
+            let h = u16::interpolate(source.size.height, target.size.height, domain.factor);
             Capsule::new(Point::new(x, y), Size::new(w, h))
         }
     }

--- a/src/render/circle.rs
+++ b/src/render/circle.rs
@@ -21,18 +21,16 @@ mod embedded_graphics_impl {
     use embedded_graphics_core::draw_target::DrawTarget;
 
     impl<C: PixelColor> EmbeddedGraphicsRender<C> for Circle {
-        fn render(&self, render_target: &mut impl DrawTarget<Color = C>, style: &C) {
-            _ = embedded_graphics::primitives::Circle::new(
-                self.origin.into(),
-                self.diameter.into(),
-            )
-            .draw_styled(&PrimitiveStyle::with_fill(*style), render_target);
+        fn render(&self, render_target: &mut impl DrawTarget<Color = C>, style: &C, offset: Point) {
+            let center = self.origin + offset;
+            _ = embedded_graphics::primitives::Circle::new(center.into(), self.diameter.into())
+                .draw_styled(&PrimitiveStyle::with_fill(*style), render_target);
         }
 
-        fn join(source: Self, target: Self, config: &AnimationDomain) -> Self {
-            let x = i16::interpolate(source.origin.x, target.origin.x, config.factor);
-            let y = i16::interpolate(source.origin.y, target.origin.y, config.factor);
-            let diameter = u16::interpolate(source.diameter, target.diameter, config.factor);
+        fn join(source: Self, target: Self, domain: &AnimationDomain) -> Self {
+            let x = i16::interpolate(source.origin.x, target.origin.x, domain.factor);
+            let y = i16::interpolate(source.origin.y, target.origin.y, domain.factor);
+            let diameter = u16::interpolate(source.diameter, target.diameter, domain.factor);
             Circle {
                 origin: Point::new(x, y),
                 diameter,

--- a/src/render/conditional_tree.rs
+++ b/src/render/conditional_tree.rs
@@ -1,5 +1,4 @@
 use crate::{
-    pixel::Interpolate as _,
     primitives::{Point, Size},
     render::{CharacterRender, CharacterRenderTarget},
 };

--- a/src/render/conditional_tree.rs
+++ b/src/render/conditional_tree.rs
@@ -1,5 +1,6 @@
 use crate::{
-    primitives::Size,
+    pixel::Interpolate as _,
+    primitives::{Point, Size},
     render::{CharacterRender, CharacterRenderTarget},
 };
 
@@ -17,6 +18,7 @@ pub enum Subtree<T, F> {
 
 #[cfg(feature = "embedded-graphics")]
 mod embedded_graphics_impl {
+    use crate::primitives::Point;
     use crate::render::EmbeddedGraphicsRender;
 
     use super::{ConditionalTree, Subtree};
@@ -26,21 +28,21 @@ mod embedded_graphics_impl {
     impl<C: PixelColor, T: EmbeddedGraphicsRender<C>, F: EmbeddedGraphicsRender<C>>
         EmbeddedGraphicsRender<C> for ConditionalTree<T, F>
     {
-        fn render(&self, target: &mut impl DrawTarget<Color = C>, style: &C) {
+        fn render(&self, target: &mut impl DrawTarget<Color = C>, style: &C, offset: Point) {
             match &self.subtree {
-                Subtree::True(true_tree) => true_tree.render(target, style),
-                Subtree::False(false_tree) => false_tree.render(target, style),
+                Subtree::True(true_tree) => true_tree.render(target, style, offset),
+                Subtree::False(false_tree) => false_tree.render(target, style, offset),
             }
         }
 
-        fn join(source: Self, target: Self, config: &crate::render::AnimationDomain) -> Self {
+        fn join(source: Self, target: Self, domain: &crate::render::AnimationDomain) -> Self {
             match (source.subtree, target.subtree) {
                 (Subtree::True(source_tree), Subtree::True(target_tree)) => Self {
-                    subtree: Subtree::True(T::join(source_tree, target_tree, config)),
+                    subtree: Subtree::True(T::join(source_tree, target_tree, domain)),
                     size: target.size,
                 },
                 (Subtree::False(source_tree), Subtree::False(target_tree)) => Self {
-                    subtree: Subtree::False(F::join(source_tree, target_tree, config)),
+                    subtree: Subtree::False(F::join(source_tree, target_tree, domain)),
                     size: target.size,
                 },
                 (_, target_tree) => Self {
@@ -53,21 +55,34 @@ mod embedded_graphics_impl {
 }
 
 impl<C, T: CharacterRender<C>, F: CharacterRender<C>> CharacterRender<C> for ConditionalTree<T, F> {
-    fn render(&self, target: &mut impl CharacterRenderTarget<Color = C>, style: &C) {
+    fn render(&self, target: &mut impl CharacterRenderTarget<Color = C>, style: &C, offset: Point) {
         match &self.subtree {
-            Subtree::True(true_tree) => true_tree.render(target, style),
-            Subtree::False(false_tree) => false_tree.render(target, style),
+            Subtree::True(true_tree) => true_tree.render(target, style, offset),
+            Subtree::False(false_tree) => false_tree.render(target, style, offset),
         }
     }
 
-    fn join(source: Self, target: Self, config: &crate::render::AnimationDomain) -> Self {
+    fn render_animated(
+        render_target: &mut impl CharacterRenderTarget<Color = C>,
+        source: &Self,
+        target: &Self,
+        style: &C,
+        offset: Point,
+
+        config: &crate::render::AnimationDomain,
+    ) {
+        let intermediate = Self::join(source.clone(), target.clone(), config);
+        intermediate.render(render_target, style, offset);
+    }
+
+    fn join(source: Self, target: Self, domain: &crate::render::AnimationDomain) -> Self {
         match (source.subtree, target.subtree) {
-            (Subtree::True(source_tree), Subtree::True(target_tree)) => Self {
-                subtree: Subtree::True(T::join(source_tree, target_tree, config)),
+            (Subtree::True(s), Subtree::True(t)) => Self {
+                subtree: Subtree::True(T::join(s, t, domain)),
                 size: target.size,
             },
-            (Subtree::False(source_tree), Subtree::False(target_tree)) => Self {
-                subtree: Subtree::False(F::join(source_tree, target_tree, config)),
+            (Subtree::False(s), Subtree::False(t)) => Self {
+                subtree: Subtree::False(F::join(s, t, domain)),
                 size: target.size,
             },
             (_, target_tree) => Self {

--- a/src/render/offset.rs
+++ b/src/render/offset.rs
@@ -1,0 +1,96 @@
+use crate::{pixel::Interpolate as _, primitives::Point};
+
+use super::{AnimationDomain, CharacterRender, CharacterRenderTarget};
+
+/// A render tree item that offsets its children by a fixed amount.
+/// The offset is animated, resulting in all children moving in unison.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Offset<T> {
+    offset: Point,
+    subtree: T,
+}
+
+impl<T> Offset<T> {
+    /// Create a new offset render tree item
+    pub fn new(offset: Point, subtree: T) -> Self {
+        Self { offset, subtree }
+    }
+}
+impl<T: CharacterRender<C>, C> CharacterRender<C> for Offset<T> {
+    fn render(
+        &self,
+        render_target: &mut impl CharacterRenderTarget<Color = C>,
+        style: &C,
+        offset: Point,
+    ) {
+        self.subtree
+            .render(render_target, style, self.offset + offset);
+    }
+
+    fn render_animated(
+        render_target: &mut impl CharacterRenderTarget<Color = C>,
+        source: &Self,
+        target: &Self,
+        style: &C,
+        offset: Point,
+        domain: &super::AnimationDomain,
+    ) {
+        T::render_animated(
+            render_target,
+            &source.subtree,
+            &target.subtree,
+            style,
+            Point::interpolate(source.offset, target.offset, domain.factor) + offset,
+            domain,
+        );
+    }
+
+    fn join(source: Self, target: Self, domain: &AnimationDomain) -> Self {
+        let subtree = T::join(source.subtree, target.subtree, domain);
+        let offset = Point::interpolate(source.offset, target.offset, domain.factor);
+        Self { offset, subtree }
+    }
+}
+
+#[cfg(feature = "embedded-graphics")]
+mod embedded_graphics_impl {
+    use embedded_graphics::prelude::PixelColor;
+    use embedded_graphics_core::draw_target::DrawTarget;
+
+    use crate::pixel::Interpolate;
+    use crate::primitives::Point;
+    use crate::render::{AnimationDomain, EmbeddedGraphicsRender};
+
+    use super::Offset;
+
+    impl<T: EmbeddedGraphicsRender<C>, C: PixelColor> EmbeddedGraphicsRender<C> for Offset<T> {
+        fn render(&self, render_target: &mut impl DrawTarget<Color = C>, style: &C, offset: Point) {
+            self.subtree
+                .render(render_target, style, self.offset + offset);
+        }
+
+        fn render_animated(
+            render_target: &mut impl DrawTarget<Color = C>,
+            source: &Self,
+            target: &Self,
+            style: &C,
+            offset: Point,
+            domain: &super::AnimationDomain,
+        ) {
+            T::render_animated(
+                render_target,
+                &source.subtree,
+                &target.subtree,
+                style,
+                Point::interpolate(source.offset, target.offset, domain.factor) + offset,
+                domain,
+            );
+        }
+
+        fn join(source: Self, target: Self, domain: &AnimationDomain) -> Self {
+            let subtree = T::join(source.subtree, target.subtree, domain);
+            let offset = Point::interpolate(source.offset, target.offset, domain.factor);
+            Self { offset, subtree }
+        }
+    }
+}

--- a/src/render/one_of.rs
+++ b/src/render/one_of.rs
@@ -87,7 +87,7 @@ mod embedded_graphics_render {
             }
         }
 
-        fn join(source: Self, target: Self, _domain: &crate::render::AnimationDomain) -> Self {
+        fn join(_source: Self, target: Self, _domain: &crate::render::AnimationDomain) -> Self {
             // jump to target
             target
         }
@@ -108,7 +108,7 @@ mod embedded_graphics_render {
             }
         }
 
-        fn join(source: Self, target: Self, _domain: &crate::render::AnimationDomain) -> Self {
+        fn join(_source: Self, target: Self, _domain: &crate::render::AnimationDomain) -> Self {
             // jump to target
             target
         }

--- a/src/render/one_of.rs
+++ b/src/render/one_of.rs
@@ -1,4 +1,7 @@
-use crate::render::{CharacterRender, CharacterRenderTarget};
+use crate::{
+    primitives::Point,
+    render::{CharacterRender, CharacterRenderTarget},
+};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum OneOf2<V0, V1> {
@@ -18,15 +21,28 @@ where
     V0: CharacterRender<C>,
     V1: CharacterRender<C>,
 {
-    fn render(&self, target: &mut impl CharacterRenderTarget<Color = C>, color: &C) {
+    fn render(&self, target: &mut impl CharacterRenderTarget<Color = C>, color: &C, offset: Point) {
         match self {
-            OneOf2::Variant0(v0) => v0.render(target, color),
-            OneOf2::Variant1(v1) => v1.render(target, color),
+            OneOf2::Variant0(v0) => v0.render(target, color, offset),
+            OneOf2::Variant1(v1) => v1.render(target, color, offset),
         }
     }
 
+    fn render_animated(
+        render_target: &mut impl CharacterRenderTarget<Color = C>,
+        source: &Self,
+        target: &Self,
+        style: &C,
+        offset: Point,
+
+        domain: &crate::render::AnimationDomain,
+    ) {
+        let intermediate = Self::join(source.clone(), target.clone(), domain);
+        // TODO: use transaction???
+        intermediate.render(render_target, style, offset);
+    }
+
     fn join(_source: Self, target: Self, _domain: &crate::render::AnimationDomain) -> Self {
-        // jump to target
         target
     }
 }
@@ -37,16 +53,15 @@ where
     V1: CharacterRender<C>,
     V2: CharacterRender<C>,
 {
-    fn render(&self, target: &mut impl CharacterRenderTarget<Color = C>, color: &C) {
+    fn render(&self, target: &mut impl CharacterRenderTarget<Color = C>, color: &C, offset: Point) {
         match self {
-            OneOf3::Variant0(v0) => v0.render(target, color),
-            OneOf3::Variant1(v1) => v1.render(target, color),
-            OneOf3::Variant2(v2) => v2.render(target, color),
+            OneOf3::Variant0(v0) => v0.render(target, color, offset),
+            OneOf3::Variant1(v1) => v1.render(target, color, offset),
+            OneOf3::Variant2(v2) => v2.render(target, color, offset),
         }
     }
 
     fn join(_source: Self, target: Self, _domain: &crate::render::AnimationDomain) -> Self {
-        // jump to target
         target
     }
 }
@@ -55,7 +70,7 @@ where
 mod embedded_graphics_render {
     use embedded_graphics::prelude::{DrawTarget, PixelColor};
 
-    use crate::render::EmbeddedGraphicsRender;
+    use crate::{primitives::Point, render::EmbeddedGraphicsRender};
 
     use super::{OneOf2, OneOf3};
 
@@ -65,14 +80,14 @@ mod embedded_graphics_render {
         V1: EmbeddedGraphicsRender<C>,
         C: PixelColor,
     {
-        fn render(&self, target: &mut impl DrawTarget<Color = C>, color: &C) {
+        fn render(&self, target: &mut impl DrawTarget<Color = C>, color: &C, offset: Point) {
             match self {
-                OneOf2::Variant0(v0) => v0.render(target, color),
-                OneOf2::Variant1(v1) => v1.render(target, color),
+                OneOf2::Variant0(v0) => v0.render(target, color, offset),
+                OneOf2::Variant1(v1) => v1.render(target, color, offset),
             }
         }
 
-        fn join(_source: Self, target: Self, _domain: &crate::render::AnimationDomain) -> Self {
+        fn join(source: Self, target: Self, _domain: &crate::render::AnimationDomain) -> Self {
             // jump to target
             target
         }
@@ -85,15 +100,15 @@ mod embedded_graphics_render {
         V2: EmbeddedGraphicsRender<C>,
         C: PixelColor,
     {
-        fn render(&self, target: &mut impl DrawTarget<Color = C>, color: &C) {
+        fn render(&self, target: &mut impl DrawTarget<Color = C>, color: &C, offset: Point) {
             match self {
-                OneOf3::Variant0(v0) => v0.render(target, color),
-                OneOf3::Variant1(v1) => v1.render(target, color),
-                OneOf3::Variant2(v2) => v2.render(target, color),
+                OneOf3::Variant0(v0) => v0.render(target, color, offset),
+                OneOf3::Variant1(v1) => v1.render(target, color, offset),
+                OneOf3::Variant2(v2) => v2.render(target, color, offset),
             }
         }
 
-        fn join(_source: Self, target: Self, _domain: &crate::render::AnimationDomain) -> Self {
+        fn join(source: Self, target: Self, _domain: &crate::render::AnimationDomain) -> Self {
             // jump to target
             target
         }

--- a/src/render/owned_text.rs
+++ b/src/render/owned_text.rs
@@ -26,11 +26,12 @@ mod embedded_graphics_impl {
     use embedded_graphics_core::draw_target::DrawTarget;
 
     impl<C: PixelColor, const N: usize> EmbeddedGraphicsRender<C> for OwnedText<'_, N, MonoFont<'_>> {
-        fn render(&self, render_target: &mut impl DrawTarget<Color = C>, style: &C) {
+        fn render(&self, render_target: &mut impl DrawTarget<Color = C>, style: &C, offset: Point) {
             if self.size.area() == 0 {
                 return;
             }
 
+            let origin = self.origin + offset;
             let line_height = self.font.line_height() as i16;
 
             let baseline = self.font.baseline() as i16;
@@ -44,7 +45,7 @@ mod embedded_graphics_impl {
 
                 let x = self.alignment.align(self.size.width as i16, width as i16);
                 // embedded_graphics draws text at the baseline
-                let txt_start = self.origin + Point::new(x, height + baseline);
+                let txt_start = origin + Point::new(x, height + baseline);
                 _ = embedded_graphics::text::Text::new(line, txt_start.into(), style)
                     .draw(render_target);
 

--- a/src/render/rect.rs
+++ b/src/render/rect.rs
@@ -15,6 +15,30 @@ impl Rect {
     }
 }
 
+impl<C> CharacterRender<C> for Rect {
+    fn render(
+        &self,
+        render_target: &mut impl CharacterRenderTarget<Color = C>,
+        style: &C,
+        offset: Point,
+    ) {
+        let origin = self.origin + offset;
+        for y in origin.y..origin.y + self.size.height as i16 {
+            for x in origin.x..origin.x + self.size.width as i16 {
+                render_target.draw_color(Point::new(x, y), style);
+            }
+        }
+    }
+
+    fn join(source: Self, target: Self, domain: &AnimationDomain) -> Self {
+        let x = i16::interpolate(source.origin.x, target.origin.x, domain.factor);
+        let y = i16::interpolate(source.origin.y, target.origin.y, domain.factor);
+        let w = u16::interpolate(source.size.width, target.size.width, domain.factor);
+        let h = u16::interpolate(source.size.height, target.size.height, domain.factor);
+        Rect::new(Point::new(x, y), Size::new(w, h))
+    }
+}
+
 #[cfg(feature = "embedded-graphics")]
 mod embedded_graphics_impl {
     use embedded_graphics::prelude::PixelColor;
@@ -28,39 +52,19 @@ mod embedded_graphics_impl {
     use super::Rect;
     // TODO: not really ideal...reimplement later
     impl<C: PixelColor> EmbeddedGraphicsRender<C> for Rect {
-        fn render(&self, render_target: &mut impl DrawTarget<Color = C>, style: &C) {
-            _ = embedded_graphics::primitives::Rectangle {
-                top_left: self.origin.into(),
-                size: self.size.into(),
-            }
-            .draw_styled(&PrimitiveStyle::with_fill(*style), render_target);
+        fn render(&self, render_target: &mut impl DrawTarget<Color = C>, style: &C, offset: Point) {
+            let origin = self.origin + offset;
+            let eg_rect =
+                embedded_graphics::primitives::Rectangle::new(origin.into(), self.size.into());
+            _ = eg_rect.draw_styled(&PrimitiveStyle::with_fill(*style), render_target);
         }
 
-        fn join(source: Self, target: Self, config: &AnimationDomain) -> Self {
-            let x = i16::interpolate(source.origin.x, target.origin.x, config.factor);
-            let y = i16::interpolate(source.origin.y, target.origin.y, config.factor);
-            let w = u16::interpolate(source.size.width, target.size.width, config.factor);
-            let h = u16::interpolate(source.size.height, target.size.height, config.factor);
+        fn join(source: Self, target: Self, domain: &AnimationDomain) -> Self {
+            let x = i16::interpolate(source.origin.x, target.origin.x, domain.factor);
+            let y = i16::interpolate(source.origin.y, target.origin.y, domain.factor);
+            let w = u16::interpolate(source.size.width, target.size.width, domain.factor);
+            let h = u16::interpolate(source.size.height, target.size.height, domain.factor);
             Rect::new(Point::new(x, y), Size::new(w, h))
         }
-    }
-}
-
-impl<C> CharacterRender<C> for Rect {
-    fn render(&self, render_target: &mut impl CharacterRenderTarget<Color = C>, style: &C) {
-        // TODO: don't draw offscreen?
-        for x in self.origin.x..self.origin.x + self.size.width as i16 {
-            for y in self.origin.y..self.origin.y + self.size.height as i16 {
-                render_target.draw_color(Point::new(x, y), style);
-            }
-        }
-    }
-
-    fn join(source: Self, target: Self, config: &AnimationDomain) -> Self {
-        let x = i16::interpolate(source.origin.x, target.origin.x, config.factor);
-        let y = i16::interpolate(source.origin.y, target.origin.y, config.factor);
-        let w = u16::interpolate(source.size.width, target.size.width, config.factor);
-        let h = u16::interpolate(source.size.height, target.size.height, config.factor);
-        Rect::new(Point::new(x, y), Size::new(w, h))
     }
 }

--- a/src/render/rounded_rect.rs
+++ b/src/render/rounded_rect.rs
@@ -21,10 +21,11 @@ mod embedded_graphics_impl {
     use super::{Point, RoundedRect, Size};
 
     impl<C: PixelColor> EmbeddedGraphicsRender<C> for RoundedRect {
-        fn render(&self, render_target: &mut impl DrawTarget<Color = C>, style: &C) {
+        fn render(&self, render_target: &mut impl DrawTarget<Color = C>, style: &C, offset: Point) {
+            let top_left = (self.origin + offset).into();
             _ = embedded_graphics::primitives::RoundedRectangle::new(
                 embedded_graphics::primitives::Rectangle {
-                    top_left: self.origin.into(),
+                    top_left,
                     size: self.size.into(),
                 },
                 embedded_graphics::primitives::CornerRadii::new(

--- a/src/render/shade_subtree.rs
+++ b/src/render/shade_subtree.rs
@@ -1,4 +1,7 @@
-use crate::render::{AnimationDomain, CharacterRender, CharacterRenderTarget};
+use crate::{
+    primitives::Point,
+    render::{AnimationDomain, CharacterRender, CharacterRenderTarget},
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ShadeSubtree<C, T> {
@@ -14,7 +17,7 @@ impl<C, T> ShadeSubtree<C, T> {
 
 #[cfg(feature = "embedded-graphics")]
 mod embedded_graphics_impl {
-    use crate::{pixel::Interpolate, render::EmbeddedGraphicsRender};
+    use crate::{pixel::Interpolate, primitives::Point, render::EmbeddedGraphicsRender};
 
     use super::{AnimationDomain, ShadeSubtree};
     use embedded_graphics::prelude::PixelColor;
@@ -23,8 +26,8 @@ mod embedded_graphics_impl {
     impl<C: PixelColor + Interpolate, T: EmbeddedGraphicsRender<C>> EmbeddedGraphicsRender<C>
         for ShadeSubtree<C, T>
     {
-        fn render(&self, render_target: &mut impl DrawTarget<Color = C>, _: &C) {
-            self.subtree.render(render_target, &self.style);
+        fn render(&self, render_target: &mut impl DrawTarget<Color = C>, _: &C, offset: Point) {
+            self.subtree.render(render_target, &self.style, offset);
         }
 
         fn render_animated(
@@ -32,6 +35,7 @@ mod embedded_graphics_impl {
             source: &Self,
             target: &Self,
             _: &C,
+            offset: Point,
             config: &AnimationDomain,
         ) {
             let style = Interpolate::interpolate(source.style, target.style, config.factor);
@@ -40,6 +44,7 @@ mod embedded_graphics_impl {
                 &source.subtree,
                 &target.subtree,
                 &style,
+                offset,
                 config,
             );
         }
@@ -54,8 +59,13 @@ mod embedded_graphics_impl {
 }
 
 impl<C: Clone, T: CharacterRender<C>> CharacterRender<C> for ShadeSubtree<C, T> {
-    fn render(&self, render_target: &mut impl CharacterRenderTarget<Color = C>, _: &C) {
-        self.subtree.render(render_target, &self.style);
+    fn render(
+        &self,
+        render_target: &mut impl CharacterRenderTarget<Color = C>,
+        _: &C,
+        offset: Point,
+    ) {
+        self.subtree.render(render_target, &self.style, offset);
     }
 
     fn render_animated(
@@ -63,6 +73,8 @@ impl<C: Clone, T: CharacterRender<C>> CharacterRender<C> for ShadeSubtree<C, T> 
         source: &Self,
         target: &Self,
         _: &C,
+        offset: Point,
+
         config: &AnimationDomain,
     ) {
         // TODO: This should be animated, but then I'd need to update all the char types in tests
@@ -79,13 +91,13 @@ impl<C: Clone, T: CharacterRender<C>> CharacterRender<C> for ShadeSubtree<C, T> 
             &source.subtree,
             &target.subtree,
             &target.style,
+            offset,
             config,
         );
     }
 
     fn join(source: Self, target: Self, config: &AnimationDomain) -> Self {
         Self {
-            // TODO: This "jumps" to the target style, should be an interpolated intermetiate
             style: target.style,
             subtree: T::join(source.subtree, target.subtree, config),
         }

--- a/src/view.rs
+++ b/src/view.rs
@@ -22,7 +22,9 @@ pub use text::{HorizontalTextAlignment, Text};
 pub use vstack::VStack;
 pub use zstack::ZStack;
 
-use modifier::{Animated, FixedFrame, FlexFrame, ForegroundStyle, Padding, Priority};
+use modifier::{
+    Animated, FixedFrame, FlexFrame, ForegroundStyle, GeometryGroup, Padding, Priority,
+};
 
 use crate::{
     environment::DefaultEnvironment,
@@ -62,6 +64,10 @@ pub trait LayoutExtensions: Sized {
 
     fn animated<T: PartialEq + Clone>(self, animation: Animation, value: T) -> Animated<Self, T> {
         Animated::new(self, animation, value)
+    }
+
+    fn geometry_group(self) -> GeometryGroup<Self> {
+        GeometryGroup::new(self)
     }
 }
 

--- a/src/view/modifier.rs
+++ b/src/view/modifier.rs
@@ -2,6 +2,7 @@ mod animated;
 mod fixed_frame;
 mod flex_frame;
 mod foreground_color;
+mod geometry_group;
 mod padding;
 mod priority;
 
@@ -9,5 +10,6 @@ pub use animated::Animated;
 pub use fixed_frame::FixedFrame;
 pub use flex_frame::FlexFrame;
 pub use foreground_color::ForegroundStyle;
+pub use geometry_group::GeometryGroup;
 pub use padding::Padding;
 pub use priority::Priority;

--- a/src/view/modifier/geometry_group.rs
+++ b/src/view/modifier/geometry_group.rs
@@ -1,0 +1,42 @@
+use crate::{
+    layout::Layout,
+    primitives::Point,
+    render::{Offset, Renderable},
+};
+
+pub struct GeometryGroup<View> {
+    view: View,
+}
+
+impl<View> GeometryGroup<View> {
+    pub fn new(view: View) -> Self {
+        Self { view }
+    }
+}
+
+// Transparent layout
+impl<T: Layout> Layout for GeometryGroup<T> {
+    type Sublayout = T::Sublayout;
+
+    fn layout(
+        &self,
+        offer: &crate::primitives::ProposedDimensions,
+        env: &impl crate::environment::LayoutEnvironment,
+    ) -> crate::layout::ResolvedLayout<Self::Sublayout> {
+        self.view.layout(offer, env)
+    }
+}
+
+impl<T: Renderable<C>, C> Renderable<C> for GeometryGroup<T> {
+    type Renderables = Offset<T::Renderables>;
+
+    fn render_tree(
+        &self,
+        layout: &crate::layout::ResolvedLayout<Self::Sublayout>,
+        origin: crate::primitives::Point,
+        env: &impl crate::environment::LayoutEnvironment,
+    ) -> Self::Renderables {
+        // Store the offset, and render subtrees from zero
+        Offset::new(origin, self.view.render_tree(layout, Point::zero(), env))
+    }
+}

--- a/tests/animation.rs
+++ b/tests/animation.rs
@@ -47,6 +47,7 @@ fn sanity_animation_wipe() {
             &source_tree,
             &target_tree,
             &' ',
+            Point::zero(),
             &AnimationDomain::new(255, Duration::from_millis(i * 10)),
         );
     }
@@ -71,6 +72,7 @@ fn sanity_animation_wipe_leading_half() {
             &source_tree,
             &target_tree,
             &' ',
+            Point::zero(),
             &AnimationDomain::new(255, Duration::from_millis(i * 10)),
         );
     }
@@ -96,6 +98,7 @@ fn sanity_animation_wipe_trailing_half() {
         &source_tree,
         &target_tree,
         &' ',
+        Point::zero(),
         &AnimationDomain::new(255, Duration::from_millis(0)),
     );
     assert_eq!(buffer.text[0].iter().collect::<String>(), "X         ");
@@ -107,6 +110,7 @@ fn sanity_animation_wipe_trailing_half() {
             &source_tree,
             &target_tree,
             &' ',
+            Point::zero(),
             &AnimationDomain::new(255, Duration::from_millis(i * 10)),
         );
     }
@@ -141,6 +145,7 @@ fn animation_only_occurs_on_animated_subtrees() {
         &source_tree,
         &target_tree,
         &' ',
+        Point::zero(),
         &AnimationDomain::new(255, Duration::from_millis(0)),
     );
     assert_eq!(buffer.text[0].iter().collect::<String>(), "X         ");
@@ -157,6 +162,7 @@ fn animation_only_occurs_on_animated_subtrees() {
             &source_tree,
             &target_tree,
             &' ',
+            Point::zero(),
             &AnimationDomain::new(255, Duration::from_millis(i * 10)),
         );
     }
@@ -197,6 +203,7 @@ fn no_animation_when_value_doesnt_change() {
         &source_tree,
         &target_tree,
         &' ',
+        Point::zero(),
         &AnimationDomain::new(255, Duration::from_millis(0)),
     );
     assert_eq!(buffer.text[0].iter().collect::<String>(), "X         ");
@@ -209,6 +216,7 @@ fn no_animation_when_value_doesnt_change() {
             &source_tree,
             &target_tree,
             &' ',
+            Point::zero(),
             &AnimationDomain::new(255, Duration::from_millis(i * 10)),
         );
     }
@@ -255,6 +263,7 @@ fn partial_animation_join() {
         &source_tree,
         &target_tree,
         &' ',
+        Point::zero(),
         &AnimationDomain::new(255, Duration::from_millis(0)),
     );
     assert_eq!(buffer.text[0].iter().collect::<String>(), "X          ");
@@ -268,6 +277,7 @@ fn partial_animation_join() {
         &source_tree,
         &target_tree,
         &' ',
+        Point::zero(),
         &AnimationDomain::new(255, Duration::from_millis(500)),
     );
     assert_eq!(buffer.text[0].iter().collect::<String>(), "     X     ");
@@ -283,7 +293,7 @@ fn partial_animation_join() {
     );
 
     // The joined view should render to the correct partial animation state
-    source_tree.render(&mut buffer, &' ');
+    source_tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "          X");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "     Y     ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "     Z     ");
@@ -306,6 +316,7 @@ fn partial_animation_join() {
         &source_tree,
         &target_tree,
         &' ',
+        Point::zero(),
         &AnimationDomain::new(255, Duration::from_millis(1000)),
     );
 
@@ -321,6 +332,7 @@ fn partial_animation_join() {
         &source_tree,
         &target_tree,
         &' ',
+        Point::zero(),
         &AnimationDomain::new(255, Duration::from_millis(2000)),
     );
 
@@ -334,6 +346,7 @@ fn partial_animation_join() {
         &source_tree,
         &target_tree,
         &' ',
+        Point::zero(),
         &AnimationDomain::new(255, Duration::from_millis(3000)),
     );
 
@@ -421,6 +434,7 @@ fn jump_toggle_animation() {
         &source_tree,
         &target_tree,
         &' ',
+        Point::zero(),
         &AnimationDomain::top_level(Duration::from_millis(0)),
     );
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      #____");
@@ -434,6 +448,7 @@ fn jump_toggle_animation() {
         &source_tree,
         &target_tree,
         &' ',
+        Point::zero(),
         &AnimationDomain::top_level(Duration::from_millis(500)),
     );
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      __#__");
@@ -447,7 +462,7 @@ fn jump_toggle_animation() {
         &AnimationDomain::top_level(Duration::from_millis(500)),
     );
 
-    source_tree.render(&mut buffer, &' ');
+    source_tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      __#__");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "        xxx");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "           ");
@@ -463,6 +478,7 @@ fn jump_toggle_animation() {
         &source_tree,
         &target_tree,
         &' ',
+        Point::zero(),
         &AnimationDomain::top_level(Duration::from_millis(500)),
     );
 
@@ -477,6 +493,7 @@ fn jump_toggle_animation() {
         &source_tree,
         &target_tree,
         &' ',
+        Point::zero(),
         &AnimationDomain::top_level(Duration::from_millis(1000)),
     );
 
@@ -522,6 +539,7 @@ fn nested_toggle_animation() {
         &source_tree,
         &target_tree,
         &' ',
+        Point::zero(),
         &AnimationDomain::top_level(Duration::from_millis(0)),
     );
     // subtext should jump
@@ -539,6 +557,7 @@ fn nested_toggle_animation() {
         &source_tree,
         &target_tree,
         &' ',
+        Point::zero(),
         &AnimationDomain::top_level(Duration::from_millis(500)),
     );
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      __#__");
@@ -556,7 +575,7 @@ fn nested_toggle_animation() {
     );
 
     // The joined view should render to the partial animation state
-    source_tree.render(&mut buffer, &' ');
+    source_tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      __#__");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "     123456");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "      __#__");
@@ -574,6 +593,7 @@ fn nested_toggle_animation() {
         &source_tree,
         &target_tree,
         &' ',
+        Point::zero(),
         &AnimationDomain::top_level(Duration::from_millis(500)),
     );
     // again, should be the same view
@@ -590,6 +610,7 @@ fn nested_toggle_animation() {
         &source_tree,
         &target_tree,
         &' ',
+        Point::zero(),
         &AnimationDomain::top_level(Duration::from_millis(1000)),
     );
 

--- a/tests/conditional_view.rs
+++ b/tests/conditional_view.rs
@@ -26,7 +26,7 @@ fn test_conditional_view_layout() {
     let layout = view.layout(&buffer.size().into(), &env);
     assert_eq!(layout.resolved_size, Size::new(4, 2).into());
     let tree = view.render_tree(&layout, Point::zero(), &env);
-    tree.render(&mut buffer, &env.foreground_color);
+    tree.render(&mut buffer, &env.foreground_color, Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "true ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "!!!  ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "     ");
@@ -37,7 +37,7 @@ fn test_conditional_view_layout() {
     let layout = view.layout(&buffer.size().into(), &env);
     assert_eq!(layout.resolved_size, Size::new(1, 1).into());
     let tree = view.render_tree(&layout, Point::zero(), &env);
-    tree.render(&mut buffer, &env.foreground_color);
+    tree.render(&mut buffer, &env.foreground_color, Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "f    ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "     ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "     ");
@@ -60,7 +60,7 @@ fn one_arm_if() {
     let layout = view.layout(&buffer.size().into(), &env);
     assert_eq!(layout.resolved_size, Size::new(4, 2).into());
     let tree = view.render_tree(&layout, Point::zero(), &env);
-    tree.render(&mut buffer, &env.foreground_color);
+    tree.render(&mut buffer, &env.foreground_color, Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "true ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "!!!  ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "     ");
@@ -72,7 +72,7 @@ fn one_arm_if() {
     let layout = view.layout(&buffer.size().into(), &env);
     assert_eq!(layout.resolved_size, Size::new(0, 0).into());
     let tree = view.render_tree(&layout, Point::zero(), &env);
-    tree.render(&mut buffer, &env.foreground_color);
+    tree.render(&mut buffer, &env.foreground_color, Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "     ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "     ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "     ");

--- a/tests/divider.rs
+++ b/tests/divider.rs
@@ -32,7 +32,7 @@ fn test_horizontal_render() {
     let env = TestEnv::default().with_direction(LayoutDirection::Horizontal);
     let layout = divider.layout(&buffer.size().into(), &env);
     let tree = divider.render_tree(&layout, Point::new(0, 0), &env);
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0][0], '|');
     assert_eq!(buffer.text[4][0], '|');
     assert_eq!(buffer.text[0][1], ' ');
@@ -45,7 +45,7 @@ fn test_vertical_render() {
     let env = TestEnv::default().with_direction(LayoutDirection::Vertical);
     let layout = divider.layout(&buffer.size().into(), &env);
     let tree = divider.render_tree(&layout, Point::new(0, 0), &env);
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0][0], '-');
     assert_eq!(buffer.text[0][4], '-');
     assert_eq!(buffer.text[1][0], ' ');

--- a/tests/fixed_frame.rs
+++ b/tests/fixed_frame.rs
@@ -1,7 +1,7 @@
 use buoyant::{
     font::CharacterBufferFont,
     layout::{HorizontalAlignment, Layout, VerticalAlignment},
-    primitives::{Dimensions, ProposedDimension, ProposedDimensions, Size},
+    primitives::{Dimensions, Point, ProposedDimension, ProposedDimensions, Size},
     render::{CharacterRender, CharacterRenderTarget},
     render_target::FixedTextBuffer,
     view::{make_render_tree, LayoutExtensions, RenderExtensions as _, Text},
@@ -146,7 +146,7 @@ fn test_render_frame_top_leading_alignment() {
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "aa    ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "bb    ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "cc    ");
@@ -162,7 +162,7 @@ fn test_render_frame_top_center_alignment() {
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "  aa  ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "  bb  ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "  cc  ");
@@ -183,7 +183,7 @@ fn test_render_frame_top_trailing_alignment() {
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "    aa");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "    bb");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "    cc");
@@ -199,7 +199,7 @@ fn test_render_frame_center_leading_alignment() {
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "aa    ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "bb    ");
@@ -215,7 +215,7 @@ fn test_render_frame_center_center_alignment() {
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "  aa  ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "  bb  ");
@@ -231,7 +231,7 @@ fn test_render_frame_center_trailing_alignment() {
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "    aa");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "    bb");
@@ -252,7 +252,7 @@ fn test_render_frame_bottom_leading_alignment() {
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "aa    ");
@@ -268,7 +268,7 @@ fn test_render_frame_bottom_center_alignment() {
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "  aa  ");
@@ -289,7 +289,7 @@ fn test_render_frame_bottom_trailing_alignment() {
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "    aa");

--- a/tests/flex_frame.rs
+++ b/tests/flex_frame.rs
@@ -1,3 +1,4 @@
+use buoyant::primitives::Point;
 use buoyant::render::CharacterRender;
 use buoyant::render::CharacterRenderTarget;
 use buoyant::view::RenderExtensions;
@@ -126,7 +127,7 @@ fn test_min_max() {
 
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "xxx|  ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "xxx|  ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "xxx|  ");
@@ -146,7 +147,7 @@ fn test_render_min_flex_frame_top_leading_alignment() {
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "aa    ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "bb    ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "cc    ");
@@ -165,7 +166,7 @@ fn test_render_min_flex_frame_top_center_alignment() {
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "  aa  ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "  bb  ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "  cc  ");
@@ -185,7 +186,7 @@ fn test_render_min_flex_frame_top_trailing_alignment() {
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "    aa");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "    bb");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "    cc");
@@ -204,7 +205,7 @@ fn test_render_min_flex_frame_center_leading_alignment() {
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "aa    ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "bb    ");
@@ -222,7 +223,7 @@ fn test_render_min_flex_frame_center_center_alignment() {
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "  aa  ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "  bb  ");
@@ -241,7 +242,7 @@ fn test_render_min_flex_frame_center_trailing_alignment() {
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "    aa");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "    bb");
@@ -261,7 +262,7 @@ fn test_render_min_flex_frame_bottom_leading_alignment() {
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "aa    ");
@@ -280,7 +281,7 @@ fn test_render_min_flex_frame_bottom_center_alignment() {
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "  aa  ");
@@ -300,7 +301,7 @@ fn test_render_min_flex_frame_bottom_trailing_alignment() {
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "    aa");
@@ -320,7 +321,7 @@ fn test_render_infinite_width_height_fills_space() {
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "  aa  ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "  bb  ");
@@ -342,7 +343,7 @@ fn test_render_oversize_mix() {
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "   aa ");

--- a/tests/foreach.rs
+++ b/tests/foreach.rs
@@ -1,3 +1,4 @@
+use buoyant::primitives::Point;
 use buoyant::render::CharacterRender;
 use buoyant::render::CharacterRenderTarget;
 use buoyant::view::RenderExtensions as _;
@@ -52,7 +53,7 @@ fn foreach_with_inner_wrapping_hstack() {
     });
     let mut buffer = FixedTextBuffer::<10, 5>::default();
     let tree = make_render_tree(&view, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "Alice   99");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "Bob      2");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "Person    ");
@@ -94,7 +95,7 @@ fn foreach_leading_aligned() {
     .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<10, 5>::default();
     let tree = make_render_tree(&view, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "Alice 99  ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "Bob 2     ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "Person    ");
@@ -136,7 +137,7 @@ fn foreach_trailing_aligned() {
     .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<10, 5>::default();
     let tree = make_render_tree(&view, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), " Alice 99 ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "    Bob 2 ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "Person    ");

--- a/tests/geometry_group.rs
+++ b/tests/geometry_group.rs
@@ -1,0 +1,24 @@
+use buoyant::{
+    font::CharacterBufferFont,
+    primitives::Point,
+    render::{CharacterRender as _, CharacterRenderTarget as _},
+    render_target::FixedTextBuffer,
+    view::{make_render_tree, LayoutExtensions as _, RenderExtensions as _, Text, VStack},
+};
+
+#[test]
+fn test_geometry_group_retains_text_offset() {
+    let font = CharacterBufferFont {};
+    let content = VStack::new((
+        Text::str("aa aa", &font).foreground_color(' '),
+        Text::str("bb", &font).geometry_group(),
+        Text::str("ccc", &font),
+    ));
+    let mut buffer = FixedTextBuffer::<6, 4>::default();
+    let tree = make_render_tree(&content, buffer.size());
+    tree.render(&mut buffer, &' ', Point::zero());
+    assert_eq!(buffer.text[0].iter().collect::<String>(), "aa aa ");
+    assert_eq!(buffer.text[1].iter().collect::<String>(), " bb   ");
+    assert_eq!(buffer.text[2].iter().collect::<String>(), " ccc  ");
+    assert_eq!(buffer.text[3].iter().collect::<String>(), "      ");
+}

--- a/tests/hstack.rs
+++ b/tests/hstack.rs
@@ -59,7 +59,7 @@ fn test_horizontal_render_2() {
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<9, 1>::default();
     let tree = make_render_tree(&hstack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "123 4567 ");
 }
@@ -80,7 +80,7 @@ fn test_undersized_layout_3_left_pad() {
     let mut buffer = FixedTextBuffer::<10, 1>::default();
     hstack
         .render_tree(&layout, Point::zero(), &env)
-        .render(&mut buffer, &' ');
+        .render(&mut buffer, &' ', Point::zero());
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "1234567   ");
 }
@@ -101,7 +101,7 @@ fn test_undersized_layout_3_right_pad_space() {
     let mut buffer = FixedTextBuffer::<10, 1>::default();
     hstack
         .render_tree(&layout, Point::zero(), &env)
-        .render(&mut buffer, &' ');
+        .render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "  234 5678");
 }
 
@@ -123,7 +123,7 @@ fn test_oversized_layout_3_leading_pad_space() {
     let mut buffer = FixedTextBuffer::<10, 1>::default();
     hstack
         .render_tree(&layout, Point::zero(), &env)
-        .render(&mut buffer, &' ');
+        .render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), " 234 56789");
 }
 
@@ -143,7 +143,7 @@ fn test_undersized_layout_3_middle_pad() {
     let mut buffer = FixedTextBuffer::<10, 1>::default();
     hstack
         .render_tree(&layout, Point::zero(), &env)
-        .render(&mut buffer, &' ');
+        .render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "234   5678");
 }
 
@@ -165,7 +165,7 @@ fn test_oversized_layout_3_middle_pad_space() {
     let mut buffer = FixedTextBuffer::<10, 1>::default();
     hstack
         .render_tree(&layout, Point::zero(), &env)
-        .render(&mut buffer, &' ');
+        .render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "234  56789");
 }
 
@@ -187,7 +187,7 @@ fn test_oversized_layout_3_trailing_pad_space() {
     let mut buffer = FixedTextBuffer::<10, 1>::default();
     hstack
         .render_tree(&layout, Point::zero(), &env)
-        .render(&mut buffer, &' ');
+        .render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "234 56789 ");
 }
 
@@ -207,28 +207,28 @@ fn test_layout_3_remainder_allocation() {
     let layout = hstack.layout(&offer.into(), &env);
     hstack
         .render_tree(&layout, Point::zero(), &env)
-        .render(&mut buffer, &' ');
+        .render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "aaabbcc   ");
 
     let offer = Size::new(8, 1);
     let layout = hstack.layout(&offer.into(), &env);
     hstack
         .render_tree(&layout, Point::zero(), &env)
-        .render(&mut buffer, &' ');
+        .render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "aaabbbcc  ");
 
     let offer = Size::new(9, 1);
     let layout = hstack.layout(&offer.into(), &env);
     hstack
         .render_tree(&layout, Point::zero(), &env)
-        .render(&mut buffer, &' ');
+        .render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "aaabbbccc ");
 
     let offer = Size::new(10, 1);
     let layout = hstack.layout(&offer.into(), &env);
     hstack
         .render_tree(&layout, Point::zero(), &env)
-        .render(&mut buffer, &' ');
+        .render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "aaabbbccc ");
 }
 
@@ -245,7 +245,7 @@ fn test_layout_3_vertical_alignment_bottom() {
     .with_spacing(1);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&hstack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "   |  ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "   |  ");
@@ -267,7 +267,7 @@ fn test_layout_3_vertical_alignment_center() {
     .with_spacing(1);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&hstack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "   |  ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "aa | c");
@@ -289,7 +289,7 @@ fn test_layout_3_vertical_alignment_top() {
     .with_spacing(1);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&hstack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "aa | c");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "a  | c");
@@ -314,7 +314,7 @@ fn test_minimal_offer_extra_space_1() {
     let mut buffer = FixedTextBuffer::<19, 5>::default();
 
     let tree = make_render_tree(&hstack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
 
     let lines = [
         "a b c d e f g h i j",
@@ -340,7 +340,7 @@ fn test_layout_3_extra_space_allocation() {
     .with_spacing(0);
     let mut buffer = FixedTextBuffer::<9, 3>::default();
     let tree = make_render_tree(&hstack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "xxxx ++++");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "xxxxT++++");
@@ -380,7 +380,7 @@ fn stack_fits_subviews_regardless_of_flexibility_order() {
             for w3 in 1..12 {
                 let view = view(w1, w2, w3);
                 let tree = make_render_tree(&view, buffer.size());
-                tree.render(&mut buffer, &' ');
+                tree.render(&mut buffer, &' ', Point::zero());
                 // This is the only arrangement that fits
                 assert_eq!(buffer.text[0].iter().collect::<String>(), "xxx--++++");
             }
@@ -398,7 +398,7 @@ fn empty_view_does_not_create_extra_spacing() {
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&hstack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "aa  cc");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "a   c ");

--- a/tests/match_view.rs
+++ b/tests/match_view.rs
@@ -25,7 +25,7 @@ fn test_match_view_two_variants() {
     let layout = view.layout(&buffer.size().into(), &env);
     assert_eq!(layout.resolved_size, Size::new(4, 2).into());
     let tree = view.render_tree(&layout, Point::zero(), &env);
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "zero ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "!!!  ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "     ");
@@ -36,7 +36,7 @@ fn test_match_view_two_variants() {
     let layout = view.layout(&buffer.size().into(), &env);
     assert_eq!(layout.resolved_size, Size::new(5, 1).into());
     let tree = view.render_tree(&layout, Point::zero(), &env);
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "other");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "     ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "     ");
@@ -67,7 +67,7 @@ fn test_match_view_three_variants() {
     let layout = view.layout(&buffer.size().into(), &env);
     assert_eq!(layout.resolved_size, Size::new(3, 1).into());
     let tree = view.render_tree(&layout, Point::zero(), &env);
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "AAA  ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "     ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "     ");
@@ -76,7 +76,7 @@ fn test_match_view_three_variants() {
     let layout = view.layout(&buffer.size().into(), &env);
     assert_eq!(layout.resolved_size, Size::new(3, 1).into());
     let tree = view.render_tree(&layout, Point::zero(), &env);
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "BBB  ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "     ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "     ");
@@ -87,7 +87,7 @@ fn test_match_view_three_variants() {
     let layout = view.layout(&buffer.size().into(), &env);
     assert_eq!(layout.resolved_size, Size::new(3, 1).into());
     let tree = view.render_tree(&layout, Point::zero(), &env);
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "CCC  ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "     ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "     ");
@@ -124,7 +124,7 @@ fn test_match_view_borrow() {
     let layout = view.layout(&buffer.size().into(), &env);
     assert_eq!(layout.resolved_size, Size::new(3, 1).into());
     let tree = view.render_tree(&layout, Point::zero(), &env);
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "BBB  ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "     ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "     ");
@@ -150,7 +150,7 @@ fn test_match_view_two_variants_invalid_layout() {
 
     let view = make_view(1);
     let tree = view.render_tree(&layout, Point::zero(), &env);
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "other");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "     ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "     ");

--- a/tests/padding.rs
+++ b/tests/padding.rs
@@ -1,5 +1,6 @@
 use std::iter::zip;
 
+use buoyant::primitives::Point;
 use buoyant::render::CharacterRender;
 use buoyant::render::CharacterRenderTarget;
 use buoyant::{
@@ -32,7 +33,7 @@ fn test_clipped_text_trails_correctly() {
 
     let tree = make_render_tree(&view, buffer.size());
 
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
 
     let lines = [
         "                              ",

--- a/tests/spacer.rs
+++ b/tests/spacer.rs
@@ -1,6 +1,8 @@
 use buoyant::font::CharacterBufferFont;
 use buoyant::layout::{Layout, LayoutDirection};
-use buoyant::primitives::{Dimension, Dimensions, ProposedDimension, ProposedDimensions, Size};
+use buoyant::primitives::{
+    Dimension, Dimensions, Point, ProposedDimension, ProposedDimensions, Size,
+};
 use buoyant::render::CharacterRender;
 use buoyant::render::CharacterRenderTarget;
 use buoyant::render_target::FixedTextBuffer;
@@ -122,7 +124,7 @@ fn test_render_fills_hstack() {
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<9, 1>::default();
     let tree = make_render_tree(&hstack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "       67");
 }
 
@@ -134,6 +136,6 @@ fn test_render_fills_vstack() {
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<1, 9>::default();
     let tree = make_render_tree(&vstack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(collect_text(&buffer), "       67");
 }

--- a/tests/text.rs
+++ b/tests/text.rs
@@ -209,7 +209,7 @@ fn test_render_wrapping_leading() {
     let font = CharacterBufferFont {};
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let text = Text::str("This is a lengthy text here", &font).foreground_color(' ');
-    make_render_tree(&text, buffer.size()).render(&mut buffer, &' ');
+    make_render_tree(&text, buffer.size()).render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "This  ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "is a  ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "length");
@@ -224,7 +224,7 @@ fn test_render_wrapping_center_even() {
     let text = Text::str("This is a lengthy text here", &font)
         .multiline_text_alignment(HorizontalTextAlignment::Center)
         .foreground_color(' ');
-    make_render_tree(&text, buffer.size()).render(&mut buffer, &' ');
+    make_render_tree(&text, buffer.size()).render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), " This ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), " is a ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "length");
@@ -239,7 +239,7 @@ fn test_render_wrapping_center_odd() {
     let text = Text::str("This is a lengthy text 12345", &font)
         .multiline_text_alignment(HorizontalTextAlignment::Center)
         .foreground_color(' ');
-    make_render_tree(&text, buffer.size()).render(&mut buffer, &' ');
+    make_render_tree(&text, buffer.size()).render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), " This ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), " is a ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "length");
@@ -254,7 +254,7 @@ fn test_render_wrapping_trailing() {
     let text = Text::str("This is a lengthy text here", &font)
         .multiline_text_alignment(HorizontalTextAlignment::Trailing)
         .foreground_color(' ');
-    make_render_tree(&text, buffer.size()).render(&mut buffer, &' ');
+    make_render_tree(&text, buffer.size()).render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "  This");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "  is a");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "length");
@@ -280,7 +280,7 @@ fn test_clipped_text_is_centered_correctly() {
     assert_eq!(layout.resolved_size, Dimensions::new(13, 2));
 
     let tree = view.render_tree(&layout, Point::zero(), &env);
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
 
     let lines = [
         "Several lines                           ",
@@ -310,7 +310,7 @@ fn test_clipped_text_trails_correctly() {
     assert_eq!(layout.resolved_size, Dimensions::new(13, 2));
 
     let tree = view.render_tree(&layout, Point::zero(), &env);
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
 
     let lines = [
         "Several lines                           ",

--- a/tests/vstack.rs
+++ b/tests/vstack.rs
@@ -1,7 +1,7 @@
 use buoyant::environment::DefaultEnvironment;
 use buoyant::font::CharacterBufferFont;
 use buoyant::layout::{HorizontalAlignment, Layout, VerticalAlignment};
-use buoyant::primitives::{Dimensions, ProposedDimension, ProposedDimensions, Size};
+use buoyant::primitives::{Dimensions, Point, ProposedDimension, ProposedDimensions, Size};
 use buoyant::render::CharacterRender;
 use buoyant::render::CharacterRenderTarget;
 use buoyant::render_target::FixedTextBuffer;
@@ -129,7 +129,7 @@ fn test_undersized_layout_3_bottom_pad() {
     assert_eq!(layout.resolved_size, Dimensions::new(1, 10));
     let mut buffer = FixedTextBuffer::<1, 10>::default();
     let tree = make_render_tree(&vstack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "1");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "2");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "3");
@@ -158,7 +158,7 @@ fn test_undersized_layout_3_right_pad_space() {
     assert_eq!(layout.resolved_size, Dimensions::new(1, 10));
     let mut buffer = FixedTextBuffer::<1, 10>::default();
     let tree = make_render_tree(&vstack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(collect_text(&buffer), "  234 5678");
 }
 
@@ -179,7 +179,7 @@ fn test_oversized_layout_3_right_pad_space() {
     assert_eq!(layout.resolved_size, Dimensions::new(1, 10));
     let mut buffer = FixedTextBuffer::<1, 10>::default();
     let tree = make_render_tree(&vstack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(collect_text(&buffer), " 234 56789");
 }
 
@@ -200,7 +200,7 @@ fn test_oversized_layout_3_middle_pad_space() {
     assert_eq!(layout.resolved_size, Dimensions::new(1, 10));
     let mut buffer = FixedTextBuffer::<1, 10>::default();
     let tree = make_render_tree(&vstack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(collect_text(&buffer), "234  56789");
 }
 
@@ -221,7 +221,7 @@ fn test_oversized_layout_3_trailing_pad_space() {
     assert_eq!(layout.resolved_size, Dimensions::new(1, 10));
     let mut buffer = FixedTextBuffer::<1, 10>::default();
     let tree = make_render_tree(&vstack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(collect_text(&buffer), "234 56789 ");
 }
 
@@ -240,7 +240,7 @@ fn test_undersized_layout_3_middle_pad() {
     assert_eq!(layout.resolved_size, Dimensions::new(1, 10));
     let mut buffer = FixedTextBuffer::<1, 10>::default();
     let tree = make_render_tree(&vstack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(collect_text(&buffer), "234   5678");
 }
 
@@ -258,22 +258,22 @@ fn test_layout_3_remainder_allocation() {
     let mut buffer = FixedTextBuffer::<1, 10>::default();
     let offer = Size::new(1, 7);
     let tree = make_render_tree(&vstack, offer);
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(collect_text(&buffer), "aaabbcc   ");
 
     let offer = Size::new(1, 8);
     let tree = make_render_tree(&vstack, offer);
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(collect_text(&buffer), "aaabbbcc  ");
 
     let offer = Size::new(1, 9);
     let tree = make_render_tree(&vstack, offer);
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(collect_text(&buffer), "aaabbbccc ");
 
     let offer = Size::new(1, 10);
     let tree = make_render_tree(&vstack, offer);
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(collect_text(&buffer), "aaabbbccc ");
 }
 
@@ -307,7 +307,7 @@ fn test_layout_3_horizontal_alignment_trailing() {
     .with_spacing(1);
     let mut buffer = FixedTextBuffer::<6, 7>::default();
     let tree = make_render_tree(&vstack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "   aaa");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "------");
@@ -330,7 +330,7 @@ fn test_layout_3_alignment_center() {
     .with_alignment(HorizontalAlignment::Center);
     let mut buffer = FixedTextBuffer::<7, 5>::default();
     let tree = make_render_tree(&vstack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "  aaa  ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "-------");
     assert_eq!(buffer.text[2].iter().collect::<String>(), " cccc  ");
@@ -351,7 +351,7 @@ fn test_layout_3_alignment_leading() {
     .with_spacing(1);
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&vstack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "aaa   ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "      ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "------");
@@ -370,7 +370,7 @@ fn test_layout_direction_is_set_inner_hstack() {
     ));
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&vstack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "------");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "|     ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "|     ");
@@ -387,7 +387,7 @@ fn test_layout_direction_is_set_inner_vstack() {
     ));
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&hstack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "|----|");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "|    |");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "|    |");
@@ -450,7 +450,7 @@ fn test_layout_3_extra_space_allocation() {
     .with_spacing(0);
     let mut buffer = FixedTextBuffer::<6, 10>::default();
     let tree = make_render_tree(&vstack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "xxxxxx");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "xxxxxx");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "xxxxxx");
@@ -474,7 +474,7 @@ fn empty_view_does_not_recieve_spacing() {
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<7, 5>::default();
     let tree = make_render_tree(&vstack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "a      ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "       ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "c      ");

--- a/tests/zstack.rs
+++ b/tests/zstack.rs
@@ -1,7 +1,7 @@
 use buoyant::environment::DefaultEnvironment;
 use buoyant::font::CharacterBufferFont;
 use buoyant::layout::{HorizontalAlignment, Layout, VerticalAlignment};
-use buoyant::primitives::{Dimensions, Size};
+use buoyant::primitives::{Dimensions, Point, Size};
 use buoyant::render::CharacterRender;
 use buoyant::render::CharacterRenderTarget;
 use buoyant::render_target::FixedTextBuffer;
@@ -34,7 +34,7 @@ fn test_render_two_centered_overlap() {
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&stack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), " aa   ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "test  ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), " cc   ");
@@ -49,7 +49,7 @@ fn test_render_two_centered() {
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&stack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), " aa   ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "tbbt  ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), " cc   ");
@@ -68,7 +68,7 @@ fn test_render_two_top_center_alignment() {
     .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&stack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "axxxa ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "b b b ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "c c c ");
@@ -88,7 +88,7 @@ fn test_render_two_top_leading_alignment() {
     .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&stack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "xxx a ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "b b b ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "c c c ");
@@ -108,7 +108,7 @@ fn test_render_two_top_trailing_alignment() {
     .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&stack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "a xxx ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "b b b ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "c c c ");
@@ -127,7 +127,7 @@ fn test_render_two_center_leading_alignment() {
     .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&stack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "a a a ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "xxx b ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "c c c ");
@@ -146,7 +146,7 @@ fn test_render_two_center_trailing_alignment() {
     .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&stack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "a a a ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "b xxx ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "c c c ");
@@ -166,7 +166,7 @@ fn test_render_two_bottom_leading_alignment() {
     .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&stack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "a a a ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "b b b ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "xxx c ");
@@ -185,7 +185,7 @@ fn test_render_two_bottom_center_alignment() {
     .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&stack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "a a a ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "b b b ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "cxxxc ");
@@ -205,7 +205,7 @@ fn test_render_two_bottom_trailing_alignment() {
     .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&stack, buffer.size());
-    tree.render(&mut buffer, &' ');
+    tree.render(&mut buffer, &' ', Point::zero());
     assert_eq!(buffer.text[0].iter().collect::<String>(), "a a a ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "b b b ");
     assert_eq!(buffer.text[2].iter().collect::<String>(), "c xxx ");


### PR DESCRIPTION
Adds the `geometry_group` modifier to allow subtrees to animate against a common origin. In the below implementation of a toggle button, the geometry group ensures the circle and capsule always animate together as one element. Without this, compound animations where the toggle frame moves as a result of a parent animation would result in the circle moving outside the capsule. 

The render tree functions now track the offset (origin?), with only the offset node modifying it. These changes are critical to the upcoming implementation of transitions, which animates subtree offsets upon appearance.

```rust
fn toggle_button(is_on: bool) -> impl Renderable<Rgb565, Renderables: EmbeddedGraphicsRender<Rgb565>> {
    let (color, alignment) = if is_on {
        (Rgb565::GREEN, HorizontalAlignment::Trailing)
    } else {
        (Rgb565::CSS_LIGHT_GRAY, HorizontalAlignment::Leading)
    };

    ZStack::new((
        Capsule.foreground_color(color),
        Circle
            .foreground_color(Rgb565::WHITE)
            .padding(2)
            .animated(Animation::Linear(Duration::from_millis(100)), is_on),
    ))
    .with_horizontal_alignment(alignment)
    .geometry_group()
    .frame(Some(50), Some(25), None, None)
}
```

Contrary to what intuition would suggest, simply moving the `.animated` modifier to encompass the entire toggle does not resolve the issue. In that case, the entire toggle would tend to move relative its animated siblings under similar compound animation. With the geometry group, the toggle component moves correctly relative to siblings in response to external animation, while keeping the circle, which may animate at a different rate, inside the capsule.