### PR TITLE
Convenience frame and alignment modifiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "buoyant"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "crossterm",
  "embedded-graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "buoyant"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Riley Williams"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -38,9 +38,8 @@ fn toggle_button(is_on: bool) -> impl EmbeddedGraphicsView<Rgb565> {
     ))
     .with_horizontal_alignment(alignment)
     .frame()
-    .with_width(50)
-    .with_height(25)
-    .animated(Animation::Linear(Duration::from_millis(200)), is_on)
+    .with_size(50, 25)
+    .animated(Animation::linear(Duration::from_millis(200)), is_on)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ fn toggle_button(is_on: bool) -> impl EmbeddedGraphicsView<Rgb565> {
         Circle.foreground_color(Rgb565::WHITE).padding(2),
     ))
     .with_horizontal_alignment(alignment)
-    .frame()
-    .with_size(50, 25)
+    .frame_sized(50, 25)
     .animated(Animation::linear(Duration::from_millis(200)), is_on)
 }
 ```

--- a/docs/book/src/building-views/collections.md
+++ b/docs/book/src/building-views/collections.md
@@ -78,8 +78,7 @@ fn view(swatches: &[Swatch]) -> impl EmbeddedGraphicsView<Rgb888> + use<'_> {
         HStack::new((
             RoundedRectangle::new(8)
                 .foreground_color(swatch.color)
-                .frame()
-                .with_size(40, 40),
+                .frame_sized(40, 40),
             Text::new(swatch.name, &FONT_9X15).foreground_color(Rgb888::WHITE),
         ))
         .with_spacing(spacing::ELEMENT)

--- a/docs/book/src/building-views/collections.md
+++ b/docs/book/src/building-views/collections.md
@@ -79,8 +79,7 @@ fn view(swatches: &[Swatch]) -> impl EmbeddedGraphicsView<Rgb888> + use<'_> {
             RoundedRectangle::new(8)
                 .foreground_color(swatch.color)
                 .frame()
-                .with_width(40)
-                .with_height(40),
+                .with_size(40, 40),
             Text::new(swatch.name, &FONT_9X15).foreground_color(Rgb888::WHITE),
         ))
         .with_spacing(spacing::ELEMENT)

--- a/docs/book/src/building-views/mixed-alignment.md
+++ b/docs/book/src/building-views/mixed-alignment.md
@@ -100,10 +100,10 @@ with configurable minimum and maximum dimensions. Child views won't necessarily 
 the space within this frame, so you can also specify horizontal and vertical alignment to
 place the child within the virtual frame.
 
-Creating virtual frames that are as wide or tall as possible is relatively common, and
-Buoyant provides `.with_infinite_max_width()` and `.with_infinite_max_height()` for configuring
-this. You can use this in combination with a leading horizontal alignment of the
-circle inside the frame to achieve the same result as the previous code.
+Buoyant provides `.with_infinite_max_width()` and `.with_infinite_max_height()` for creating
+virtual frames that are as wide or tall as possible. You can use this in combination with
+a leading horizontal alignment of the circle inside the frame to achieve the same result
+as the previous code.
 
 ```rust,no_run
 # extern crate buoyant;
@@ -162,3 +162,64 @@ fn view() -> impl EmbeddedGraphicsView<Rgb888> {
 ```
 
 This is both faster for Buoyant to lay out and easier to read.
+
+## Preferred implementations
+
+This behavior is *so* common, shortcuts exist to specify an infinite width or height with
+the alignment in one call.
+
+### Maximally wide views
+
+```rust
+# extern crate buoyant;
+# use buoyant::layout::HorizontalAlignment;
+# use buoyant::view::LayoutExtensions as _;
+# use buoyant::view::{shape::Circle, HStack, Spacer};
+# let content = Circle;
+// Avoid:
+HStack::new((
+    Spacer::default(),
+    content,
+))
+# ;
+
+// Preferred:
+content
+    .flex_frame()
+    .with_infinite_max_width()
+    .with_horizontal_alignment(HorizontalAlignment::Trailing)
+# ;
+
+// Preferred, shortcut:
+content
+    .flex_infinite_width(HorizontalAlignment::Trailing)
+# ;
+```
+
+### Maximally tall views
+
+```rust
+# extern crate buoyant;
+# use buoyant::layout::VerticalAlignment;
+# use buoyant::view::LayoutExtensions as _;
+# use buoyant::view::{shape::Circle, VStack, Spacer};
+# let content = Circle;
+// Avoid:
+VStack::new((
+    content,
+    Spacer::default(),
+))
+# ;
+
+// Preferred:
+content
+    .flex_frame()
+    .with_infinite_max_height()
+    .with_vertical_alignment(VerticalAlignment::Top)
+# ;
+
+// Preferred, shortcut:
+content
+    .flex_infinite_height(VerticalAlignment::Top)
+# ;
+```

--- a/examples/crossterm.rs
+++ b/examples/crossterm.rs
@@ -55,7 +55,7 @@ fn view() -> impl CharacterView<Colors> {
                     "This is in a fixed size box",
                     &FONT,
                 )
-                    .frame().with_size(10, 10),
+                    .frame_sized(10, 10),
             )),
             Text::new(
                 "This is several lines of text.\nEach line is centered in the available space.\n The rectangle fills all the remaining verical space and aligns the content within it.\n2 points of padding are around this text",

--- a/examples/crossterm.rs
+++ b/examples/crossterm.rs
@@ -55,7 +55,7 @@ fn view() -> impl CharacterView<Colors> {
                     "This is in a fixed size box",
                     &FONT,
                 )
-                    .frame().with_width(10).with_height(10),
+                    .frame().with_size(10, 10),
             )),
             Text::new(
                 "This is several lines of text.\nEach line is centered in the available space.\n The rectangle fills all the remaining verical space and aligns the content within it.\n2 points of padding are around this text",

--- a/examples/espresso.rs
+++ b/examples/espresso.rs
@@ -336,7 +336,6 @@ fn toggle_button(is_on: bool) -> impl EmbeddedGraphicsView<color::Space> {
             .animated(Animation::linear(Duration::from_millis(125)), is_on),
     ))
     .with_horizontal_alignment(alignment)
-    .frame()
-    .with_size(50, 25)
+    .frame_sized(50, 25)
     .geometry_group()
 }

--- a/examples/espresso.rs
+++ b/examples/espresso.rs
@@ -341,7 +341,6 @@ fn toggle_button(is_on: bool) -> impl EmbeddedGraphicsView<color::Space> {
     ))
     .with_horizontal_alignment(alignment)
     .frame()
-    .with_width(50)
-    .with_height(25)
+    .with_size(50, 25)
     .geometry_group()
 }

--- a/examples/espresso.rs
+++ b/examples/espresso.rs
@@ -262,9 +262,7 @@ impl App {
         ))
         .with_spacing(spacing::COMPONENT)
         .with_alignment(HorizontalAlignment::Leading)
-        .flex_frame()
-        .with_infinite_max_width()
-        .with_horizontal_alignment(HorizontalAlignment::Leading)
+        .flex_infinite_width(HorizontalAlignment::Leading)
         .padding(Edges::All, spacing::SECTION_MARGIN)
         .foreground_color(color::Space::WHITE)
     }
@@ -320,9 +318,7 @@ fn toggle_text<'a>(
     ))
     .with_spacing(spacing::ELEMENT)
     .with_alignment(HorizontalAlignment::Trailing)
-    .flex_frame()
-    .with_infinite_max_width()
-    .with_horizontal_alignment(HorizontalAlignment::Trailing)
+    .flex_infinite_width(HorizontalAlignment::Trailing)
 }
 
 fn toggle_button(is_on: bool) -> impl EmbeddedGraphicsView<color::Space> {

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -1,10 +1,9 @@
 use core::time::Duration;
 
-use crate::layout::{Alignment, LayoutDirection};
+use crate::layout::LayoutDirection;
 
 pub trait LayoutEnvironment {
     fn layout_direction(&self) -> LayoutDirection;
-    fn alignment(&self) -> Alignment;
     /// The duration since the application started.
     /// This is used to drive animations.
     fn app_time(&self) -> Duration;
@@ -32,10 +31,6 @@ impl DefaultEnvironment {
 impl LayoutEnvironment for DefaultEnvironment {
     fn layout_direction(&self) -> LayoutDirection {
         LayoutDirection::default()
-    }
-
-    fn alignment(&self) -> Alignment {
-        Alignment::default()
     }
 
     fn app_time(&self) -> Duration {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -13,19 +13,57 @@ pub enum LayoutDirection {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Default)]
-pub struct Alignment {
-    pub horizontal: HorizontalAlignment,
-    pub vertical: VerticalAlignment,
+pub enum Alignment {
+    TopLeading,
+    Top,
+    TopTrailing,
+    Leading,
+    #[default]
+    Center,
+    Trailing,
+    BottomLeading,
+    Bottom,
+    BottomTrailing,
+}
+
+impl Alignment {
+    #[must_use]
+    pub const fn horizontal(&self) -> HorizontalAlignment {
+        match self {
+            Alignment::TopLeading | Alignment::Leading | Alignment::BottomLeading => {
+                HorizontalAlignment::Leading
+            }
+            Alignment::Top | Alignment::Center | Alignment::Bottom => HorizontalAlignment::Center,
+            Alignment::TopTrailing | Alignment::Trailing | Alignment::BottomTrailing => {
+                HorizontalAlignment::Trailing
+            }
+        }
+    }
+
+    #[must_use]
+    pub const fn vertical(&self) -> VerticalAlignment {
+        match self {
+            Alignment::TopLeading | Alignment::Top | Alignment::TopTrailing => {
+                VerticalAlignment::Top
+            }
+            Alignment::Leading | Alignment::Center | Alignment::Trailing => {
+                VerticalAlignment::Center
+            }
+            Alignment::BottomLeading | Alignment::Bottom | Alignment::BottomTrailing => {
+                VerticalAlignment::Bottom
+            }
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Default)]
 pub enum HorizontalAlignment {
-    /// Align the content to the start of the layout direction
+    /// Align the content to the leading edge
     Leading,
-    /// Align the content to the center of the layout direction
+    /// Align the content to the center
     #[default]
     Center,
-    /// Align the content to the end of the layout direction
+    /// Align the content to the trailing edge
     Trailing,
 }
 
@@ -43,12 +81,12 @@ impl HorizontalAlignment {
 #[derive(Clone, Copy, Debug, PartialEq, Default)]
 /// Strategy to align the heights of items that do not fill the available frame height
 pub enum VerticalAlignment {
-    /// Align the content to the start of the layout direction
+    /// Align the content to the top edge
     Top,
-    /// Align the content to the center of the layout direction
+    /// Align the content to the center
     #[default]
     Center,
-    /// Align the content to the end of the layout direction
+    /// Align the content to the bottom edge
     Bottom,
 }
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -27,6 +27,7 @@ pub enum Alignment {
 }
 
 impl Alignment {
+    /// The horizontal component of the alignment
     #[must_use]
     pub const fn horizontal(&self) -> HorizontalAlignment {
         match self {
@@ -40,6 +41,7 @@ impl Alignment {
         }
     }
 
+    /// The vertical component of the alignment
     #[must_use]
     pub const fn vertical(&self) -> VerticalAlignment {
         match self {

--- a/src/view.rs
+++ b/src/view.rs
@@ -83,9 +83,7 @@ pub trait LayoutExtensions: Sized {
     /// # let my_view = buoyant::view::shape::Rectangle;
     /// # let alignment = buoyant::layout::HorizontalAlignment::Center;
     /// my_view
-    ///     .flex_frame()
-    ///     .with_infinite_max_width()
-    ///     .with_horizontal_alignment(alignment)
+    ///     .flex_infinite_width(alignment)
     /// # ;
     /// ```
     fn flex_infinite_width(self, alignment: HorizontalAlignment) -> FlexFrame<Self> {
@@ -104,9 +102,7 @@ pub trait LayoutExtensions: Sized {
     /// # let my_view = buoyant::view::shape::Rectangle;
     /// # let alignment = VerticalAlignment::Center;
     /// my_view
-    ///     .flex_frame()
-    ///     .with_infinite_max_height()
-    ///     .with_vertical_alignment(alignment)
+    ///     .flex_infinite_height(alignment)
     /// # ;
     /// ```
     fn flex_infinite_height(self, alignment: VerticalAlignment) -> FlexFrame<Self> {

--- a/src/view.rs
+++ b/src/view.rs
@@ -33,22 +33,86 @@ use modifier::{
 use crate::{
     animation::Animation,
     environment::DefaultEnvironment,
+    layout::{HorizontalAlignment, VerticalAlignment},
     primitives::{Point, Size},
     render::{CharacterRender, Renderable},
 };
 
+/// Modifiers that extend the functionality of views.
 pub trait LayoutExtensions: Sized {
     /// Applies padding to the specified edges
     fn padding(self, edges: padding::Edges, amount: u16) -> Padding<Self> {
         Padding::new(edges, amount, self)
     }
 
+    /// A virtual frame that can be configured with fixed size dimensions.
     fn frame(self) -> FixedFrame<Self> {
         FixedFrame::new(self)
     }
 
+    /// A fixed size frame with the specified width and height.
+    ///
+    /// This is a shortcut for:
+    ///
+    /// ```
+    /// # use buoyant::view::LayoutExtensions as _;
+    /// # let my_view = buoyant::view::shape::Rectangle;
+    /// # let width = 100;
+    /// # let height = 100;
+    /// my_view
+    ///     .frame()
+    ///     .with_width(width)
+    ///     .with_height(height)
+    /// # ;
+    /// ```
+    fn frame_with_size(self, width: u16, height: u16) -> FixedFrame<Self> {
+        FixedFrame::new(self).with_width(width).with_height(height)
+    }
+
+    /// A virtual frame that can be configured with flexible dimensions.
     fn flex_frame(self) -> FlexFrame<Self> {
         FlexFrame::new(self)
+    }
+
+    /// Creates a virtual frame that expands to fill as much horizontal space as possible.
+    ///
+    /// This is a shortcut for:
+    ///
+    /// ```
+    /// # use buoyant::view::LayoutExtensions as _;
+    /// # let my_view = buoyant::view::shape::Rectangle;
+    /// # let alignment = buoyant::layout::HorizontalAlignment::Center;
+    /// my_view
+    ///     .flex_frame()
+    ///     .with_infinite_max_width()
+    ///     .with_horizontal_alignment(alignment)
+    /// # ;
+    /// ```
+    fn flex_infinite_width(self, alignment: HorizontalAlignment) -> FlexFrame<Self> {
+        FlexFrame::new(self)
+            .with_infinite_max_width()
+            .with_horizontal_alignment(alignment)
+    }
+
+    /// Creates a virtual frame that expands to fill as much vertical space as possible.
+    ///
+    /// This is a shortcut for:
+    ///
+    /// ```
+    /// # use buoyant::view::LayoutExtensions as _;
+    /// # use buoyant::layout::VerticalAlignment;
+    /// # let my_view = buoyant::view::shape::Rectangle;
+    /// # let alignment = VerticalAlignment::Center;
+    /// my_view
+    ///     .flex_frame()
+    ///     .with_infinite_max_height()
+    ///     .with_vertical_alignment(alignment)
+    /// # ;
+    /// ```
+    fn flex_infinite_height(self, alignment: VerticalAlignment) -> FlexFrame<Self> {
+        FlexFrame::new(self)
+            .with_infinite_max_width()
+            .with_vertical_alignment(alignment)
     }
 
     /// Proposes ``ProposedDimension::Compact``, resulting in the child view rendering at its ideal
@@ -109,7 +173,8 @@ pub trait LayoutExtensions: Sized {
     ///     ))
     ///     .with_horizontal_alignment(alignment)
     ///     .geometry_group()
-    ///     .frame().with_width(50).with_height(25)
+    ///     .frame()
+    ///     .with_size(50, 25)
     /// }
     /// ```
     fn geometry_group(self) -> GeometryGroup<Self> {

--- a/src/view.rs
+++ b/src/view.rs
@@ -65,11 +65,25 @@ pub trait LayoutExtensions: Sized {
     ///     .with_height(height)
     /// # ;
     /// ```
-    fn frame_with_size(self, width: u16, height: u16) -> FixedFrame<Self> {
+    fn frame_sized(self, width: u16, height: u16) -> FixedFrame<Self> {
         FixedFrame::new(self).with_width(width).with_height(height)
     }
 
     /// A virtual frame that can be configured with flexible dimensions.
+    ///
+    /// Examples:
+    ///
+    /// ```
+    /// # use buoyant::view::LayoutExtensions as _;
+    /// # use buoyant::layout::Alignment;
+    /// # let my_view = buoyant::view::shape::Rectangle;
+    /// my_view
+    ///     .flex_frame()
+    ///     .with_min_size(25, 25)
+    ///     .with_max_width(50)
+    ///     .with_alignment(Alignment::TopLeading)
+    /// # ;
+    /// ```
     fn flex_frame(self) -> FlexFrame<Self> {
         FlexFrame::new(self)
     }
@@ -83,7 +97,9 @@ pub trait LayoutExtensions: Sized {
     /// # let my_view = buoyant::view::shape::Rectangle;
     /// # let alignment = buoyant::layout::HorizontalAlignment::Center;
     /// my_view
-    ///     .flex_infinite_width(alignment)
+    ///     .flex_frame()
+    ///     .with_infinite_max_width()
+    ///     .with_horizontal_alignment(alignment)
     /// # ;
     /// ```
     fn flex_infinite_width(self, alignment: HorizontalAlignment) -> FlexFrame<Self> {
@@ -102,12 +118,14 @@ pub trait LayoutExtensions: Sized {
     /// # let my_view = buoyant::view::shape::Rectangle;
     /// # let alignment = VerticalAlignment::Center;
     /// my_view
-    ///     .flex_infinite_height(alignment)
+    ///     .flex_frame()
+    ///     .with_infinite_max_height()
+    ///     .with_vertical_alignment(alignment)
     /// # ;
     /// ```
     fn flex_infinite_height(self, alignment: VerticalAlignment) -> FlexFrame<Self> {
         FlexFrame::new(self)
-            .with_infinite_max_width()
+            .with_infinite_max_height()
             .with_vertical_alignment(alignment)
     }
 
@@ -169,8 +187,7 @@ pub trait LayoutExtensions: Sized {
     ///     ))
     ///     .with_horizontal_alignment(alignment)
     ///     .geometry_group()
-    ///     .frame()
-    ///     .with_size(50, 25)
+    ///     .frame_sized(50, 25)
     /// }
     /// ```
     fn geometry_group(self) -> GeometryGroup<Self> {

--- a/src/view/foreach.rs
+++ b/src/view/foreach.rs
@@ -13,10 +13,6 @@ struct ForEachEnvironment<'a, T> {
 }
 
 impl<T: LayoutEnvironment> LayoutEnvironment for ForEachEnvironment<'_, T> {
-    fn alignment(&self) -> crate::layout::Alignment {
-        self.inner_environment.alignment()
-    }
-
     fn layout_direction(&self) -> LayoutDirection {
         LayoutDirection::Vertical
     }

--- a/src/view/hstack.rs
+++ b/src/view/hstack.rs
@@ -20,9 +20,6 @@ struct HorizontalEnvironment<'a, T> {
 }
 
 impl<T: LayoutEnvironment> LayoutEnvironment for HorizontalEnvironment<'_, T> {
-    fn alignment(&self) -> crate::layout::Alignment {
-        self.inner_environment.alignment()
-    }
     fn layout_direction(&self) -> LayoutDirection {
         LayoutDirection::Horizontal
     }

--- a/src/view/modifier/fixed_frame.rs
+++ b/src/view/modifier/fixed_frame.rs
@@ -1,6 +1,6 @@
 use crate::{
     environment::LayoutEnvironment,
-    layout::{HorizontalAlignment, Layout, ResolvedLayout, VerticalAlignment},
+    layout::{Alignment, HorizontalAlignment, Layout, ResolvedLayout, VerticalAlignment},
     primitives::{Dimension, Dimensions, Point, ProposedDimension, ProposedDimensions},
     render::Renderable,
 };
@@ -9,8 +9,8 @@ use crate::{
 pub struct FixedFrame<T> {
     width: Option<u16>,
     height: Option<u16>,
-    horizontal_alignment: Option<HorizontalAlignment>,
-    vertical_alignment: Option<VerticalAlignment>,
+    horizontal_alignment: HorizontalAlignment,
+    vertical_alignment: VerticalAlignment,
     child: T,
 }
 
@@ -19,38 +19,48 @@ impl<T> FixedFrame<T> {
         Self {
             width: None,
             height: None,
-            horizontal_alignment: None,
-            vertical_alignment: None,
+            horizontal_alignment: HorizontalAlignment::Center,
+            vertical_alignment: VerticalAlignment::Center,
             child,
         }
     }
 
-    pub fn with_width(self, width: u16) -> Self {
-        Self {
-            width: Some(width),
-            ..self
-        }
+    /// Sets the width of the frame.
+    pub const fn with_width(mut self, width: u16) -> Self {
+        self.width = Some(width);
+        self
     }
 
-    pub fn with_height(self, height: u16) -> Self {
-        Self {
-            height: Some(height),
-            ..self
-        }
+    /// Sets the height of the frame.
+    pub const fn with_height(mut self, height: u16) -> Self {
+        self.height = Some(height);
+        self
     }
 
-    pub fn with_horizontal_alignment(self, alignment: HorizontalAlignment) -> Self {
-        Self {
-            horizontal_alignment: Some(alignment),
-            ..self
-        }
+    /// Sets the size of the frame.
+    pub const fn with_size(mut self, width: u16, height: u16) -> Self {
+        self.width = Some(width);
+        self.height = Some(height);
+        self
     }
 
-    pub fn with_vertical_alignment(self, alignment: VerticalAlignment) -> Self {
-        Self {
-            vertical_alignment: Some(alignment),
-            ..self
-        }
+    /// The horizontal alignment to apply when the child view is larger or smaller than the frame.
+    pub const fn with_horizontal_alignment(mut self, alignment: HorizontalAlignment) -> Self {
+        self.horizontal_alignment = alignment;
+        self
+    }
+
+    /// The vertical alignment to apply when the child view is larger or smaller than the frame.
+    pub const fn with_vertical_alignment(mut self, alignment: VerticalAlignment) -> Self {
+        self.vertical_alignment = alignment;
+        self
+    }
+
+    /// The alignment to apply when the child view is larger or smaller than the frame.
+    pub const fn with_alignment(mut self, alignment: Alignment) -> Self {
+        self.horizontal_alignment = alignment.horizontal();
+        self.vertical_alignment = alignment.vertical();
+        self
     }
 }
 
@@ -102,11 +112,11 @@ impl<T: Renderable<C>, C> Renderable<C> for FixedFrame<T> {
     ) -> Self::Renderables {
         let new_origin = origin
             + Point::new(
-                self.horizontal_alignment.unwrap_or_default().align(
+                self.horizontal_alignment.align(
                     layout.resolved_size.width.into(),
                     layout.sublayouts.resolved_size.width.into(),
                 ),
-                self.vertical_alignment.unwrap_or_default().align(
+                self.vertical_alignment.align(
                     layout.resolved_size.height.into(),
                     layout.sublayouts.resolved_size.height.into(),
                 ),

--- a/src/view/modifier/flex_frame.rs
+++ b/src/view/modifier/flex_frame.rs
@@ -52,9 +52,9 @@ impl<T> FlexFrame<T> {
 
     /// The maximum width of the frame.
     ///
-    /// This width will be proposed to the child, and the frame will resolve greedily
-    /// up to this width.
-    pub fn with_max_width(mut self, max_width: u16) -> Self {
+    /// The child view will be proposed a width up to the max, and the frame will resolve
+    /// greedily up to this width.
+    pub fn with_max_width<U: Into<Dimension>>(mut self, max_width: U) -> Self {
         self.max_width = Some(max_width.into());
         self
     }
@@ -84,9 +84,9 @@ impl<T> FlexFrame<T> {
 
     /// The maximum height of the frame.
     ///
-    /// This height will be proposed to the child, and the frame will resolve greedily
-    /// up to this height.
-    pub fn with_max_height(mut self, max_height: u16) -> Self {
+    /// The child view will be proposed a height up to the max, and the frame will resolve
+    /// greedily up to this height.
+    pub fn with_max_height<U: Into<Dimension>>(mut self, max_height: U) -> Self {
         self.max_height = Some(max_height.into());
         self
     }
@@ -98,7 +98,7 @@ impl<T> FlexFrame<T> {
     }
 
     /// Sets the maximum size of the frame.
-    pub fn with_max_size(mut self, max_width: u16, max_height: u16) -> Self {
+    pub fn with_max_size<U: Into<Dimension>>(mut self, max_width: U, max_height: U) -> Self {
         self.max_width = Some(max_width.into());
         self.max_height = Some(max_height.into());
         self

--- a/src/view/modifier/flex_frame.rs
+++ b/src/view/modifier/flex_frame.rs
@@ -1,6 +1,6 @@
 use crate::{
     environment::LayoutEnvironment,
-    layout::{HorizontalAlignment, Layout, ResolvedLayout, VerticalAlignment},
+    layout::{Alignment, HorizontalAlignment, Layout, ResolvedLayout, VerticalAlignment},
     primitives::{Dimension, Dimensions, Point, ProposedDimension, ProposedDimensions},
     render::Renderable,
 };
@@ -33,53 +33,107 @@ impl<T> FlexFrame<T> {
         }
     }
 
+    /// Applies a minimum width to the frame.
+    ///
+    /// The child view may still resolve to a smaller width if it is smaller than
+    /// the minimum width.
     pub const fn with_min_width(mut self, min_width: u16) -> Self {
         self.min_width = Some(min_width);
         self
     }
 
+    /// The width to propose to the child view when a parent view requests a compact width.
+    ///
+    /// This is especially useful for views like shapes which have no inherent size.
     pub const fn with_ideal_width(mut self, ideal_width: u16) -> Self {
         self.ideal_width = Some(ideal_width);
         self
     }
 
+    /// The maximum width of the frame.
+    ///
+    /// This width will be proposed to the child, and the frame will resolve greedily
+    /// up to this width.
     pub fn with_max_width(mut self, max_width: u16) -> Self {
         self.max_width = Some(max_width.into());
         self
     }
 
+    /// Sets the frame to expand to fill as much horizontal space as possible.
     pub const fn with_infinite_max_width(mut self) -> Self {
         self.max_width = Some(Dimension::infinite());
         self
     }
 
+    /// Applies a minimum height to the frame.
+    ///
+    /// The child view may still resolve to a smaller height if it is smaller than
+    /// the minimum height.
     pub const fn with_min_height(mut self, min_height: u16) -> Self {
         self.min_height = Some(min_height);
         self
     }
 
+    /// The height to propose to the child view when a parent view requests a compact height.
+    ///
+    /// This is especially useful for views like shapes which have no inherent size.
     pub const fn with_ideal_height(mut self, ideal_height: u16) -> Self {
         self.ideal_height = Some(ideal_height);
         self
     }
 
+    /// The maximum height of the frame.
+    ///
+    /// This height will be proposed to the child, and the frame will resolve greedily
+    /// up to this height.
     pub fn with_max_height(mut self, max_height: u16) -> Self {
         self.max_height = Some(max_height.into());
         self
     }
 
+    /// Sets the frame to expand to fill as much vertical space as possible.
     pub const fn with_infinite_max_height(mut self) -> Self {
         self.max_height = Some(Dimension::infinite());
         self
     }
 
+    /// Sets the maximum size of the frame.
+    pub fn with_max_size(mut self, max_width: u16, max_height: u16) -> Self {
+        self.max_width = Some(max_width.into());
+        self.max_height = Some(max_height.into());
+        self
+    }
+
+    /// Sets the ideal size of the frame.
+    pub const fn with_ideal_size(mut self, ideal_width: u16, ideal_height: u16) -> Self {
+        self.ideal_width = Some(ideal_width);
+        self.ideal_height = Some(ideal_height);
+        self
+    }
+
+    /// Sets the minimum size of the frame.
+    pub const fn with_min_size(mut self, min_width: u16, min_height: u16) -> Self {
+        self.min_width = Some(min_width);
+        self.min_height = Some(min_height);
+        self
+    }
+
+    /// The horizontal alignment to apply when the child view is larger or smaller than the frame.
     pub const fn with_horizontal_alignment(mut self, alignment: HorizontalAlignment) -> Self {
         self.horizontal_alignment = alignment;
         self
     }
 
+    /// The vertical alignment to apply when the child view is larger or smaller than the frame.
     pub const fn with_vertical_alignment(mut self, alignment: VerticalAlignment) -> Self {
         self.vertical_alignment = alignment;
+        self
+    }
+
+    /// The alignment to apply when the child view is larger or smaller than the frame.
+    pub const fn with_alignment(mut self, alignment: Alignment) -> Self {
+        self.horizontal_alignment = alignment.horizontal();
+        self.vertical_alignment = alignment.vertical();
         self
     }
 }

--- a/src/view/vstack.rs
+++ b/src/view/vstack.rs
@@ -19,10 +19,6 @@ struct VerticalEnvironment<'a, T> {
 }
 
 impl<T: LayoutEnvironment> LayoutEnvironment for VerticalEnvironment<'_, T> {
-    fn alignment(&self) -> crate::layout::Alignment {
-        self.inner_environment.alignment()
-    }
-
     fn layout_direction(&self) -> LayoutDirection {
         LayoutDirection::Vertical
     }

--- a/src/view/zstack.rs
+++ b/src/view/zstack.rs
@@ -1,6 +1,6 @@
 use crate::{
     environment::LayoutEnvironment,
-    layout::{HorizontalAlignment, Layout, ResolvedLayout, VerticalAlignment},
+    layout::{Alignment, HorizontalAlignment, Layout, ResolvedLayout, VerticalAlignment},
     primitives::{Point, ProposedDimension, ProposedDimensions},
     render::Renderable,
 };
@@ -14,7 +14,7 @@ use paste::paste;
 ///
 /// ```rust
 /// use buoyant::font::CharacterBufferFont;
-/// use buoyant::layout::{HorizontalAlignment, VerticalAlignment};
+/// use buoyant::layout::Alignment;
 /// use buoyant::view::{ZStack, shape::Rectangle, Text, RenderExtensions as _};
 ///
 /// /// A fish at the bottom right corner of an 'o'cean
@@ -23,8 +23,7 @@ use paste::paste;
 ///         Rectangle,
 ///         Text::new("><>", &font),
 ///     ))
-///     .with_vertical_alignment(VerticalAlignment::Bottom)
-///     .with_horizontal_alignment(HorizontalAlignment::Trailing)
+///     .with_alignment(Alignment::BottomTrailing)
 ///     .foreground_color('o');
 /// ```
 #[derive(Debug, Clone)]
@@ -54,6 +53,15 @@ impl<T> ZStack<T> {
     pub fn with_vertical_alignment(self, alignment: VerticalAlignment) -> Self {
         Self {
             vertical_alignment: alignment,
+            ..self
+        }
+    }
+
+    #[must_use]
+    pub fn with_alignment(self, alignment: Alignment) -> Self {
+        Self {
+            horizontal_alignment: alignment.horizontal(),
+            vertical_alignment: alignment.vertical(),
             ..self
         }
     }

--- a/tests/animation.rs
+++ b/tests/animation.rs
@@ -375,12 +375,10 @@ fn toggle_switch(is_on: bool, subtext: &str) -> impl CharacterView<char> + use<'
         ZStack::new((
             Rectangle
                 .foreground_color('_')
-                .frame()
-                .with_size(5, 1),
+                .frame_sized(5, 1),
             Rectangle
                 .foreground_color('#')
-                .frame()
-                .with_size(1, 1),
+                .frame_sized(1, 1),
         ))
         .with_horizontal_alignment(alignment)
         .animated(Animation::linear(Duration::from_secs(1)), is_on),

--- a/tests/animation.rs
+++ b/tests/animation.rs
@@ -22,9 +22,7 @@ const FONT: CharacterBufferFont = CharacterBufferFont;
 
 fn x_bar(alignment: HorizontalAlignment) -> impl CharacterView<char> {
     Text::new("X", &FONT)
-        .flex_frame()
-        .with_infinite_max_width()
-        .with_horizontal_alignment(alignment)
+        .flex_infinite_width(alignment)
         .animated(Animation::linear(Duration::from_secs(1)), alignment)
 }
 

--- a/tests/animation.rs
+++ b/tests/animation.rs
@@ -378,13 +378,11 @@ fn toggle_switch(is_on: bool, subtext: &str) -> impl CharacterView<char> + use<'
             Rectangle
                 .foreground_color('_')
                 .frame()
-                .with_width(5)
-                .with_height(1),
+                .with_size(5, 1),
             Rectangle
                 .foreground_color('#')
                 .frame()
-                .with_width(1)
-                .with_height(1),
+                .with_size(1, 1),
         ))
         .with_horizontal_alignment(alignment)
         .animated(Animation::linear(Duration::from_secs(1)), is_on),

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -19,10 +19,6 @@ impl LayoutEnvironment for TestEnv {
         self.direction
     }
 
-    fn alignment(&self) -> Alignment {
-        self.alignment
-    }
-
     fn app_time(&self) -> Duration {
         self.app_time
     }

--- a/tests/fixed_frame.rs
+++ b/tests/fixed_frame.rs
@@ -1,6 +1,6 @@
 use buoyant::{
     font::CharacterBufferFont,
-    layout::{HorizontalAlignment, Layout, VerticalAlignment},
+    layout::{Alignment, HorizontalAlignment, Layout, VerticalAlignment},
     primitives::{Dimensions, Point, ProposedDimension, ProposedDimensions, Size},
     render::{CharacterRender, CharacterRenderTarget},
     render_target::FixedTextBuffer,
@@ -72,8 +72,7 @@ fn test_fixed_frame_compact_width_height() {
     let font = CharacterBufferFont {};
     let content = Text::new("123456", &font)
         .frame()
-        .with_width(2)
-        .with_height(2);
+        .with_size(2, 2);
     let env = common::TestEnv::default();
 
     assert_eq!(
@@ -121,8 +120,7 @@ fn test_fixed_frame_infinite_width_height() {
     let font = CharacterBufferFont {};
     let content = Text::new("123456", &font)
         .frame()
-        .with_width(25)
-        .with_height(25);
+        .with_size(25, 25);
     let env = common::TestEnv::default();
 
     assert_eq!(
@@ -144,10 +142,8 @@ fn test_render_frame_top_leading_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::new("aa\nbb\ncc", &font)
         .frame()
-        .with_width(6)
-        .with_height(5)
-        .with_horizontal_alignment(HorizontalAlignment::Leading)
-        .with_vertical_alignment(VerticalAlignment::Top)
+        .with_size(6, 5)
+        .with_alignment(Alignment::TopLeading)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
@@ -164,8 +160,7 @@ fn test_render_frame_top_center_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::new("aa\nbb\ncc", &font)
         .frame()
-        .with_width(6)
-        .with_height(5)
+        .with_size(6, 5)
         .with_vertical_alignment(VerticalAlignment::Top)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
@@ -183,10 +178,8 @@ fn test_render_frame_top_trailing_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::new("aa\nbb\ncc", &font)
         .frame()
-        .with_width(6)
-        .with_height(5)
-        .with_horizontal_alignment(HorizontalAlignment::Trailing)
-        .with_vertical_alignment(VerticalAlignment::Top)
+        .with_size(6, 5)
+        .with_alignment(Alignment::TopTrailing)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
@@ -203,8 +196,7 @@ fn test_render_frame_center_leading_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::new("aa\nbb\ncc", &font)
         .frame()
-        .with_width(6)
-        .with_height(5)
+        .with_size(6, 5)
         .with_horizontal_alignment(HorizontalAlignment::Leading)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
@@ -222,8 +214,7 @@ fn test_render_frame_center_center_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::new("aa\nbb\ncc", &font)
         .frame()
-        .with_width(6)
-        .with_height(5)
+        .with_size(6, 5)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
@@ -240,8 +231,7 @@ fn test_render_frame_center_trailing_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::new("aa\nbb\ncc", &font)
         .frame()
-        .with_width(6)
-        .with_height(5)
+        .with_size(6, 5)
         .with_horizontal_alignment(HorizontalAlignment::Trailing)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
@@ -259,8 +249,8 @@ fn test_render_frame_bottom_leading_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::new("aa\nbb\ncc", &font)
         .frame()
-        .with_width(6)
-        .with_height(5)
+        .with_size(6, 5)
+        .with_alignment(Alignment::TopLeading)
         .with_horizontal_alignment(HorizontalAlignment::Leading)
         .with_vertical_alignment(VerticalAlignment::Bottom)
         .foreground_color(' ');
@@ -279,8 +269,7 @@ fn test_render_frame_bottom_center_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::new("aa\nbb\ncc", &font)
         .frame()
-        .with_width(6)
-        .with_height(5)
+        .with_size(6, 5)
         .with_vertical_alignment(VerticalAlignment::Bottom)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
@@ -298,10 +287,8 @@ fn test_render_frame_bottom_trailing_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::new("aa\nbb\ncc", &font)
         .frame()
-        .with_width(6)
-        .with_height(5)
-        .with_horizontal_alignment(HorizontalAlignment::Trailing)
-        .with_vertical_alignment(VerticalAlignment::Bottom)
+        .with_size(6, 5)
+        .with_alignment(Alignment::BottomTrailing)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());

--- a/tests/fixed_frame.rs
+++ b/tests/fixed_frame.rs
@@ -71,8 +71,7 @@ fn test_fixed_height() {
 fn test_fixed_frame_compact_width_height() {
     let font = CharacterBufferFont {};
     let content = Text::new("123456", &font)
-        .frame()
-        .with_size(2, 2);
+        .frame_sized(2, 2);
     let env = common::TestEnv::default();
 
     assert_eq!(
@@ -119,8 +118,7 @@ fn test_fixed_frame_compact_width_height() {
 fn test_fixed_frame_infinite_width_height() {
     let font = CharacterBufferFont {};
     let content = Text::new("123456", &font)
-        .frame()
-        .with_size(25, 25);
+        .frame_sized(25, 25);
     let env = common::TestEnv::default();
 
     assert_eq!(
@@ -141,8 +139,7 @@ fn test_fixed_frame_infinite_width_height() {
 fn test_render_frame_top_leading_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::new("aa\nbb\ncc", &font)
-        .frame()
-        .with_size(6, 5)
+        .frame_sized(6, 5)
         .with_alignment(Alignment::TopLeading)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
@@ -159,8 +156,7 @@ fn test_render_frame_top_leading_alignment() {
 fn test_render_frame_top_center_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::new("aa\nbb\ncc", &font)
-        .frame()
-        .with_size(6, 5)
+        .frame_sized(6, 5)
         .with_vertical_alignment(VerticalAlignment::Top)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
@@ -177,8 +173,7 @@ fn test_render_frame_top_center_alignment() {
 fn test_render_frame_top_trailing_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::new("aa\nbb\ncc", &font)
-        .frame()
-        .with_size(6, 5)
+        .frame_sized(6, 5)
         .with_alignment(Alignment::TopTrailing)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
@@ -195,8 +190,7 @@ fn test_render_frame_top_trailing_alignment() {
 fn test_render_frame_center_leading_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::new("aa\nbb\ncc", &font)
-        .frame()
-        .with_size(6, 5)
+        .frame_sized(6, 5)
         .with_horizontal_alignment(HorizontalAlignment::Leading)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
@@ -213,8 +207,7 @@ fn test_render_frame_center_leading_alignment() {
 fn test_render_frame_center_center_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::new("aa\nbb\ncc", &font)
-        .frame()
-        .with_size(6, 5)
+        .frame_sized(6, 5)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
@@ -230,8 +223,7 @@ fn test_render_frame_center_center_alignment() {
 fn test_render_frame_center_trailing_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::new("aa\nbb\ncc", &font)
-        .frame()
-        .with_size(6, 5)
+        .frame_sized(6, 5)
         .with_horizontal_alignment(HorizontalAlignment::Trailing)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
@@ -248,8 +240,7 @@ fn test_render_frame_center_trailing_alignment() {
 fn test_render_frame_bottom_leading_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::new("aa\nbb\ncc", &font)
-        .frame()
-        .with_size(6, 5)
+        .frame_sized(6, 5)
         .with_alignment(Alignment::TopLeading)
         .with_horizontal_alignment(HorizontalAlignment::Leading)
         .with_vertical_alignment(VerticalAlignment::Bottom)
@@ -268,8 +259,7 @@ fn test_render_frame_bottom_leading_alignment() {
 fn test_render_frame_bottom_center_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::new("aa\nbb\ncc", &font)
-        .frame()
-        .with_size(6, 5)
+        .frame_sized(6, 5)
         .with_vertical_alignment(VerticalAlignment::Bottom)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
@@ -286,8 +276,7 @@ fn test_render_frame_bottom_center_alignment() {
 fn test_render_frame_bottom_trailing_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::new("aa\nbb\ncc", &font)
-        .frame()
-        .with_size(6, 5)
+        .frame_sized(6, 5)
         .with_alignment(Alignment::BottomTrailing)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();

--- a/tests/flex_frame.rs
+++ b/tests/flex_frame.rs
@@ -1,3 +1,4 @@
+use buoyant::layout::Alignment;
 use buoyant::primitives::Point;
 use buoyant::render::CharacterRender;
 use buoyant::render::CharacterRenderTarget;
@@ -16,8 +17,7 @@ fn test_min() {
     let font = CharacterBufferFont {};
     let content = Text::new("123456", &font)
         .flex_frame()
-        .with_min_width(2)
-        .with_min_height(2);
+        .with_min_size(2, 2);
 
     let env = DefaultEnvironment::non_animated();
 
@@ -51,8 +51,7 @@ fn test_max() {
     let font = CharacterBufferFont {};
     let content = Text::new("123456", &font)
         .flex_frame()
-        .with_max_width(2)
-        .with_max_height(2);
+        .with_max_size(2, 2);
 
     let env = DefaultEnvironment::non_animated();
 
@@ -140,10 +139,8 @@ fn test_render_min_flex_frame_top_leading_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::new("aa\nbb\ncc", &font)
         .flex_frame()
-        .with_min_width(6)
-        .with_min_height(5)
-        .with_horizontal_alignment(HorizontalAlignment::Leading)
-        .with_vertical_alignment(VerticalAlignment::Top)
+        .with_min_size(6, 5)
+        .with_alignment(Alignment::TopLeading)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
@@ -160,8 +157,7 @@ fn test_render_min_flex_frame_top_center_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::new("aa\nbb\ncc", &font)
         .flex_frame()
-        .with_min_width(6)
-        .with_min_height(5)
+        .with_min_size(6, 5)
         .with_vertical_alignment(VerticalAlignment::Top)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
@@ -179,10 +175,8 @@ fn test_render_min_flex_frame_top_trailing_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::new("aa\nbb\ncc", &font)
         .flex_frame()
-        .with_min_width(6)
-        .with_min_height(5)
-        .with_horizontal_alignment(HorizontalAlignment::Trailing)
-        .with_vertical_alignment(VerticalAlignment::Top)
+        .with_min_size(6, 5)
+        .with_alignment(Alignment::TopTrailing)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
@@ -199,8 +193,7 @@ fn test_render_min_flex_frame_center_leading_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::new("aa\nbb\ncc", &font)
         .flex_frame()
-        .with_min_width(6)
-        .with_min_height(5)
+        .with_min_size(6, 5)
         .with_horizontal_alignment(HorizontalAlignment::Leading)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
@@ -218,8 +211,7 @@ fn test_render_min_flex_frame_center_center_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::new("aa\nbb\ncc", &font)
         .flex_frame()
-        .with_min_width(6)
-        .with_min_height(5)
+        .with_min_size(6, 5)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
@@ -236,8 +228,7 @@ fn test_render_min_flex_frame_center_trailing_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::new("aa\nbb\ncc", &font)
         .flex_frame()
-        .with_min_width(6)
-        .with_min_height(5)
+        .with_min_size(6, 5)
         .with_horizontal_alignment(HorizontalAlignment::Trailing)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
@@ -255,10 +246,8 @@ fn test_render_min_flex_frame_bottom_leading_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::new("aa\nbb\ncc", &font)
         .flex_frame()
-        .with_min_width(6)
-        .with_min_height(5)
-        .with_horizontal_alignment(HorizontalAlignment::Leading)
-        .with_vertical_alignment(VerticalAlignment::Bottom)
+        .with_min_size(6, 5)
+        .with_alignment(Alignment::BottomLeading)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
@@ -275,8 +264,7 @@ fn test_render_min_flex_frame_bottom_center_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::new("aa\nbb\ncc", &font)
         .flex_frame()
-        .with_min_width(6)
-        .with_min_height(5)
+        .with_min_size(6, 5)
         .with_vertical_alignment(VerticalAlignment::Bottom)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
@@ -294,10 +282,8 @@ fn test_render_min_flex_frame_bottom_trailing_alignment() {
     let font = CharacterBufferFont {};
     let content = Text::new("aa\nbb\ncc", &font)
         .flex_frame()
-        .with_min_width(6)
-        .with_min_height(5)
-        .with_horizontal_alignment(HorizontalAlignment::Trailing)
-        .with_vertical_alignment(VerticalAlignment::Bottom)
+        .with_min_size(6, 5)
+        .with_alignment(Alignment::BottomTrailing)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
@@ -338,8 +324,6 @@ fn test_render_oversize_mix() {
         .with_max_width(u16::MAX)
         .with_min_height(8)
         .with_max_height(u16::MAX)
-        .with_horizontal_alignment(HorizontalAlignment::Center)
-        .with_vertical_alignment(VerticalAlignment::Center)
         .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&content, buffer.size());
@@ -356,10 +340,8 @@ fn test_compact() {
     let env = DefaultEnvironment::non_animated();
     let content = Rectangle
         .flex_frame()
-        .with_ideal_width(8)
-        .with_ideal_height(4)
-        .with_min_width(2)
-        .with_min_height(2);
+        .with_ideal_size(8, 4)
+        .with_min_size(2, 2);
 
     let layout = content.layout(
         &ProposedDimensions {

--- a/tests/flex_frame.rs
+++ b/tests/flex_frame.rs
@@ -2,7 +2,10 @@ use buoyant::layout::Alignment;
 use buoyant::primitives::Point;
 use buoyant::render::CharacterRender;
 use buoyant::render::CharacterRenderTarget;
+use buoyant::view::HStack;
 use buoyant::view::RenderExtensions;
+use buoyant::view::Spacer;
+use buoyant::view::VStack;
 use buoyant::{
     environment::DefaultEnvironment,
     font::CharacterBufferFont,
@@ -15,9 +18,7 @@ use buoyant::{
 #[test]
 fn test_min() {
     let font = CharacterBufferFont {};
-    let content = Text::new("123456", &font)
-        .flex_frame()
-        .with_min_size(2, 2);
+    let content = Text::new("123456", &font).flex_frame().with_min_size(2, 2);
 
     let env = DefaultEnvironment::non_animated();
 
@@ -49,9 +50,7 @@ fn test_min() {
 #[test]
 fn test_max() {
     let font = CharacterBufferFont {};
-    let content = Text::new("123456", &font)
-        .flex_frame()
-        .with_max_size(2, 2);
+    let content = Text::new("123456", &font).flex_frame().with_max_size(2, 2);
 
     let env = DefaultEnvironment::non_animated();
 
@@ -682,4 +681,60 @@ fn test_infinite_max_height_with_min_ideal() {
     );
     assert_eq!(layout.resolved_size.width, 5.into());
     assert_eq!(layout.resolved_size.height, 5.into()); // Uses min
+}
+
+/// Usage of ``flex_infinite_width`` should be equivalent to using ``HStack`` with ``Spacer``
+#[test]
+fn infinite_max_width_equivalent_to_hstack_spacer() {
+    let font = CharacterBufferFont {};
+    let stack_view = VStack::new((
+        Text::new("aa", &font),
+        HStack::new((Spacer::default(), Text::new("bb", &font))),
+        HStack::new((Text::new("cc", &font), Spacer::default())),
+    ))
+    .foreground_color(' ');
+
+    let flex_view = VStack::new((
+        Text::new("aa", &font).flex_infinite_width(HorizontalAlignment::Center),
+        Text::new("bb", &font).flex_infinite_width(HorizontalAlignment::Trailing),
+        Text::new("cc", &font).flex_infinite_width(HorizontalAlignment::Leading),
+    ))
+    .foreground_color(' ');
+    let mut buffer1 = FixedTextBuffer::<6, 5>::default();
+    let tree = make_render_tree(&stack_view, buffer1.size());
+    tree.render(&mut buffer1, &' ', Point::zero());
+
+    let mut buffer2 = FixedTextBuffer::<6, 5>::default();
+    let tree = make_render_tree(&flex_view, buffer2.size());
+    tree.render(&mut buffer2, &' ', Point::zero());
+
+    assert_eq!(buffer1, buffer2);
+}
+
+/// Usage of ``flex_infinite_height`` should be equivalent to using ``VStack`` with ``Spacer``
+#[test]
+fn infinite_max_height_equivalent_to_vstack_spacer() {
+    let font = CharacterBufferFont {};
+    let stack_view = HStack::new((
+        Text::new("aa", &font),
+        VStack::new((Spacer::default(), Text::new("bb", &font))),
+        VStack::new((Text::new("cc", &font), Spacer::default())),
+    ))
+    .foreground_color(' ');
+
+    let flex_view = HStack::new((
+        Text::new("aa", &font).flex_infinite_height(VerticalAlignment::Center),
+        Text::new("bb", &font).flex_infinite_height(VerticalAlignment::Bottom),
+        Text::new("cc", &font).flex_infinite_height(VerticalAlignment::Top),
+    ))
+    .foreground_color(' ');
+    let mut buffer1 = FixedTextBuffer::<6, 5>::default();
+    let tree = make_render_tree(&stack_view, buffer1.size());
+    tree.render(&mut buffer1, &' ', Point::zero());
+
+    let mut buffer2 = FixedTextBuffer::<6, 5>::default();
+    let tree = make_render_tree(&flex_view, buffer2.size());
+    tree.render(&mut buffer2, &' ', Point::zero());
+
+    assert_eq!(buffer1, buffer2);
 }

--- a/tests/hstack.rs
+++ b/tests/hstack.rs
@@ -407,9 +407,9 @@ fn empty_view_does_not_create_extra_spacing() {
 #[test]
 fn infinite_width_offer_results_in_sum_of_subview_widths() {
     let hstack = HStack::new((
-        Rectangle.frame().with_width(8).with_height(3),
-        Rectangle.frame().with_width(40).with_height(1),
-        Rectangle.frame().with_width(200).with_height(8),
+        Rectangle.frame().with_size(8, 3),
+        Rectangle.frame().with_size(40, 1),
+        Rectangle.frame().with_size(200, 8),
     ))
     .with_spacing(1);
     let offer = ProposedDimensions {
@@ -424,9 +424,9 @@ fn infinite_width_offer_results_in_sum_of_subview_widths() {
 #[test]
 fn compact_width_offer_results_in_sum_of_subview_widths() {
     let hstack = HStack::new((
-        Rectangle.frame().with_width(8).with_height(3),
-        Rectangle.frame().with_width(40).with_height(1),
-        Rectangle.frame().with_width(200).with_height(8),
+        Rectangle.frame().with_size(8, 3),
+        Rectangle.frame().with_size(40, 1),
+        Rectangle.frame().with_size(200, 8),
     ))
     .with_spacing(1);
     let offer = ProposedDimensions {
@@ -441,9 +441,9 @@ fn compact_width_offer_results_in_sum_of_subview_widths() {
 #[test]
 fn infinite_width_offer_results_in_sum_of_subview_widths_minus_empties() {
     let hstack = HStack::new((
-        Rectangle.frame().with_width(8).with_height(3),
+        Rectangle.frame().with_size(8, 3),
         EmptyView,
-        Rectangle.frame().with_width(200).with_height(8),
+        Rectangle.frame().with_size(200, 8),
     ))
     .with_spacing(1);
     let offer = ProposedDimensions {
@@ -458,9 +458,9 @@ fn infinite_width_offer_results_in_sum_of_subview_widths_minus_empties() {
 #[test]
 fn compact_width_offer_results_in_sum_of_subview_widths_minus_empties() {
     let hstack = HStack::new((
-        Rectangle.frame().with_width(8).with_height(3),
+        Rectangle.frame().with_size(8, 3),
         EmptyView,
-        Rectangle.frame().with_width(200).with_height(8),
+        Rectangle.frame().with_size(200, 8),
     ))
     .with_spacing(1);
     let offer = ProposedDimensions {

--- a/tests/hstack.rs
+++ b/tests/hstack.rs
@@ -407,9 +407,9 @@ fn empty_view_does_not_create_extra_spacing() {
 #[test]
 fn infinite_width_offer_results_in_sum_of_subview_widths() {
     let hstack = HStack::new((
-        Rectangle.frame().with_size(8, 3),
-        Rectangle.frame().with_size(40, 1),
-        Rectangle.frame().with_size(200, 8),
+        Rectangle.frame_sized(8, 3),
+        Rectangle.frame_sized(40, 1),
+        Rectangle.frame_sized(200, 8),
     ))
     .with_spacing(1);
     let offer = ProposedDimensions {
@@ -424,9 +424,9 @@ fn infinite_width_offer_results_in_sum_of_subview_widths() {
 #[test]
 fn compact_width_offer_results_in_sum_of_subview_widths() {
     let hstack = HStack::new((
-        Rectangle.frame().with_size(8, 3),
-        Rectangle.frame().with_size(40, 1),
-        Rectangle.frame().with_size(200, 8),
+        Rectangle.frame_sized(8, 3),
+        Rectangle.frame_sized(40, 1),
+        Rectangle.frame_sized(200, 8),
     ))
     .with_spacing(1);
     let offer = ProposedDimensions {
@@ -441,9 +441,9 @@ fn compact_width_offer_results_in_sum_of_subview_widths() {
 #[test]
 fn infinite_width_offer_results_in_sum_of_subview_widths_minus_empties() {
     let hstack = HStack::new((
-        Rectangle.frame().with_size(8, 3),
+        Rectangle.frame_sized(8, 3),
         EmptyView,
-        Rectangle.frame().with_size(200, 8),
+        Rectangle.frame_sized(200, 8),
     ))
     .with_spacing(1);
     let offer = ProposedDimensions {
@@ -458,9 +458,9 @@ fn infinite_width_offer_results_in_sum_of_subview_widths_minus_empties() {
 #[test]
 fn compact_width_offer_results_in_sum_of_subview_widths_minus_empties() {
     let hstack = HStack::new((
-        Rectangle.frame().with_size(8, 3),
+        Rectangle.frame_sized(8, 3),
         EmptyView,
-        Rectangle.frame().with_size(200, 8),
+        Rectangle.frame_sized(200, 8),
     ))
     .with_spacing(1);
     let offer = ProposedDimensions {

--- a/tests/padding.rs
+++ b/tests/padding.rs
@@ -53,8 +53,7 @@ fn test_clipped_text_trails_correctly() {
 #[test]
 fn test_padding_is_oversized_for_oversized_child() {
     let view = Rectangle
-        .frame()
-        .with_size(10, 10)
+        .frame_sized(10, 10)
         .padding(Edges::All, 2);
 
     let env = DefaultEnvironment::non_animated();

--- a/tests/padding.rs
+++ b/tests/padding.rs
@@ -54,8 +54,7 @@ fn test_clipped_text_trails_correctly() {
 fn test_padding_is_oversized_for_oversized_child() {
     let view = Rectangle
         .frame()
-        .with_width(10)
-        .with_height(10)
+        .with_size(10, 10)
         .padding(Edges::All, 2);
 
     let env = DefaultEnvironment::non_animated();

--- a/tests/vstack.rs
+++ b/tests/vstack.rs
@@ -50,9 +50,9 @@ fn test_oversized_layout_3() {
 #[test]
 fn infinite_height_offer_results_in_sum_of_subview_heights() {
     let vstack = VStack::new((
-        Rectangle.frame().with_width(3).with_height(8),
-        Rectangle.frame().with_width(1).with_height(40),
-        Rectangle.frame().with_width(8).with_height(200),
+        Rectangle.frame().with_size(3, 8),
+        Rectangle.frame().with_size(1, 40),
+        Rectangle.frame().with_size(8, 200),
     ))
     .with_spacing(1);
     let offer = ProposedDimensions {
@@ -67,9 +67,9 @@ fn infinite_height_offer_results_in_sum_of_subview_heights() {
 #[test]
 fn compact_height_offer_results_in_sum_of_subview_heights() {
     let vstack = VStack::new((
-        Rectangle.frame().with_width(3).with_height(8),
-        Rectangle.frame().with_width(1).with_height(40),
-        Rectangle.frame().with_width(8).with_height(200),
+        Rectangle.frame().with_size(3, 8),
+        Rectangle.frame().with_size(1, 40),
+        Rectangle.frame().with_size(8, 200),
     ))
     .with_spacing(1);
     let offer = ProposedDimensions {
@@ -84,9 +84,9 @@ fn compact_height_offer_results_in_sum_of_subview_heights() {
 #[test]
 fn infinite_height_offer_results_in_sum_of_subview_heights_minus_empties() {
     let vstack = VStack::new((
-        Rectangle.frame().with_width(3).with_height(8),
+        Rectangle.frame().with_size(3, 8),
         EmptyView,
-        Rectangle.frame().with_width(8).with_height(200),
+        Rectangle.frame().with_size(8, 200),
     ))
     .with_spacing(1);
     let offer = ProposedDimensions {
@@ -101,9 +101,9 @@ fn infinite_height_offer_results_in_sum_of_subview_heights_minus_empties() {
 #[test]
 fn compact_height_offer_results_in_sum_of_subview_heights_minus_empties() {
     let vstack = VStack::new((
-        Rectangle.frame().with_width(3).with_height(8),
+        Rectangle.frame().with_size(3, 8),
         EmptyView,
-        Rectangle.frame().with_width(8).with_height(200),
+        Rectangle.frame().with_size(8, 200),
     ))
     .with_spacing(1);
     let offer = ProposedDimensions {

--- a/tests/vstack.rs
+++ b/tests/vstack.rs
@@ -50,9 +50,9 @@ fn test_oversized_layout_3() {
 #[test]
 fn infinite_height_offer_results_in_sum_of_subview_heights() {
     let vstack = VStack::new((
-        Rectangle.frame().with_size(3, 8),
-        Rectangle.frame().with_size(1, 40),
-        Rectangle.frame().with_size(8, 200),
+        Rectangle.frame_sized(3, 8),
+        Rectangle.frame_sized(1, 40),
+        Rectangle.frame_sized(8, 200),
     ))
     .with_spacing(1);
     let offer = ProposedDimensions {
@@ -67,9 +67,9 @@ fn infinite_height_offer_results_in_sum_of_subview_heights() {
 #[test]
 fn compact_height_offer_results_in_sum_of_subview_heights() {
     let vstack = VStack::new((
-        Rectangle.frame().with_size(3, 8),
-        Rectangle.frame().with_size(1, 40),
-        Rectangle.frame().with_size(8, 200),
+        Rectangle.frame_sized(3, 8),
+        Rectangle.frame_sized(1, 40),
+        Rectangle.frame_sized(8, 200),
     ))
     .with_spacing(1);
     let offer = ProposedDimensions {
@@ -84,9 +84,9 @@ fn compact_height_offer_results_in_sum_of_subview_heights() {
 #[test]
 fn infinite_height_offer_results_in_sum_of_subview_heights_minus_empties() {
     let vstack = VStack::new((
-        Rectangle.frame().with_size(3, 8),
+        Rectangle.frame_sized(3, 8),
         EmptyView,
-        Rectangle.frame().with_size(8, 200),
+        Rectangle.frame_sized(8, 200),
     ))
     .with_spacing(1);
     let offer = ProposedDimensions {
@@ -101,9 +101,9 @@ fn infinite_height_offer_results_in_sum_of_subview_heights_minus_empties() {
 #[test]
 fn compact_height_offer_results_in_sum_of_subview_heights_minus_empties() {
     let vstack = VStack::new((
-        Rectangle.frame().with_size(3, 8),
+        Rectangle.frame_sized(3, 8),
         EmptyView,
-        Rectangle.frame().with_size(8, 200),
+        Rectangle.frame_sized(8, 200),
     ))
     .with_spacing(1);
     let offer = ProposedDimensions {

--- a/tests/zstack.rs
+++ b/tests/zstack.rs
@@ -1,6 +1,6 @@
 use buoyant::environment::DefaultEnvironment;
 use buoyant::font::CharacterBufferFont;
-use buoyant::layout::{HorizontalAlignment, Layout, VerticalAlignment};
+use buoyant::layout::{Alignment, HorizontalAlignment, Layout, VerticalAlignment};
 use buoyant::primitives::{Dimensions, Point, Size};
 use buoyant::render::CharacterRender;
 use buoyant::render::CharacterRenderTarget;
@@ -85,8 +85,7 @@ fn test_render_two_top_leading_alignment() {
         Text::new("a a a\nb b b\nc c c", &font),
         Text::new("xxx", &font),
     ))
-    .with_vertical_alignment(VerticalAlignment::Top)
-    .with_horizontal_alignment(HorizontalAlignment::Leading)
+    .with_alignment(Alignment::TopLeading)
     .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&stack, buffer.size());
@@ -105,8 +104,7 @@ fn test_render_two_top_trailing_alignment() {
         Text::new("a a a\nb b b\nc c c", &font),
         Text::new("xxx", &font),
     ))
-    .with_vertical_alignment(VerticalAlignment::Top)
-    .with_horizontal_alignment(HorizontalAlignment::Trailing)
+    .with_alignment(Alignment::TopTrailing)
     .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&stack, buffer.size());
@@ -163,8 +161,7 @@ fn test_render_two_bottom_leading_alignment() {
         Text::new("a a a\nb b b\nc c c", &font),
         Text::new("xxx", &font),
     ))
-    .with_vertical_alignment(VerticalAlignment::Bottom)
-    .with_horizontal_alignment(HorizontalAlignment::Leading)
+    .with_alignment(Alignment::BottomLeading)
     .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&stack, buffer.size());
@@ -202,8 +199,7 @@ fn test_render_two_bottom_trailing_alignment() {
         Text::new("a a a\nb b b\nc c c", &font),
         Text::new("xxx", &font),
     ))
-    .with_vertical_alignment(VerticalAlignment::Bottom)
-    .with_horizontal_alignment(HorizontalAlignment::Trailing)
+    .with_alignment(Alignment::BottomTrailing)
     .foreground_color(' ');
     let mut buffer = FixedTextBuffer::<6, 5>::default();
     let tree = make_render_tree(&stack, buffer.size());


### PR DESCRIPTION
Adds convenience modifiers for setting frames and alignments

> [!WARNING]
> Another breaking change removing alignment from the `Layout` trait, but it was unused, so not expecting any impact