### PR TITLE
Clean up core features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "buoyant"
-version = "0.3.0-alpha.1"
+version = "0.3.0-alpha.2"
 dependencies = [
  "crossterm",
  "embedded-graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "buoyant"
-version = "0.3.0-alpha.1"
+version = "0.3.0-alpha.2"
 authors = ["Riley Williams"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/examples/crossterm.rs
+++ b/examples/crossterm.rs
@@ -3,6 +3,7 @@ use buoyant::primitives::Point;
 use buoyant::render::CharacterRender;
 use buoyant::render::CharacterRenderTarget;
 use buoyant::render::Renderable;
+use buoyant::view::padding::Edges;
 use buoyant::view::{make_render_tree, LayoutExtensions, RenderExtensions};
 use buoyant::{
     layout::VerticalAlignment,
@@ -54,7 +55,7 @@ fn view() -> impl Renderable<Colors, Renderables: CharacterRender<Colors>> {
                     "This is in a fixed size box",
                     &FONT,
                 )
-                    .frame(Some(10), Some(10), None, None),
+                    .frame().with_width(10).with_height(10),
             )),
             Text::str(
                 "This is several lines of text.\nEach line is centered in the available space.\n The rectangle fills all the remaining verical space and aligns the content within it.\n2 points of padding are around this text",
@@ -67,7 +68,7 @@ fn view() -> impl Renderable<Colors, Renderables: CharacterRender<Colors>> {
                         background: None
                     }
                 )
-                .padding(2),
+                .padding(Edges::All, 2),
             Divider::default()
                 .foreground_color(Colors {
                     foreground: Some(crossterm::style::Color::DarkYellow),

--- a/examples/profiler.rs
+++ b/examples/profiler.rs
@@ -1,5 +1,6 @@
 use buoyant::primitives::Point;
 use buoyant::render::{CharacterRender as _, CharacterRenderTarget};
+use buoyant::view::padding::Edges;
 use buoyant::{
     environment::DefaultEnvironment,
     font::CharacterBufferFont,
@@ -46,7 +47,7 @@ fn main() {
              &font,
          )
              .multiline_text_alignment(HorizontalTextAlignment::Center)
-             .padding(2),
+             .padding(Edges::All, 2),
          Divider::default().foreground_color('-'),
          )),
      ));

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -1,31 +1,3 @@
-use crate::primitives::Point;
-
-pub struct Pixel<C> {
-    pub point: Point,
-    pub color: C,
-}
-
-#[cfg(feature = "embedded-graphics")]
-impl<T: embedded_graphics_core::pixelcolor::PixelColor> From<Pixel<T>>
-    for embedded_graphics_core::Pixel<T>
-{
-    fn from(value: Pixel<T>) -> Self {
-        embedded_graphics_core::Pixel(value.point.into(), value.color)
-    }
-}
-
-#[cfg(feature = "embedded-graphics")]
-impl<T: embedded_graphics_core::pixelcolor::PixelColor> From<embedded_graphics_core::Pixel<T>>
-    for Pixel<T>
-{
-    fn from(value: embedded_graphics_core::Pixel<T>) -> Self {
-        Pixel {
-            point: value.0.into(),
-            color: value.1,
-        }
-    }
-}
-
 pub trait Interpolate: Copy + PartialEq {
     /// Interpolate between two colors
     fn interpolate(from: Self, to: Self, amount: u8) -> Self {
@@ -39,13 +11,15 @@ pub trait Interpolate: Copy + PartialEq {
 
 impl Interpolate for u16 {
     fn interpolate(from: Self, to: Self, amount: u8) -> Self {
-        (((u32::from(amount) * u32::from(to)) + (u32::from(255 - amount) * u32::from(from))) / 255) as u16
+        (((u32::from(amount) * u32::from(to)) + (u32::from(255 - amount) * u32::from(from))) / 255)
+            as u16
     }
 }
 
 impl Interpolate for i16 {
     fn interpolate(from: Self, to: Self, amount: u8) -> Self {
-        (((i32::from(amount) * i32::from(to)) + (i32::from(255 - amount) * i32::from(from))) / 255) as i16
+        (((i32::from(amount) * i32::from(to)) + (i32::from(255 - amount) * i32::from(from))) / 255)
+            as i16
     }
 }
 
@@ -112,7 +86,7 @@ fn interpolate_crossterm_colors(
 mod embedded_graphics_impl {
 
     use super::Interpolate;
-    use embedded_graphics::primitives::PrimitiveStyle;
+    use embedded_graphics::{pixelcolor::Rgb888, primitives::PrimitiveStyle};
     use embedded_graphics_core::pixelcolor::{Rgb565, RgbColor};
 
     impl Interpolate for embedded_graphics_core::pixelcolor::BinaryColor {}
@@ -131,10 +105,26 @@ mod embedded_graphics_impl {
         }
     }
 
+    impl Interpolate for embedded_graphics_core::pixelcolor::Rgb888 {
+        fn interpolate(from: Self, to: Self, amount: u8) -> Self {
+            if amount == 255 {
+                return to;
+            }
+            let t_fixed = i16::from(amount);
+
+            let r = interpolate_channel(from.r(), to.r(), t_fixed);
+            let g = interpolate_channel(from.g(), to.g(), t_fixed);
+            let b = interpolate_channel(from.b(), to.b(), t_fixed);
+            Rgb888::new(r, g, b)
+        }
+    }
+
     #[inline]
     /// Interpolate between two colors, using a u16 between 0 and 256
     fn interpolate_channel(a: u8, b: u8, t: i16) -> u8 {
-        (i16::from(a) + ((i16::from(b).wrapping_sub(i16::from(a))).wrapping_mul(t) as u16 >> 8) as i16) as u8
+        (i16::from(a)
+            + ((i16::from(b).wrapping_sub(i16::from(a))).wrapping_mul(t) as u16 >> 8) as i16)
+            as u8
     }
 
     impl<C: embedded_graphics::prelude::PixelColor + Interpolate> Interpolate for PrimitiveStyle<C> {

--- a/src/render/animate.rs
+++ b/src/render/animate.rs
@@ -8,16 +8,16 @@ use crate::{
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Animate<T, U> {
-    subtree: T,
+    pub subtree: T,
     /// Length of the animation
-    animation: Animation,
+    pub animation: Animation,
     /// The time at which this frame was generated
-    frame_time: Duration,
-    value: U,
+    pub frame_time: Duration,
+    pub value: U,
     /// This is true if the animation is the result of a partially-completed join operation.
     /// If this is true, the source animation / duration will be used
     /// if the values are equal to avoid animations cancelling.
-    is_partial: bool,
+    pub is_partial: bool,
 }
 
 impl<T, U: PartialEq + Clone> Animate<T, U> {

--- a/src/render/capsule.rs
+++ b/src/render/capsule.rs
@@ -2,8 +2,8 @@ use crate::primitives::{Point, Size};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Capsule {
-    origin: Point,
-    size: Size,
+    pub origin: Point,
+    pub size: Size,
 }
 
 impl Capsule {

--- a/src/render/offset.rs
+++ b/src/render/offset.rs
@@ -6,8 +6,8 @@ use super::{AnimationDomain, CharacterRender, CharacterRenderTarget};
 /// The offset is animated, resulting in all children moving in unison.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Offset<T> {
-    offset: Point,
-    subtree: T,
+    pub offset: Point,
+    pub subtree: T,
 }
 
 impl<T> Offset<T> {
@@ -16,6 +16,7 @@ impl<T> Offset<T> {
         Self { offset, subtree }
     }
 }
+
 impl<T: CharacterRender<C>, C> CharacterRender<C> for Offset<T> {
     fn render(
         &self,

--- a/src/render/one_of.rs
+++ b/src/render/one_of.rs
@@ -37,13 +37,29 @@ where
 
         domain: &crate::render::AnimationDomain,
     ) {
-        let intermediate = Self::join(source.clone(), target.clone(), domain);
-        // TODO: use transaction???
-        intermediate.render(render_target, style, offset);
+        match (source, target) {
+            (OneOf2::Variant0(source), OneOf2::Variant0(target)) => {
+                V0::render_animated(render_target, source, target, style, offset, domain);
+            }
+            (OneOf2::Variant1(source), OneOf2::Variant1(target)) => {
+                V1::render_animated(render_target, source, target, style, offset, domain);
+            }
+            (_, target) => {
+                target.render(render_target, style, offset);
+            }
+        }
     }
 
-    fn join(_source: Self, target: Self, _domain: &crate::render::AnimationDomain) -> Self {
-        target
+    fn join(source: Self, target: Self, domain: &crate::render::AnimationDomain) -> Self {
+        match (source, target) {
+            (OneOf2::Variant0(source), OneOf2::Variant0(target)) => {
+                OneOf2::Variant0(V0::join(source, target, domain))
+            }
+            (OneOf2::Variant1(source), OneOf2::Variant1(target)) => {
+                OneOf2::Variant1(V1::join(source, target, domain))
+            }
+            (_, target) => target,
+        }
     }
 }
 
@@ -61,8 +77,44 @@ where
         }
     }
 
-    fn join(_source: Self, target: Self, _domain: &crate::render::AnimationDomain) -> Self {
-        target
+    fn render_animated(
+        render_target: &mut impl CharacterRenderTarget<Color = C>,
+        source: &Self,
+        target: &Self,
+        style: &C,
+        offset: Point,
+
+        domain: &crate::render::AnimationDomain,
+    ) {
+        match (source, target) {
+            (OneOf3::Variant0(source), OneOf3::Variant0(target)) => {
+                V0::render_animated(render_target, source, target, style, offset, domain);
+            }
+            (OneOf3::Variant1(source), OneOf3::Variant1(target)) => {
+                V1::render_animated(render_target, source, target, style, offset, domain);
+            }
+            (OneOf3::Variant2(source), OneOf3::Variant2(target)) => {
+                V2::render_animated(render_target, source, target, style, offset, domain);
+            }
+            (_, target) => {
+                target.render(render_target, style, offset);
+            }
+        }
+    }
+
+    fn join(source: Self, target: Self, domain: &crate::render::AnimationDomain) -> Self {
+        match (source, target) {
+            (OneOf3::Variant0(source), OneOf3::Variant0(target)) => {
+                OneOf3::Variant0(V0::join(source, target, domain))
+            }
+            (OneOf3::Variant1(source), OneOf3::Variant1(target)) => {
+                OneOf3::Variant1(V1::join(source, target, domain))
+            }
+            (OneOf3::Variant2(source), OneOf3::Variant2(target)) => {
+                OneOf3::Variant2(V2::join(source, target, domain))
+            }
+            (_, target) => target,
+        }
     }
 }
 
@@ -87,9 +139,38 @@ mod embedded_graphics_render {
             }
         }
 
-        fn join(_source: Self, target: Self, _domain: &crate::render::AnimationDomain) -> Self {
-            // jump to target
-            target
+        fn render_animated(
+            render_target: &mut impl DrawTarget<Color = C>,
+            source: &Self,
+            target: &Self,
+            style: &C,
+            offset: Point,
+
+            domain: &crate::render::AnimationDomain,
+        ) {
+            match (source, target) {
+                (OneOf2::Variant0(source), OneOf2::Variant0(target)) => {
+                    V0::render_animated(render_target, source, target, style, offset, domain);
+                }
+                (OneOf2::Variant1(source), OneOf2::Variant1(target)) => {
+                    V1::render_animated(render_target, source, target, style, offset, domain);
+                }
+                (_, target) => {
+                    target.render(render_target, style, offset);
+                }
+            }
+        }
+
+        fn join(source: Self, target: Self, domain: &crate::render::AnimationDomain) -> Self {
+            match (source, target) {
+                (OneOf2::Variant0(source), OneOf2::Variant0(target)) => {
+                    OneOf2::Variant0(V0::join(source, target, domain))
+                }
+                (OneOf2::Variant1(source), OneOf2::Variant1(target)) => {
+                    OneOf2::Variant1(V1::join(source, target, domain))
+                }
+                (_, target) => target,
+            }
         }
     }
 
@@ -108,9 +189,44 @@ mod embedded_graphics_render {
             }
         }
 
-        fn join(_source: Self, target: Self, _domain: &crate::render::AnimationDomain) -> Self {
-            // jump to target
-            target
+        fn render_animated(
+            render_target: &mut impl DrawTarget<Color = C>,
+            source: &Self,
+            target: &Self,
+            style: &C,
+            offset: Point,
+
+            domain: &crate::render::AnimationDomain,
+        ) {
+            match (source, target) {
+                (OneOf3::Variant0(source), OneOf3::Variant0(target)) => {
+                    V0::render_animated(render_target, source, target, style, offset, domain);
+                }
+                (OneOf3::Variant1(source), OneOf3::Variant1(target)) => {
+                    V1::render_animated(render_target, source, target, style, offset, domain);
+                }
+                (OneOf3::Variant2(source), OneOf3::Variant2(target)) => {
+                    V2::render_animated(render_target, source, target, style, offset, domain);
+                }
+                (_, target) => {
+                    target.render(render_target, style, offset);
+                }
+            }
+        }
+
+        fn join(source: Self, target: Self, domain: &crate::render::AnimationDomain) -> Self {
+            match (source, target) {
+                (OneOf3::Variant0(source), OneOf3::Variant0(target)) => {
+                    OneOf3::Variant0(V0::join(source, target, domain))
+                }
+                (OneOf3::Variant1(source), OneOf3::Variant1(target)) => {
+                    OneOf3::Variant1(V1::join(source, target, domain))
+                }
+                (OneOf3::Variant2(source), OneOf3::Variant2(target)) => {
+                    OneOf3::Variant2(V2::join(source, target, domain))
+                }
+                (_, target) => target,
+            }
         }
     }
 }

--- a/src/render/shade_subtree.rs
+++ b/src/render/shade_subtree.rs
@@ -5,8 +5,8 @@ use crate::{
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ShadeSubtree<C, T> {
-    style: C,
-    subtree: T,
+    pub style: C,
+    pub subtree: T,
 }
 
 impl<C, T> ShadeSubtree<C, T> {

--- a/src/view.rs
+++ b/src/view.rs
@@ -16,6 +16,7 @@ pub use divider::Divider;
 pub use empty_view::EmptyView;
 pub use foreach::ForEach;
 pub use hstack::HStack;
+pub use modifier::padding;
 pub use spacer::Spacer;
 pub(crate) use text::WhitespaceWrap;
 pub use text::{HorizontalTextAlignment, Text};
@@ -23,7 +24,7 @@ pub use vstack::VStack;
 pub use zstack::ZStack;
 
 use modifier::{
-    Animated, FixedFrame, FlexFrame, ForegroundStyle, GeometryGroup, Padding, Priority,
+    Animated, FixedFrame, FixedSize, FlexFrame, ForegroundStyle, GeometryGroup, Padding, Priority,
 };
 
 use crate::{
@@ -34,28 +35,22 @@ use crate::{
 };
 
 pub trait LayoutExtensions: Sized {
-    fn padding(self, amount: u16) -> Padding<Self> {
-        Padding::new(amount, self)
+    fn padding(self, edges: padding::Edges, amount: u16) -> Padding<Self> {
+        Padding::new(edges, amount, self)
     }
 
-    fn frame(
-        self,
-        width: Option<u16>,
-        height: Option<u16>,
-        horizontal_alignment: Option<crate::layout::HorizontalAlignment>,
-        vertical_alignment: Option<crate::layout::VerticalAlignment>,
-    ) -> FixedFrame<Self> {
-        FixedFrame::new(
-            self,
-            width,
-            height,
-            horizontal_alignment,
-            vertical_alignment,
-        )
+    fn frame(self) -> FixedFrame<Self> {
+        FixedFrame::new(self)
     }
 
     fn flex_frame(self) -> FlexFrame<Self> {
         FlexFrame::new(self)
+    }
+
+    /// Proposes ``ProposedDimension::Compact``, resulting in the child view rendering at its ideal
+    /// size along the specified axis.
+    fn fixed_size(self, horizontal: bool, vertical: bool) -> FixedSize<Self> {
+        FixedSize::new(horizontal, vertical, self)
     }
 
     fn priority(self, priority: u16) -> Priority<Self> {

--- a/src/view/match_view.rs
+++ b/src/view/match_view.rs
@@ -37,6 +37,32 @@ impl<V0, V1, V2> MatchView<Branch3<V0, V1, V2>> {
     }
 }
 
+/// A view that can conditionally render one of N heterogeneous subtrees based on the enum variant.
+/// Enum associated values can be unwrapped in the match arms.
+///
+/// ```
+/// use buoyant::match_view;
+/// use buoyant::font::CharacterBufferFont;
+/// use buoyant::view::{shape::Rectangle, Text};
+///
+/// #[derive(Clone)]
+/// enum State {
+///     Message(&'static str),
+///     Error,
+///     Redacted,
+/// }
+///
+/// let font = CharacterBufferFont;
+///
+/// let view = |state| {
+///     match_view!(state => {
+///         State::Message(msg) => Text::str(msg, &font),
+///         State::Error => Text::str("Uh oh", &font),
+///         State::Redacted => Rectangle,
+///     })
+/// };
+///
+/// ```
 #[macro_export]
 macro_rules! match_view {
     (

--- a/src/view/modifier.rs
+++ b/src/view/modifier.rs
@@ -1,13 +1,15 @@
 mod animated;
 mod fixed_frame;
+mod fixed_size;
 mod flex_frame;
 mod foreground_color;
 mod geometry_group;
-mod padding;
+pub mod padding;
 mod priority;
 
 pub use animated::Animated;
 pub use fixed_frame::FixedFrame;
+pub use fixed_size::FixedSize;
 pub use flex_frame::FlexFrame;
 pub use foreground_color::ForegroundStyle;
 pub use geometry_group::GeometryGroup;

--- a/src/view/modifier/fixed_frame.rs
+++ b/src/view/modifier/fixed_frame.rs
@@ -14,19 +14,41 @@ pub struct FixedFrame<T> {
 }
 
 impl<T> FixedFrame<T> {
-    pub fn new(
-        child: T,
-        width: Option<u16>,
-        height: Option<u16>,
-        horizontal_alignment: Option<HorizontalAlignment>,
-        vertical_alignment: Option<VerticalAlignment>,
-    ) -> Self {
+    pub fn new(child: T) -> Self {
         Self {
-            width,
-            height,
-            horizontal_alignment,
-            vertical_alignment,
+            width: None,
+            height: None,
+            horizontal_alignment: None,
+            vertical_alignment: None,
             child,
+        }
+    }
+
+    pub fn with_width(self, width: u16) -> Self {
+        Self {
+            width: Some(width),
+            ..self
+        }
+    }
+
+    pub fn with_height(self, height: u16) -> Self {
+        Self {
+            height: Some(height),
+            ..self
+        }
+    }
+
+    pub fn with_horizontal_alignment(self, alignment: HorizontalAlignment) -> Self {
+        Self {
+            horizontal_alignment: Some(alignment),
+            ..self
+        }
+    }
+
+    pub fn with_vertical_alignment(self, alignment: VerticalAlignment) -> Self {
+        Self {
+            vertical_alignment: Some(alignment),
+            ..self
         }
     }
 }

--- a/src/view/modifier/fixed_size.rs
+++ b/src/view/modifier/fixed_size.rs
@@ -1,0 +1,66 @@
+use crate::{
+    environment::LayoutEnvironment,
+    layout::{Layout, ResolvedLayout},
+    primitives::{Point, ProposedDimension, ProposedDimensions},
+    render::Renderable,
+};
+
+/// Proposes ``ProposedDimension::Compact``, resulting in the child view rendering at its ideal
+/// size along the specified axis.
+pub struct FixedSize<T> {
+    horizontal: bool,
+    vertical: bool,
+    child: T,
+}
+
+impl<T> FixedSize<T> {
+    pub fn new(horizontal: bool, vertical: bool, child: T) -> Self {
+        Self {
+            horizontal,
+            vertical,
+            child,
+        }
+    }
+}
+
+impl<V: Layout> Layout for FixedSize<V> {
+    type Sublayout = V::Sublayout;
+
+    fn layout(
+        &self,
+        offer: &ProposedDimensions,
+        env: &impl LayoutEnvironment,
+    ) -> ResolvedLayout<Self::Sublayout> {
+        let proposed_width = if self.horizontal {
+            ProposedDimension::Compact
+        } else {
+            offer.width
+        };
+
+        let proposed_height = if self.vertical {
+            ProposedDimension::Compact
+        } else {
+            offer.height
+        };
+
+        let offer = ProposedDimensions {
+            width: proposed_width,
+            height: proposed_height,
+        };
+
+        self.child.layout(&offer, env)
+    }
+}
+
+impl<T: Renderable<C>, C> Renderable<C> for FixedSize<T> {
+    type Renderables = T::Renderables;
+
+    fn render_tree(
+        &self,
+        layout: &ResolvedLayout<Self::Sublayout>,
+        origin: Point,
+        env: &impl LayoutEnvironment,
+    ) -> Self::Renderables {
+        self.child.render_tree(layout, origin, env)
+    }
+}

--- a/src/view/modifier/padding.rs
+++ b/src/view/modifier/padding.rs
@@ -5,23 +5,40 @@ use crate::{
     render::Renderable,
 };
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Edges {
+    All,
+    Horizontal,
+    Vertical,
+    Top,
+    Bottom,
+    Leading,
+    Trailing,
+}
+
 /// A view that adds padding around a child view.
 /// When the space offered to the padding is less than 2* the padding, the padding will
 /// not be truncated and will return a size larger than the offer.
+#[derive(Debug, Clone)]
 pub struct Padding<T> {
+    edges: Edges,
     padding: u16,
     child: T,
 }
 
 impl<T> Padding<T> {
-    pub fn new(padding: u16, child: T) -> Self {
-        Self { padding, child }
+    pub fn new(edges: Edges, padding: u16, child: T) -> Self {
+        Self {
+            edges,
+            padding,
+            child,
+        }
     }
 }
 
 impl<T> PartialEq for Padding<T> {
     fn eq(&self, other: &Self) -> bool {
-        self.padding == other.padding
+        self.padding == other.padding && self.edges == other.edges
     }
 }
 
@@ -33,13 +50,23 @@ impl<V: Layout> Layout for Padding<V> {
         offer: &ProposedDimensions,
         env: &impl LayoutEnvironment,
     ) -> ResolvedLayout<Self::Sublayout> {
+        let (leading, trailing, top, bottom) = match self.edges {
+            Edges::All => (self.padding, self.padding, self.padding, self.padding),
+            Edges::Horizontal => (self.padding, self.padding, 0, 0),
+            Edges::Vertical => (0, 0, self.padding, self.padding),
+            Edges::Top => (0, 0, self.padding, 0),
+            Edges::Bottom => (0, 0, 0, self.padding),
+            Edges::Leading => (self.padding, 0, 0, 0),
+            Edges::Trailing => (0, self.padding, 0, 0),
+        };
+        let extra_width = leading + trailing;
+        let extra_height = top + bottom;
         let padded_offer = ProposedDimensions {
-            width: offer.width - (2 * self.padding),
-            height: offer.height - (2 * self.padding),
+            width: offer.width - extra_width,
+            height: offer.height - extra_height,
         };
         let child_layout = self.child.layout(&padded_offer, env);
-        let padding_size =
-            child_layout.resolved_size + Size::new(2 * self.padding, 2 * self.padding);
+        let padding_size = child_layout.resolved_size + Size::new(extra_width, extra_height);
         ResolvedLayout {
             sublayouts: child_layout,
             resolved_size: padding_size,
@@ -56,9 +83,15 @@ impl<T: Renderable<C>, C> Renderable<C> for Padding<T> {
         origin: Point,
         env: &impl LayoutEnvironment,
     ) -> Self::Renderables {
+        let (leading, top) = match self.edges {
+            Edges::All => (self.padding, self.padding),
+            Edges::Horizontal | Edges::Leading => (self.padding, 0),
+            Edges::Vertical | Edges::Top => (0, self.padding),
+            Edges::Bottom | Edges::Trailing => (0, 0),
+        };
         self.child.render_tree(
             &layout.sublayouts,
-            origin + Point::new(self.padding as i16, self.padding as i16),
+            origin + Point::new(leading as i16, top as i16),
             env,
         )
     }

--- a/tests/animation.rs
+++ b/tests/animation.rs
@@ -378,18 +378,16 @@ fn toggle_switch(
 
     VStack::new((
         ZStack::new((
-            Rectangle.foreground_color('_').frame(
-                Some(5),
-                Some(1),
-                Some(HorizontalAlignment::Center),
-                Some(VerticalAlignment::Center),
-            ),
-            Rectangle.foreground_color('#').frame(
-                Some(1),
-                Some(1),
-                Some(HorizontalAlignment::Center),
-                Some(VerticalAlignment::Center),
-            ),
+            Rectangle
+                .foreground_color('_')
+                .frame()
+                .with_width(5)
+                .with_height(1),
+            Rectangle
+                .foreground_color('#')
+                .frame()
+                .with_width(1)
+                .with_height(1),
         ))
         .with_horizontal_alignment(alignment)
         .animated(Animation::Linear(Duration::from_secs(1)), is_on),

--- a/tests/fixed_frame.rs
+++ b/tests/fixed_frame.rs
@@ -11,7 +11,7 @@ mod common;
 #[test]
 fn test_fixed_width() {
     let font = CharacterBufferFont {};
-    let content = Text::str("123456", &font).frame(Some(2), None, None, None);
+    let content = Text::str("123456", &font).frame().with_width(2);
     let env = common::TestEnv::default();
 
     assert_eq!(
@@ -42,7 +42,7 @@ fn test_fixed_width() {
 #[test]
 fn test_fixed_height() {
     let font = CharacterBufferFont {};
-    let content = Text::str("123456", &font).frame(None, Some(2), None, None);
+    let content = Text::str("123456", &font).frame().with_height(2);
     let env = common::TestEnv::default();
 
     assert_eq!(
@@ -70,7 +70,10 @@ fn test_fixed_height() {
 #[test]
 fn test_fixed_frame_compact_width_height() {
     let font = CharacterBufferFont {};
-    let content = Text::str("123456", &font).frame(Some(2), Some(2), None, None);
+    let content = Text::str("123456", &font)
+        .frame()
+        .with_width(2)
+        .with_height(2);
     let env = common::TestEnv::default();
 
     assert_eq!(
@@ -116,7 +119,10 @@ fn test_fixed_frame_compact_width_height() {
 #[test]
 fn test_fixed_frame_infinite_width_height() {
     let font = CharacterBufferFont {};
-    let content = Text::str("123456", &font).frame(Some(25), Some(25), None, None);
+    let content = Text::str("123456", &font)
+        .frame()
+        .with_width(25)
+        .with_height(25);
     let env = common::TestEnv::default();
 
     assert_eq!(
@@ -137,12 +143,11 @@ fn test_fixed_frame_infinite_width_height() {
 fn test_render_frame_top_leading_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::str("aa\nbb\ncc", &font)
-        .frame(
-            Some(6),
-            Some(5),
-            Some(HorizontalAlignment::Leading),
-            Some(VerticalAlignment::Top),
-        )
+        .frame()
+        .with_width(6)
+        .with_height(5)
+        .with_horizontal_alignment(HorizontalAlignment::Leading)
+        .with_vertical_alignment(VerticalAlignment::Top)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
@@ -158,7 +163,10 @@ fn test_render_frame_top_leading_alignment() {
 fn test_render_frame_top_center_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::str("aa\nbb\ncc", &font)
-        .frame(Some(6), Some(5), None, Some(VerticalAlignment::Top))
+        .frame()
+        .with_width(6)
+        .with_height(5)
+        .with_vertical_alignment(VerticalAlignment::Top)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
@@ -174,12 +182,11 @@ fn test_render_frame_top_center_alignment() {
 fn test_render_frame_top_trailing_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::str("aa\nbb\ncc", &font)
-        .frame(
-            Some(6),
-            Some(5),
-            Some(HorizontalAlignment::Trailing),
-            Some(VerticalAlignment::Top),
-        )
+        .frame()
+        .with_width(6)
+        .with_height(5)
+        .with_horizontal_alignment(HorizontalAlignment::Trailing)
+        .with_vertical_alignment(VerticalAlignment::Top)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
@@ -195,7 +202,10 @@ fn test_render_frame_top_trailing_alignment() {
 fn test_render_frame_center_leading_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::str("aa\nbb\ncc", &font)
-        .frame(Some(6), Some(5), Some(HorizontalAlignment::Leading), None)
+        .frame()
+        .with_width(6)
+        .with_height(5)
+        .with_horizontal_alignment(HorizontalAlignment::Leading)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
@@ -211,7 +221,9 @@ fn test_render_frame_center_leading_alignment() {
 fn test_render_frame_center_center_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::str("aa\nbb\ncc", &font)
-        .frame(Some(6), Some(5), None, None)
+        .frame()
+        .with_width(6)
+        .with_height(5)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
@@ -227,7 +239,10 @@ fn test_render_frame_center_center_alignment() {
 fn test_render_frame_center_trailing_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::str("aa\nbb\ncc", &font)
-        .frame(Some(6), Some(5), Some(HorizontalAlignment::Trailing), None)
+        .frame()
+        .with_width(6)
+        .with_height(5)
+        .with_horizontal_alignment(HorizontalAlignment::Trailing)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
@@ -243,12 +258,11 @@ fn test_render_frame_center_trailing_alignment() {
 fn test_render_frame_bottom_leading_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::str("aa\nbb\ncc", &font)
-        .frame(
-            Some(6),
-            Some(5),
-            Some(HorizontalAlignment::Leading),
-            Some(VerticalAlignment::Bottom),
-        )
+        .frame()
+        .with_width(6)
+        .with_height(5)
+        .with_horizontal_alignment(HorizontalAlignment::Leading)
+        .with_vertical_alignment(VerticalAlignment::Bottom)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
@@ -264,7 +278,10 @@ fn test_render_frame_bottom_leading_alignment() {
 fn test_render_frame_bottom_center_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::str("aa\nbb\ncc", &font)
-        .frame(Some(6), Some(5), None, Some(VerticalAlignment::Bottom))
+        .frame()
+        .with_width(6)
+        .with_height(5)
+        .with_vertical_alignment(VerticalAlignment::Bottom)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
@@ -280,12 +297,11 @@ fn test_render_frame_bottom_center_alignment() {
 fn test_render_frame_bottom_trailing_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::str("aa\nbb\ncc", &font)
-        .frame(
-            Some(6),
-            Some(5),
-            Some(HorizontalAlignment::Trailing),
-            Some(VerticalAlignment::Bottom),
-        )
+        .frame()
+        .with_width(6)
+        .with_height(5)
+        .with_horizontal_alignment(HorizontalAlignment::Trailing)
+        .with_vertical_alignment(VerticalAlignment::Bottom)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());

--- a/tests/hstack.rs
+++ b/tests/hstack.rs
@@ -7,6 +7,7 @@ use buoyant::primitives::{Dimensions, Point, ProposedDimension, ProposedDimensio
 use buoyant::render::CharacterRenderTarget;
 use buoyant::render::{CharacterRender, Renderable};
 use buoyant::render_target::FixedTextBuffer;
+use buoyant::view::padding::Edges;
 use buoyant::view::{make_render_tree, RenderExtensions as _};
 use buoyant::view::{shape::Rectangle, Divider, EmptyView, HStack, LayoutExtensions, Spacer, Text};
 
@@ -21,7 +22,7 @@ fn test_greedy_layout_2() {
 
 #[test]
 fn test_oversized_layout_2() {
-    let vstack = HStack::new((Divider::default().padding(2), Spacer::default()));
+    let vstack = HStack::new((Divider::default().padding(Edges::All, 2), Spacer::default()));
     let offer = Size::new(10, 0);
     let env = DefaultEnvironment::non_animated();
     let layout = vstack.layout(&offer.into(), &env);
@@ -32,7 +33,7 @@ fn test_oversized_layout_2() {
 fn test_oversized_layout_3() {
     let vstack = HStack::new((
         Divider::default(),
-        Divider::default().padding(2),
+        Divider::default().padding(Edges::All, 2),
         Spacer::default(),
     ));
     let offer = Size::new(10, 0);
@@ -410,9 +411,9 @@ fn empty_view_does_not_create_extra_spacing() {
 #[test]
 fn infinite_width_offer_results_in_sum_of_subview_widths() {
     let hstack = HStack::new((
-        Rectangle.frame(Some(8), Some(3), None, None),
-        Rectangle.frame(Some(40), Some(1), None, None),
-        Rectangle.frame(Some(200), Some(8), None, None),
+        Rectangle.frame().with_width(8).with_height(3),
+        Rectangle.frame().with_width(40).with_height(1),
+        Rectangle.frame().with_width(200).with_height(8),
     ))
     .with_spacing(1);
     let offer = ProposedDimensions {
@@ -427,9 +428,9 @@ fn infinite_width_offer_results_in_sum_of_subview_widths() {
 #[test]
 fn compact_width_offer_results_in_sum_of_subview_widths() {
     let hstack = HStack::new((
-        Rectangle.frame(Some(8), Some(3), None, None),
-        Rectangle.frame(Some(40), Some(1), None, None),
-        Rectangle.frame(Some(200), Some(8), None, None),
+        Rectangle.frame().with_width(8).with_height(3),
+        Rectangle.frame().with_width(40).with_height(1),
+        Rectangle.frame().with_width(200).with_height(8),
     ))
     .with_spacing(1);
     let offer = ProposedDimensions {
@@ -444,9 +445,9 @@ fn compact_width_offer_results_in_sum_of_subview_widths() {
 #[test]
 fn infinite_width_offer_results_in_sum_of_subview_widths_minus_empties() {
     let hstack = HStack::new((
-        Rectangle.frame(Some(8), Some(3), None, None),
+        Rectangle.frame().with_width(8).with_height(3),
         EmptyView,
-        Rectangle.frame(Some(200), Some(8), None, None),
+        Rectangle.frame().with_width(200).with_height(8),
     ))
     .with_spacing(1);
     let offer = ProposedDimensions {
@@ -461,9 +462,9 @@ fn infinite_width_offer_results_in_sum_of_subview_widths_minus_empties() {
 #[test]
 fn compact_width_offer_results_in_sum_of_subview_widths_minus_empties() {
     let hstack = HStack::new((
-        Rectangle.frame(Some(8), Some(3), None, None),
+        Rectangle.frame().with_width(8).with_height(3),
         EmptyView,
-        Rectangle.frame(Some(200), Some(8), None, None),
+        Rectangle.frame().with_width(200).with_height(8),
     ))
     .with_spacing(1);
     let offer = ProposedDimensions {

--- a/tests/match_view.rs
+++ b/tests/match_view.rs
@@ -56,9 +56,10 @@ fn test_match_view_three_variants() {
     let make_view = |state| {
         match_view!(state => {
             State::A => Text::str("AAA", &font),
-            State::B(msg) => Text::str(msg, &font).foreground_color(' '),
+            State::B(msg) => Text::str(msg, &font),
             State::C => Text::str("CCC", &font),
         })
+        .foreground_color(' ')
     };
     let mut buffer = FixedTextBuffer::<5, 5>::default();
     let env = DefaultEnvironment::default();

--- a/tests/padding.rs
+++ b/tests/padding.rs
@@ -3,6 +3,7 @@ use std::iter::zip;
 use buoyant::primitives::Point;
 use buoyant::render::CharacterRender;
 use buoyant::render::CharacterRenderTarget;
+use buoyant::view::padding::Edges;
 use buoyant::{
     environment::DefaultEnvironment,
     font::CharacterBufferFont,
@@ -25,7 +26,7 @@ fn test_clipped_text_trails_correctly() {
             &font,
         )
         .multiline_text_alignment(HorizontalTextAlignment::Trailing)
-        .padding(2),
+        .padding(Edges::All, 2),
         Divider::default().foreground_color('-'),
     ));
 
@@ -51,12 +52,178 @@ fn test_clipped_text_trails_correctly() {
 
 #[test]
 fn test_padding_is_oversized_for_oversized_child() {
-    let text = Rectangle.frame(Some(10), Some(10), None, None).padding(2);
+    let view = Rectangle
+        .frame()
+        .with_width(10)
+        .with_height(10)
+        .padding(Edges::All, 2);
 
     let env = DefaultEnvironment::non_animated();
 
     assert_eq!(
-        text.layout(&Size::new(1, 1).into(), &env).resolved_size,
+        view.layout(&Size::new(1, 1).into(), &env).resolved_size,
         Dimensions::new(14, 14)
     );
+}
+
+#[test]
+fn test_zero_padding_has_no_effect() {
+    let view = Rectangle.foreground_color('X').padding(Edges::All, 0);
+
+    let mut buffer = FixedTextBuffer::<20, 5>::default();
+    let tree = make_render_tree(&view, buffer.size());
+    tree.render(&mut buffer, &' ', Point::zero());
+
+    let lines = [
+        "XXXXXXXXXXXXXXXXXXXX",
+        "XXXXXXXXXXXXXXXXXXXX",
+        "XXXXXXXXXXXXXXXXXXXX",
+        "XXXXXXXXXXXXXXXXXXXX",
+        "XXXXXXXXXXXXXXXXXXXX",
+    ];
+    zip(lines.iter(), buffer.text.iter()).for_each(|(expected, actual)| {
+        assert_eq!(actual.iter().collect::<String>(), *expected);
+    });
+}
+
+#[test]
+fn test_padding_all() {
+    let view = Rectangle.foreground_color('X').padding(Edges::All, 2);
+
+    let mut buffer = FixedTextBuffer::<20, 5>::default();
+    let tree = make_render_tree(&view, buffer.size());
+    tree.render(&mut buffer, &' ', Point::zero());
+
+    let lines = [
+        "                    ",
+        "                    ",
+        "  XXXXXXXXXXXXXXXX  ",
+        "                    ",
+        "                    ",
+    ];
+    zip(lines.iter(), buffer.text.iter()).for_each(|(expected, actual)| {
+        assert_eq!(actual.iter().collect::<String>(), *expected);
+    });
+}
+
+#[test]
+fn test_padding_horizontal() {
+    let view = Rectangle
+        .foreground_color('X')
+        .padding(Edges::Horizontal, 3);
+
+    let mut buffer = FixedTextBuffer::<20, 5>::default();
+    let tree = make_render_tree(&view, buffer.size());
+    tree.render(&mut buffer, &' ', Point::zero());
+
+    let lines = [
+        "   XXXXXXXXXXXXXX   ",
+        "   XXXXXXXXXXXXXX   ",
+        "   XXXXXXXXXXXXXX   ",
+        "   XXXXXXXXXXXXXX   ",
+        "   XXXXXXXXXXXXXX   ",
+    ];
+    zip(lines.iter(), buffer.text.iter()).for_each(|(expected, actual)| {
+        assert_eq!(actual.iter().collect::<String>(), *expected);
+    });
+}
+
+#[test]
+fn test_padding_vertical() {
+    let view = Rectangle.foreground_color('X').padding(Edges::Vertical, 3);
+
+    let mut buffer = FixedTextBuffer::<20, 5>::default();
+    let tree = make_render_tree(&view, buffer.size());
+    tree.render(&mut buffer, &' ', Point::zero());
+
+    let lines = [
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+    ];
+    zip(lines.iter(), buffer.text.iter()).for_each(|(expected, actual)| {
+        assert_eq!(actual.iter().collect::<String>(), *expected);
+    });
+}
+
+#[test]
+fn test_padding_top() {
+    let view = Rectangle.foreground_color('X').padding(Edges::Top, 2);
+
+    let mut buffer = FixedTextBuffer::<20, 5>::default();
+    let tree = make_render_tree(&view, buffer.size());
+    tree.render(&mut buffer, &' ', Point::zero());
+
+    let lines = [
+        "                    ",
+        "                    ",
+        "XXXXXXXXXXXXXXXXXXXX",
+        "XXXXXXXXXXXXXXXXXXXX",
+        "XXXXXXXXXXXXXXXXXXXX",
+    ];
+    zip(lines.iter(), buffer.text.iter()).for_each(|(expected, actual)| {
+        assert_eq!(actual.iter().collect::<String>(), *expected);
+    });
+}
+
+#[test]
+fn test_padding_bottom() {
+    let view = Rectangle.foreground_color('X').padding(Edges::Bottom, 4);
+
+    let mut buffer = FixedTextBuffer::<20, 5>::default();
+    let tree = make_render_tree(&view, buffer.size());
+    tree.render(&mut buffer, &' ', Point::zero());
+
+    let lines = [
+        "XXXXXXXXXXXXXXXXXXXX",
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+    ];
+    zip(lines.iter(), buffer.text.iter()).for_each(|(expected, actual)| {
+        assert_eq!(actual.iter().collect::<String>(), *expected);
+    });
+}
+
+#[test]
+fn test_padding_leading() {
+    let view = Rectangle.foreground_color('X').padding(Edges::Leading, 5);
+
+    let mut buffer = FixedTextBuffer::<20, 5>::default();
+    let tree = make_render_tree(&view, buffer.size());
+    tree.render(&mut buffer, &' ', Point::zero());
+
+    let lines = [
+        "     XXXXXXXXXXXXXXX",
+        "     XXXXXXXXXXXXXXX",
+        "     XXXXXXXXXXXXXXX",
+        "     XXXXXXXXXXXXXXX",
+        "     XXXXXXXXXXXXXXX",
+    ];
+    zip(lines.iter(), buffer.text.iter()).for_each(|(expected, actual)| {
+        assert_eq!(actual.iter().collect::<String>(), *expected);
+    });
+}
+
+#[test]
+fn test_padding_trailing() {
+    let view = Rectangle.foreground_color('X').padding(Edges::Trailing, 1);
+
+    let mut buffer = FixedTextBuffer::<20, 5>::default();
+    let tree = make_render_tree(&view, buffer.size());
+    tree.render(&mut buffer, &' ', Point::zero());
+
+    let lines = [
+        "XXXXXXXXXXXXXXXXXXX ",
+        "XXXXXXXXXXXXXXXXXXX ",
+        "XXXXXXXXXXXXXXXXXXX ",
+        "XXXXXXXXXXXXXXXXXXX ",
+        "XXXXXXXXXXXXXXXXXXX ",
+    ];
+    zip(lines.iter(), buffer.text.iter()).for_each(|(expected, actual)| {
+        assert_eq!(actual.iter().collect::<String>(), *expected);
+    });
 }

--- a/tests/text.rs
+++ b/tests/text.rs
@@ -299,7 +299,8 @@ fn test_clipped_text_trails_correctly() {
         &font,
     )
     .multiline_text_alignment(HorizontalTextAlignment::Trailing)
-    .frame(None, Some(2), None, None) // constrain to 2 pts tall
+    .frame()
+    .with_height(2) // constrain to 2 pts tall
     .foreground_color(' ');
 
     let env = DefaultEnvironment::non_animated();

--- a/tests/vstack.rs
+++ b/tests/vstack.rs
@@ -5,6 +5,7 @@ use buoyant::primitives::{Dimensions, Point, ProposedDimension, ProposedDimensio
 use buoyant::render::CharacterRender;
 use buoyant::render::CharacterRenderTarget;
 use buoyant::render_target::FixedTextBuffer;
+use buoyant::view::padding::Edges;
 use buoyant::view::{make_render_tree, RenderExtensions as _};
 use buoyant::view::{
     shape::Rectangle, Divider, EmptyView, HStack, HorizontalTextAlignment, LayoutExtensions,
@@ -26,7 +27,7 @@ fn test_greedy_layout_2() {
 /// The Stack should never exceed the offer size.
 #[test]
 fn test_oversized_layout_2() {
-    let vstack = VStack::new((Divider::default().padding(2), Spacer::default()));
+    let vstack = VStack::new((Divider::default().padding(Edges::All, 2), Spacer::default()));
     let offer = Size::new(0, 10);
     let env = DefaultEnvironment::non_animated();
     let layout = vstack.layout(&offer.into(), &env);
@@ -37,7 +38,7 @@ fn test_oversized_layout_2() {
 fn test_oversized_layout_3() {
     let vstack = VStack::new((
         Divider::default(),
-        Divider::default().padding(2),
+        Divider::default().padding(Edges::All, 2),
         Spacer::default(),
     ));
     let offer = Size::new(0, 10);
@@ -49,9 +50,9 @@ fn test_oversized_layout_3() {
 #[test]
 fn infinite_height_offer_results_in_sum_of_subview_heights() {
     let vstack = VStack::new((
-        Rectangle.frame(Some(3), Some(8), None, None),
-        Rectangle.frame(Some(1), Some(40), None, None),
-        Rectangle.frame(Some(8), Some(200), None, None),
+        Rectangle.frame().with_width(3).with_height(8),
+        Rectangle.frame().with_width(1).with_height(40),
+        Rectangle.frame().with_width(8).with_height(200),
     ))
     .with_spacing(1);
     let offer = ProposedDimensions {
@@ -66,9 +67,9 @@ fn infinite_height_offer_results_in_sum_of_subview_heights() {
 #[test]
 fn compact_height_offer_results_in_sum_of_subview_heights() {
     let vstack = VStack::new((
-        Rectangle.frame(Some(3), Some(8), None, None),
-        Rectangle.frame(Some(1), Some(40), None, None),
-        Rectangle.frame(Some(8), Some(200), None, None),
+        Rectangle.frame().with_width(3).with_height(8),
+        Rectangle.frame().with_width(1).with_height(40),
+        Rectangle.frame().with_width(8).with_height(200),
     ))
     .with_spacing(1);
     let offer = ProposedDimensions {
@@ -83,9 +84,9 @@ fn compact_height_offer_results_in_sum_of_subview_heights() {
 #[test]
 fn infinite_height_offer_results_in_sum_of_subview_heights_minus_empties() {
     let vstack = VStack::new((
-        Rectangle.frame(Some(3), Some(8), None, None),
+        Rectangle.frame().with_width(3).with_height(8),
         EmptyView,
-        Rectangle.frame(Some(8), Some(200), None, None),
+        Rectangle.frame().with_width(8).with_height(200),
     ))
     .with_spacing(1);
     let offer = ProposedDimensions {
@@ -100,9 +101,9 @@ fn infinite_height_offer_results_in_sum_of_subview_heights_minus_empties() {
 #[test]
 fn compact_height_offer_results_in_sum_of_subview_heights_minus_empties() {
     let vstack = VStack::new((
-        Rectangle.frame(Some(3), Some(8), None, None),
+        Rectangle.frame().with_width(3).with_height(8),
         EmptyView,
-        Rectangle.frame(Some(8), Some(200), None, None),
+        Rectangle.frame().with_width(8).with_height(200),
     ))
     .with_spacing(1);
     let offer = ProposedDimensions {
@@ -422,7 +423,7 @@ fn test_flexible_layout_fills_frame_10k() {
             &font,
         )
             .multiline_text_alignment(HorizontalTextAlignment::Center)
-            .padding(2),
+            .padding(Edges::All, 2),
         Divider::default(),
         )),
     ));


### PR DESCRIPTION
While implementing a demo, I came across a number of features that were necessary and missing. This PR fixes or adds them.

- Changes the interface of fixed frame to use `.with_x(_)`
- Fixes a bug in ZStack where magic-sized subviews like Rectangle would not be offered the size of the sibling union size. Now the correctly fill the full stack area
- Adds `.fixed_size(_)` modifier
- Per-edge padding
- Fixes a todo in match views that prevented animation from working even when render tree arms matched
- Adds interpolation support to `Rgb888`. More embedded_graphics colors will be added later, it's just a matter of creating a macro so I don't have to copy/paste them all