### PR TITLE
remove Renderable `Color` generic type

### DIFF
--- a/examples/espresso.rs
+++ b/examples/espresso.rs
@@ -205,8 +205,7 @@ impl App {
 
     fn tab_bar(
         tab: Tab,
-    ) -> impl buoyant::render::Renderable<color::Space, Renderables: EmbeddedGraphicsRender<color::Space>>
-    {
+    ) -> impl buoyant::render::Renderable<Renderables: EmbeddedGraphicsRender<color::Space>> {
         HStack::new((
             Self::tab_item("Brew", tab == Tab::Brew),
             Self::tab_item("Clean", tab == Tab::Clean),
@@ -219,10 +218,8 @@ impl App {
     fn tab_item(
         name: &str,
         is_selected: bool,
-    ) -> impl buoyant::render::Renderable<
-        color::Space,
-        Renderables: EmbeddedGraphicsRender<color::Space>,
-    > + use<'_> {
+    ) -> impl buoyant::render::Renderable<Renderables: EmbeddedGraphicsRender<color::Space>> + use<'_>
+    {
         let (text_color, bar_height) = if is_selected {
             (color::ACCENT, 4)
         } else {
@@ -250,8 +247,7 @@ impl App {
 
     fn brew_tab(
         _state: &AppState,
-    ) -> impl buoyant::render::Renderable<color::Space, Renderables: EmbeddedGraphicsRender<color::Space>>
-    {
+    ) -> impl buoyant::render::Renderable<Renderables: EmbeddedGraphicsRender<color::Space>> {
         VStack::new((
             Text::new("Good morning", &font::BODY),
             Text::new(
@@ -269,8 +265,7 @@ impl App {
 
     fn settings_tab(
         state: &AppState,
-    ) -> impl buoyant::render::Renderable<color::Space, Renderables: EmbeddedGraphicsRender<color::Space>>
-    {
+    ) -> impl buoyant::render::Renderable<Renderables: EmbeddedGraphicsRender<color::Space>> {
         VStack::new((
             toggle_text(
                 "Auto (b)rew",

--- a/src/render.rs
+++ b/src/render.rs
@@ -38,7 +38,7 @@ pub use text::Text;
 /// Views may have a matching renderable, like in the case of ``Rectangle``,
 /// which has a concrete size and position. Some views like the frame modifier
 /// do not produce a node at all, and instead insert their subview render tree.
-pub trait Renderable<Color>: Layout {
+pub trait Renderable: Layout {
     type Renderables;
     fn render_tree(
         &self,
@@ -52,13 +52,13 @@ pub trait Renderable<Color>: Layout {
 ///
 /// This trait primarily serves as a shorthand for the more verbose ``Renderable<C, Renderables:
 /// CharacterRender<C>>`` bound
-pub trait CharacterView<C>: Renderable<C, Renderables: CharacterRender<C>> {}
-impl<C, T: Renderable<C, Renderables: CharacterRender<C>>> CharacterView<C> for T {}
+pub trait CharacterView<C>: Renderable<Renderables: CharacterRender<C>> {}
+impl<C, T: Renderable<Renderables: CharacterRender<C>>> CharacterView<C> for T {}
 
 /// A type that does not render, produces no side effects, and has no children.
 pub trait NullRender {}
 
-impl<C, T: NullRender + Layout> Renderable<C> for T {
+impl<T: NullRender + Layout> Renderable for T {
     type Renderables = ();
 
     fn render_tree(
@@ -115,11 +115,11 @@ mod embedded_graphics_rendering {
     /// This trait serves as a shorthand for the more verbose `Renderable<C, Renderables:
     /// EmbeddedGraphicsRender<C>>` bound
     pub trait EmbeddedGraphicsView<C: PixelColor>:
-        Renderable<C, Renderables: EmbeddedGraphicsRender<C>>
+        Renderable<Renderables: EmbeddedGraphicsRender<C>>
     {
     }
 
-    impl<C: PixelColor, T: Renderable<C, Renderables: EmbeddedGraphicsRender<C>>>
+    impl<C: PixelColor, T: Renderable<Renderables: EmbeddedGraphicsRender<C>>>
         EmbeddedGraphicsView<C> for T
     {
     }

--- a/src/view.rs
+++ b/src/view.rs
@@ -240,12 +240,12 @@ pub trait RenderExtensions<C>: Sized {
 }
 
 impl<T: crate::layout::Layout> LayoutExtensions for T {}
-impl<T: Renderable<C>, C> RenderExtensions<C> for T {}
+impl<T: Renderable, C> RenderExtensions<C> for T {}
 
 // TODO: Remove this
 pub fn make_render_tree<C, V>(view: &V, size: Size) -> V::Renderables
 where
-    V: Renderable<C>,
+    V: Renderable,
     V::Renderables: CharacterRender<C>,
 {
     let env = DefaultEnvironment::default();

--- a/src/view/divider.rs
+++ b/src/view/divider.rs
@@ -58,7 +58,7 @@ impl Layout for Divider {
     }
 }
 
-impl<C> Renderable<C> for Divider {
+impl Renderable for Divider {
     type Renderables = crate::render::Rect;
 
     fn render_tree(

--- a/src/view/foreach.rs
+++ b/src/view/foreach.rs
@@ -147,7 +147,7 @@ where
     }
 }
 
-impl<'a, const N: usize, I, V: Renderable<C>, C, F> Renderable<C> for ForEachView<'a, N, I, V, F>
+impl<'a, const N: usize, I, V: Renderable, F> Renderable for ForEachView<'a, N, I, V, F>
 where
     F: Fn(&'a I) -> V,
 {

--- a/src/view/hstack.rs
+++ b/src/view/hstack.rs
@@ -238,7 +238,7 @@ macro_rules! impl_layout_for_hstack {
             }
         }
 
-        impl<$($type: Renderable<C>),+, C> Renderable<C> for HStack<($($type),+)> {
+        impl<$($type: Renderable),+> Renderable for HStack<($($type),+)> {
             type Renderables = ($($type::Renderables),+);
 
             #[allow(unused_assignments)]

--- a/src/view/image.rs
+++ b/src/view/image.rs
@@ -41,7 +41,7 @@ impl<T: OriginDimensions> Layout for Image<'_, T> {
 }
 
 #[cfg(feature = "embedded-graphics")]
-impl<'a, C, T: ImageDrawable> Renderable<C> for Image<'a, T> {
+impl<'a, T: ImageDrawable> Renderable for Image<'a, T> {
     type Renderables = render::Image<'a, T>;
 
     fn render_tree(

--- a/src/view/match_view.rs
+++ b/src/view/match_view.rs
@@ -254,7 +254,7 @@ impl<V0: Layout, V1: Layout, V2: Layout> Layout for MatchView<Branch3<V0, V1, V2
     }
 }
 
-impl<V0: Renderable<C>, V1: Renderable<C>, C> Renderable<C> for MatchView<Branch2<V0, V1>> {
+impl<V0: Renderable, V1: Renderable> Renderable for MatchView<Branch2<V0, V1>> {
     type Renderables = OneOf2<V0::Renderables, V1::Renderables>;
 
     fn render_tree(
@@ -276,7 +276,7 @@ impl<V0: Renderable<C>, V1: Renderable<C>, C> Renderable<C> for MatchView<Branch
     }
 }
 
-impl<V0: Renderable<C>, V1: Renderable<C>, V2: Renderable<C>, C> Renderable<C>
+impl<V0: Renderable, V1: Renderable, V2: Renderable> Renderable
     for MatchView<Branch3<V0, V1, V2>>
 {
     type Renderables = OneOf3<V0::Renderables, V1::Renderables, V2::Renderables>;

--- a/src/view/modifier/animated.rs
+++ b/src/view/modifier/animated.rs
@@ -41,7 +41,7 @@ impl<T: Layout, U> Layout for Animated<T, U> {
     }
 }
 
-impl<T: Renderable<C>, C, U: PartialEq + Clone> Renderable<C> for Animated<T, U> {
+impl<T: Renderable, U: PartialEq + Clone> Renderable for Animated<T, U> {
     type Renderables = Animate<T::Renderables, U>;
 
     fn render_tree(

--- a/src/view/modifier/background.rs
+++ b/src/view/modifier/background.rs
@@ -55,7 +55,7 @@ impl<T: Layout, U: Layout> Layout for BackgroundView<T, U> {
     }
 }
 
-impl<C, T: Renderable<C>, U: Renderable<C>> Renderable<C> for BackgroundView<T, U> {
+impl<T: Renderable, U: Renderable> Renderable for BackgroundView<T, U> {
     // Tuples are rendered first to last
     type Renderables = (U::Renderables, T::Renderables);
 

--- a/src/view/modifier/fixed_frame.rs
+++ b/src/view/modifier/fixed_frame.rs
@@ -101,7 +101,7 @@ impl<V: Layout> Layout for FixedFrame<V> {
     }
 }
 
-impl<T: Renderable<C>, C> Renderable<C> for FixedFrame<T> {
+impl<T: Renderable> Renderable for FixedFrame<T> {
     type Renderables = T::Renderables;
 
     fn render_tree(

--- a/src/view/modifier/fixed_size.rs
+++ b/src/view/modifier/fixed_size.rs
@@ -61,7 +61,7 @@ impl<V: Layout> Layout for FixedSize<V> {
     }
 }
 
-impl<T: Renderable<C>, C> Renderable<C> for FixedSize<T> {
+impl<T: Renderable> Renderable for FixedSize<T> {
     type Renderables = T::Renderables;
 
     fn render_tree(

--- a/src/view/modifier/flex_frame.rs
+++ b/src/view/modifier/flex_frame.rs
@@ -237,7 +237,7 @@ fn greatest_possible(proposal: ProposedDimension, ideal: Dimension) -> Dimension
     }
 }
 
-impl<T: Renderable<C>, C> Renderable<C> for FlexFrame<T> {
+impl<T: Renderable, > Renderable for FlexFrame<T> {
     type Renderables = T::Renderables;
 
     fn render_tree(

--- a/src/view/modifier/foreground_color.rs
+++ b/src/view/modifier/foreground_color.rs
@@ -38,7 +38,7 @@ impl<Inner: Layout, Color> Layout for ForegroundStyle<Inner, Color> {
     }
 }
 
-impl<C: Clone, V: Renderable<C>> Renderable<C> for ForegroundStyle<V, C> {
+impl<C: Clone, V: Renderable> Renderable for ForegroundStyle<V, C> {
     type Renderables = ShadeSubtree<C, V::Renderables>;
 
     fn render_tree(

--- a/src/view/modifier/geometry_group.rs
+++ b/src/view/modifier/geometry_group.rs
@@ -36,7 +36,7 @@ impl<T: Layout> Layout for GeometryGroup<T> {
     }
 }
 
-impl<T: Renderable<C>, C> Renderable<C> for GeometryGroup<T> {
+impl<T: Renderable, > Renderable for GeometryGroup<T> {
     type Renderables = Offset<T::Renderables>;
 
     fn render_tree(

--- a/src/view/modifier/hidden.rs
+++ b/src/view/modifier/hidden.rs
@@ -38,7 +38,7 @@ impl<T: Layout> Layout for Hidden<T> {
     }
 }
 
-impl<C, T: Renderable<C>> Renderable<C> for Hidden<T> {
+impl<T: Renderable> Renderable for Hidden<T> {
     // Render nothing
     type Renderables = ();
 

--- a/src/view/modifier/padding.rs
+++ b/src/view/modifier/padding.rs
@@ -78,7 +78,7 @@ impl<V: Layout> Layout for Padding<V> {
     }
 }
 
-impl<T: Renderable<C>, C> Renderable<C> for Padding<T> {
+impl<T: Renderable> Renderable for Padding<T> {
     type Renderables = T::Renderables;
 
     fn render_tree(

--- a/src/view/modifier/priority.rs
+++ b/src/view/modifier/priority.rs
@@ -49,7 +49,7 @@ impl<V: Layout> Layout for Priority<V> {
     }
 }
 
-impl<T: Renderable<C>, C> Renderable<C> for Priority<T> {
+impl<T: Renderable, > Renderable for Priority<T> {
     type Renderables = T::Renderables;
 
     fn render_tree(

--- a/src/view/shape/capsule.rs
+++ b/src/view/shape/capsule.rs
@@ -24,7 +24,7 @@ impl Layout for Capsule {
     }
 }
 
-impl<C> Renderable<C> for Capsule {
+impl Renderable for Capsule {
     type Renderables = crate::render::Capsule;
 
     fn render_tree(

--- a/src/view/shape/circle.rs
+++ b/src/view/shape/circle.rs
@@ -35,7 +35,7 @@ impl Layout for Circle {
     }
 }
 
-impl<C> Renderable<C> for Circle {
+impl Renderable for Circle {
     type Renderables = crate::render::Circle;
 
     fn render_tree(

--- a/src/view/shape/rectangle.rs
+++ b/src/view/shape/rectangle.rs
@@ -35,7 +35,7 @@ impl Layout for Rectangle {
     }
 }
 
-impl<C> Renderable<C> for Rectangle {
+impl Renderable for Rectangle {
     type Renderables = crate::render::Rect;
 
     fn render_tree(

--- a/src/view/shape/rounded_rectangle.rs
+++ b/src/view/shape/rounded_rectangle.rs
@@ -32,7 +32,7 @@ impl Layout for RoundedRectangle {
     }
 }
 
-impl<C> Renderable<C> for RoundedRectangle {
+impl Renderable for RoundedRectangle {
     type Renderables = crate::render::RoundedRect;
 
     fn render_tree(

--- a/src/view/text.rs
+++ b/src/view/text.rs
@@ -91,7 +91,7 @@ impl<T: AsRef<str>, F: FontLayout> Layout for Text<'_, T, F> {
     }
 }
 
-impl<'a, T: AsRef<str> + Clone, C, F: FontLayout> Renderable<C> for Text<'a, T, F> {
+impl<'a, T: AsRef<str> + Clone, F: FontLayout> Renderable for Text<'a, T, F> {
     type Renderables = render::Text<'a, T, F>;
 
     fn render_tree(

--- a/src/view/vstack.rs
+++ b/src/view/vstack.rs
@@ -228,7 +228,7 @@ macro_rules! impl_layout_for_vstack {
             }
         }
 
-        impl<$($type: Renderable<C>),+, C> Renderable<C> for VStack<($($type),+)> {
+        impl<$($type: Renderable),+> Renderable for VStack<($($type),+)> {
             type Renderables = ($($type::Renderables),+);
 
             #[allow(unused_assignments)]

--- a/src/view/zstack.rs
+++ b/src/view/zstack.rs
@@ -119,7 +119,7 @@ macro_rules! impl_layout_for_zstack {
             }
         }
 
-        impl<$($type: Renderable<C>),+, C> Renderable<C> for ZStack<($($type),+)> {
+        impl<$($type: Renderable),+> Renderable for ZStack<($($type),+)> {
             type Renderables = ($($type::Renderables),+);
 
             fn render_tree(


### PR DESCRIPTION
Hi, while trying a quick example from my Docs issue
```rs
fn main() {
	let mut display = SimulatorDisplay::<BinaryColor>::new(Size::new(128, 64));
	let output_settings = OutputSettingsBuilder::new()
		.theme(BinaryColorTheme::OledBlue)
		.build();
	let mut window = Window::new("ceceti screen", &output_settings);

	let view = HStack::new((
		Text::new("toto", &FONT_7X14),
		Spacer::default(),
		Text::new(">", &FONT_7X14),
	));

	let resolved_layout = view.layout(
		&display.bounding_box().size.into(),
		&DefaultEnvironment::non_animated(),
	);

	let tree = view.render_tree(
		&resolved_layout,
		Point::zero(),
		&DefaultEnvironment::non_animated(),
	);

	tree.render(&mut display, &BinaryColor::On, Point::zero());

	window.show_static(&display);
}
```

I stumbled upon a compile error
```
error[E0282]: type annotations needed
  --> crates\ui\examples\display-tests.rs:42:18
   |
42 |     let tree = view.render_tree(
   |                     ^^^^^^^^^^^ cannot infer type for type parameter `C`
```

I currently fixed it by doing
```rs
let tree = buoyant::render::Renderable::<BinaryColor>::render_tree(
	&view,
	&resolved_layout,
	Point::zero(),
	&DefaultEnvironment::non_animated(),
);
```

But, looking into buoyant source code it seems like that `C` parameter is never used. 
Even the quickstart & espresso examples (using diverse colors) are fine when removing this parameter. 
I wonder if it's fine to remove it completly or are you planning on using it later on ?
