### PR TITLE
0.4 alpha update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "buoyant"
-version = "0.3.1"
+version = "0.4.0-alpha.0"
 dependencies = [
  "crossterm",
  "embedded-graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "buoyant"
-version = "0.3.1"
+version = "0.4.0-alpha.0"
 authors = ["Riley Williams"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Updates crate version to 0.4.0-alpha.0 to publish breaking Text changes.