### PR TITLE
Add embedded-graphics-simulator example

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,6 +49,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Install SDL2
+        run: sudo apt-get install libsdl2-dev
       - name: Build
         run: cargo build --verbose
       - name: Run tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,6 +25,18 @@ name = "az"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -27,9 +51,17 @@ dependencies = [
  "crossterm",
  "embedded-graphics",
  "embedded-graphics-core",
+ "embedded-graphics-simulator",
  "heapless",
  "paste",
+ "sdl2",
 ]
+
+[[package]]
+name = "bytemuck"
+version = "1.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
 
 [[package]]
 name = "byteorder"
@@ -38,10 +70,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossterm"
@@ -49,7 +96,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -92,6 +139,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-graphics-simulator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31606a4fb7d9d3a79a38d27bc2954cfa98682c8fea4b22c09a442785a80424e"
+dependencies = [
+ "base64",
+ "embedded-graphics",
+ "image",
+ "ouroboros",
+ "sdl2",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +159,25 @@ checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -128,6 +207,30 @@ dependencies = [
  "hash32",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "image"
+version = "0.25.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6f44aed642f18953a158afeb30206f4d50da59fbc66ecb53c66488de73563b"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "num-traits",
+ "png",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -164,6 +267,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c8dda44ff03a2f238717214da50f65d5a53b45cd213a7370424ffdb6fae815"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,6 +295,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "ouroboros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "static_assertions",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -214,12 +351,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+ "yansi",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -228,7 +409,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -240,6 +421,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdl2"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b498da7d14d1ad6c839729bd4ad6fc11d90a57583605f3b4df2cd709a9cd380"
+dependencies = [
+ "bitflags 1.3.2",
+ "lazy_static",
+ "libc",
+ "sdl2-sys",
+]
+
+[[package]]
+name = "sdl2-sys"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "951deab27af08ed9c6068b7b0d05a93c91f0a8eb16b6b816a5e73452a43521d3"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "version-compare",
+]
 
 [[package]]
 name = "signal-hook"
@@ -272,6 +476,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
 name = "smallvec"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +492,41 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "syn"
+version = "2.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
+
+[[package]]
+name = "version-compare"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -392,3 +637,9 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "buoyant"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "crossterm",
  "embedded-graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,9 @@ heapless = "^0.8"
 paste = "1.0.15"
 
 [dev-dependencies]
-embedded-graphics-simulator = "0.7.0"
+embedded-graphics-simulator = { version = "0.7.0", default-features = false, features = [
+  "with-sdl",
+] }
 sdl2 = "0.37.0"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "buoyant"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Riley Williams"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,10 @@ embedded-graphics = { version = "^0.8", optional = true }
 heapless = "^0.8"
 paste = "1.0.15"
 
+[dev-dependencies]
+embedded-graphics-simulator = "0.7.0"
+sdl2 = "0.37.0"
+
 [profile.release]
 debug = true
 

--- a/examples/espresso.rs
+++ b/examples/espresso.rs
@@ -1,0 +1,356 @@
+//! # Example: Espresso UI
+//!
+//! This example allows you to switch between three tabs using the left and right arrow keys.
+//! The settings can be toggled using the `b`, `w`, and `o` keys.
+//!
+//! To run this example using the embedded_graphics simulator, you must have the `sdl2` package installed.
+
+use std::time::{Duration, Instant};
+
+use buoyant::{
+    environment::DefaultEnvironment,
+    layout::{HorizontalAlignment, Layout},
+    match_view,
+    primitives::ProposedDimensions,
+    render::{AnimationDomain, EmbeddedGraphicsRender, Renderable},
+    view::{
+        padding::Edges,
+        shape::{Circle, Rectangle},
+        ConditionalView, HStack, HorizontalTextAlignment, LayoutExtensions as _, RenderExtensions,
+        Text, VStack, ZStack,
+    },
+};
+use embedded_graphics::prelude::*;
+use embedded_graphics_simulator::{
+    sdl2::Keycode, OutputSettings, SimulatorDisplay, SimulatorEvent, Window,
+};
+
+#[allow(unused)]
+mod spacing {
+    /// Spacing between sections / groups
+    pub const SECTION: u16 = 24;
+    /// Outer padding to the edge of the screen
+    pub const SECTION_MARGIN: u16 = 16;
+    /// Spacing between distinct visual components in a section / group
+    pub const COMPONENT: u16 = 16;
+    /// Spacing between elements within a component
+    pub const ELEMENT: u16 = 8;
+}
+
+#[allow(unused)]
+mod font {
+    /// Font for body text
+    pub const BODY: embedded_graphics::mono_font::MonoFont<'_> =
+        embedded_graphics::mono_font::ascii::FONT_10X20;
+    /// Font for captions, smaller text
+    pub const CAPTION: embedded_graphics::mono_font::MonoFont<'_> =
+        embedded_graphics::mono_font::ascii::FONT_9X15;
+    /// Font for bold captions
+    pub const CAPTION_BOLD: embedded_graphics::mono_font::MonoFont<'_> =
+        embedded_graphics::mono_font::ascii::FONT_9X15_BOLD;
+}
+
+#[allow(unused)]
+mod color {
+    use embedded_graphics::prelude::*;
+
+    /// Use this alias instead of directly referring to a specific embedded_graphics
+    /// color type to allow portability between displays
+    pub type Space = embedded_graphics::pixelcolor::Rgb888;
+    pub const ACCENT: Space = Space::CSS_LIGHT_SKY_BLUE;
+    pub const BACKGROUND: Space = Space::BLACK;
+    pub const BACKGROUND_SECONDARY: Space = Space::CSS_DARK_SLATE_GRAY;
+    pub const FOREGROUND_SECONDARY: Space = Space::CSS_LIGHT_SLATE_GRAY;
+}
+
+fn main() -> Result<(), core::convert::Infallible> {
+    let mut display: SimulatorDisplay<color::Space> = SimulatorDisplay::new(Size::new(480, 320));
+    let mut window = Window::new("Coffeeeee", &OutputSettings::default());
+    let app_start = Instant::now();
+
+    let mut app = App::default();
+
+    let mut source_tree = app.tree(display.size(), app_start.elapsed());
+    let mut target_tree = app.tree(display.size(), app_start.elapsed());
+
+    'running: loop {
+        // Create a new target tree if the state changes
+        if app.reset_dirty() {
+            source_tree = EmbeddedGraphicsRender::join(
+                source_tree,
+                target_tree,
+                &AnimationDomain::top_level(app_start.elapsed()),
+            );
+            target_tree = app.tree(display.size(), app_start.elapsed());
+        }
+
+        display.clear(color::BACKGROUND).unwrap();
+
+        // Render frame
+        EmbeddedGraphicsRender::render_animated(
+            &mut display,
+            &source_tree,
+            &target_tree,
+            &color::Space::WHITE,
+            buoyant::primitives::Point::zero(),
+            &AnimationDomain::top_level(app_start.elapsed()),
+        );
+
+        // Flush to window
+        window.update(&display);
+
+        for event in window.events() {
+            match event {
+                SimulatorEvent::Quit => break 'running,
+                SimulatorEvent::KeyDown { keycode, .. } => match keycode {
+                    Keycode::Left => app.state_mut().tab.previous(),
+                    Keycode::Right => app.state_mut().tab.next(),
+                    Keycode::B => app.state_mut().auto_brew = !app.state.auto_brew,
+                    Keycode::W => app.state_mut().stop_on_weight = !app.state.stop_on_weight,
+                    Keycode::O => app.state_mut().auto_off = !app.state.auto_off,
+                    _ => {}
+                },
+                _ => {}
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+enum Tab {
+    #[default]
+    Brew,
+    Clean,
+    Settings,
+}
+
+impl Tab {
+    fn next(&mut self) {
+        *self = match self {
+            Tab::Brew => Tab::Clean,
+            Tab::Clean => Tab::Settings,
+            Tab::Settings => Tab::Brew,
+        };
+    }
+
+    fn previous(&mut self) {
+        *self = match self {
+            Tab::Brew => Tab::Settings,
+            Tab::Clean => Tab::Brew,
+            Tab::Settings => Tab::Clean,
+        };
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+struct AppState {
+    pub tab: Tab,
+    pub stop_on_weight: bool,
+    pub auto_off: bool,
+    pub auto_brew: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+struct App {
+    state: AppState,
+    is_dirty: bool,
+}
+
+impl App {
+    fn state_mut(&mut self) -> &mut AppState {
+        self.is_dirty = true;
+        &mut self.state
+    }
+
+    fn reset_dirty(&mut self) -> bool {
+        let was_dirty = self.is_dirty;
+        self.is_dirty = false;
+        was_dirty
+    }
+
+    fn tree(
+        &self,
+        dimensions: impl Into<ProposedDimensions>,
+        app_time: Duration,
+    ) -> impl EmbeddedGraphicsRender<color::Space> {
+        let env = DefaultEnvironment::new(app_time);
+        let view = Self::view(&self.state);
+        let layout = view.layout(&dimensions.into(), &env);
+        view.render_tree(&layout, buoyant::primitives::Point::zero(), &env)
+    }
+
+    fn view(
+        state: &AppState,
+    ) -> impl buoyant::render::Renderable<color::Space, Renderables: EmbeddedGraphicsRender<color::Space>>
+    {
+        VStack::new((
+            Self::tab_bar(state.tab),
+            match_view!(state.tab => {
+                Tab::Brew => {
+                    Self::brew_tab(state)
+                },
+                Tab::Clean => {
+                    Text::str("Clean", &font::BODY).foreground_color(color::Space::CSS_ORANGE_RED)
+                    .padding(Edges::All, spacing::SECTION_MARGIN)
+                },
+                Tab::Settings => {
+                    Self::settings_tab(state)
+                },
+            }),
+        ))
+    }
+
+    fn tab_bar(
+        tab: Tab,
+    ) -> impl buoyant::render::Renderable<color::Space, Renderables: EmbeddedGraphicsRender<color::Space>>
+    {
+        HStack::new((
+            Self::tab_item("Brew", tab == Tab::Brew),
+            Self::tab_item("Clean", tab == Tab::Clean),
+            Self::tab_item("Settings", tab == Tab::Settings),
+        ))
+        .fixed_size(false, true)
+        .animated(buoyant::Animation::Linear(Duration::from_millis(125)), tab)
+    }
+
+    fn tab_item(
+        name: &str,
+        is_selected: bool,
+    ) -> impl buoyant::render::Renderable<
+        color::Space,
+        Renderables: EmbeddedGraphicsRender<color::Space>,
+    > + use<'_> {
+        let (text_color, bar_height) = if is_selected {
+            (color::ACCENT, 4)
+        } else {
+            (color::FOREGROUND_SECONDARY, 0)
+        };
+
+        VStack::new((
+            ZStack::new((
+                ConditionalView::if_view(
+                    is_selected,
+                    Rectangle.foreground_color(color::BACKGROUND_SECONDARY),
+                ),
+                VStack::new((
+                    Circle.frame().with_width(15),
+                    Text::str(name, &font::CAPTION_BOLD),
+                ))
+                .with_spacing(spacing::ELEMENT)
+                .padding(Edges::All, spacing::ELEMENT),
+            )),
+            Rectangle.frame().with_height(bar_height),
+        ))
+        .foreground_color(text_color)
+        .flex_frame()
+        .with_min_width(100)
+    }
+
+    fn brew_tab(
+        _state: &AppState,
+    ) -> impl buoyant::render::Renderable<color::Space, Renderables: EmbeddedGraphicsRender<color::Space>>
+    {
+        VStack::new((
+            Text::str("Good morning", &font::BODY),
+            Text::str(
+                "Use the arrow keys to navigate to the settings tab",
+                &font::CAPTION_BOLD,
+            )
+            .multiline_text_alignment(HorizontalTextAlignment::Leading),
+        ))
+        .with_spacing(spacing::COMPONENT)
+        .with_alignment(HorizontalAlignment::Leading)
+        .flex_frame()
+        .with_infinite_max_width()
+        .with_horizontal_alignment(HorizontalAlignment::Leading)
+        .padding(Edges::All, spacing::SECTION_MARGIN)
+        .foreground_color(color::Space::WHITE)
+    }
+
+    fn settings_tab(
+        state: &AppState,
+    ) -> impl buoyant::render::Renderable<color::Space, Renderables: EmbeddedGraphicsRender<color::Space>>
+    {
+        VStack::new((
+            toggle_text(
+                "Auto (b)rew",
+                state.auto_brew,
+                "Automatically brew coffee at 7am",
+                true,
+            ),
+            toggle_text(
+                "Stop on (w)eight",
+                state.stop_on_weight,
+                "Stop the machine automatically when the target weight is reached",
+                false,
+            ),
+            toggle_text(
+                "Auto (o)ff",
+                state.auto_off,
+                "The display will go to sleep after 5 minutes of inactivity",
+                true,
+            ),
+        ))
+        .with_spacing(spacing::COMPONENT)
+        .with_alignment(HorizontalAlignment::Trailing)
+        .padding(Edges::All, spacing::SECTION_MARGIN)
+        .animated(
+            buoyant::Animation::Linear(Duration::from_millis(200)),
+            state.clone(),
+        )
+    }
+}
+
+fn toggle_text<'a>(
+    label: &'a str,
+    is_on: bool,
+    description: &'a str,
+    hides_description: bool,
+) -> impl Renderable<color::Space, Renderables: EmbeddedGraphicsRender<color::Space>> + use<'a> {
+    VStack::new((
+        HStack::new((
+            Text::str(label, &font::BODY).foreground_color(color::Space::WHITE),
+            toggle_button(is_on),
+        ))
+        .with_spacing(spacing::ELEMENT),
+        ConditionalView::if_view(
+            is_on || !hides_description,
+            Text::str(description, &font::CAPTION)
+                .multiline_text_alignment(HorizontalTextAlignment::Trailing)
+                .foreground_color(color::Space::WHITE),
+        ),
+    ))
+    .with_spacing(spacing::ELEMENT)
+    .with_alignment(HorizontalAlignment::Trailing)
+    .flex_frame()
+    .with_infinite_max_width()
+    .with_horizontal_alignment(HorizontalAlignment::Trailing)
+}
+
+fn toggle_button(
+    is_on: bool,
+) -> impl Renderable<color::Space, Renderables: EmbeddedGraphicsRender<color::Space>> {
+    let (color, alignment) = if is_on {
+        (color::ACCENT, HorizontalAlignment::Trailing)
+    } else {
+        (color::Space::CSS_LIGHT_GRAY, HorizontalAlignment::Leading)
+    };
+
+    ZStack::new((
+        buoyant::view::shape::Capsule.foreground_color(color),
+        buoyant::view::shape::Circle
+            .foreground_color(color::Space::WHITE)
+            .padding(Edges::All, 2)
+            .animated(
+                buoyant::Animation::Linear(Duration::from_millis(125)),
+                is_on,
+            ),
+    ))
+    .with_horizontal_alignment(alignment)
+    .frame()
+    .with_width(50)
+    .with_height(25)
+    .geometry_group()
+}

--- a/examples/espresso.rs
+++ b/examples/espresso.rs
@@ -4,6 +4,7 @@
 //! The settings can be toggled using the `b`, `w`, and `o` keys.
 //!
 //! To run this example using the embedded_graphics simulator, you must have the `sdl2` package installed.
+//! See [SDL2](https://github.com/Rust-SDL2/rust-sdl2) for installation instructions.
 
 use std::time::{Duration, Instant};
 


### PR DESCRIPTION
Add espresso simulator example seen in readme.
Reliance on the simulator / sdl2 is probably annoying for new people running the espresso example, maybe there's a better way to simulate embedded-graphics.