### PR TITLE
impl render and layout traits for single member tuple collections

### DIFF
--- a/src/render/collections.rs
+++ b/src/render/collections.rs
@@ -3,7 +3,7 @@ use crate::primitives::Point;
 
 macro_rules! impl_join_for_collections {
     ($(($n:tt, $type:ident)),+) => {
-        impl<$($type: crate::render::AnimatedJoin),+> crate::render::AnimatedJoin for ($($type),+) {
+        impl<$($type: crate::render::AnimatedJoin),+> crate::render::AnimatedJoin for ($($type,)+) {
             fn join(
                 source: Self,
                 target: Self,
@@ -25,6 +25,7 @@ macro_rules! impl_join_for_collections {
 
 #[rustfmt::skip]
 mod impl_join {
+    impl_join_for_collections!((0, T0));
     impl_join_for_collections!((0, T0), (1, T1));
     impl_join_for_collections!((0, T0), (1, T1), (2, T2));
     impl_join_for_collections!((0, T0), (1, T1), (2, T2), (3, T3));
@@ -56,7 +57,7 @@ mod embedded_graphics_impl {
 
     macro_rules! impl_render_for_collections {
     ($(($n:tt, $type:ident)),+) => {
-        impl<Color: embedded_graphics_core::pixelcolor::PixelColor, $($type: crate::render::EmbeddedGraphicsRender<Color> ),+> crate::render::EmbeddedGraphicsRender<Color> for ($($type),+) {
+        impl<Color: embedded_graphics_core::pixelcolor::PixelColor, $($type: crate::render::EmbeddedGraphicsRender<Color> ),+> crate::render::EmbeddedGraphicsRender<Color> for ($($type,)+) {
             fn render(
                 &self,
                 target: &mut impl embedded_graphics_core::draw_target::DrawTarget<Color = Color>,
@@ -93,6 +94,7 @@ mod embedded_graphics_impl {
 
     #[rustfmt::skip]
     mod impl_render {
+        impl_render_for_collections!((0, T0));
         impl_render_for_collections!((0, T0), (1, T1));
         impl_render_for_collections!((0, T0), (1, T1), (2, T2));
         impl_render_for_collections!((0, T0), (1, T1), (2, T2), (3, T3));
@@ -137,7 +139,7 @@ mod embedded_graphics_impl {
 
 macro_rules! impl_char_render_for_collections {
     ($(($n:tt, $type:ident)),+) => {
-        impl<Color, $($type: crate::render::CharacterRender<Color> ),+> crate::render::CharacterRender<Color> for ($($type),+) {
+        impl<Color, $($type: crate::render::CharacterRender<Color> ),+> crate::render::CharacterRender<Color> for ($($type,)+) {
             fn render(
                 &self,
                 target: &mut impl crate::render::CharacterRenderTarget<Color = Color>,
@@ -174,6 +176,7 @@ macro_rules! impl_char_render_for_collections {
 
 #[rustfmt::skip]
 mod impl_char_render {
+    impl_char_render_for_collections!((0, T0));
     impl_char_render_for_collections!((0, T0), (1, T1));
     impl_char_render_for_collections!((0, T0), (1, T1), (2, T2));
     impl_char_render_for_collections!((0, T0), (1, T1), (2, T2), (3, T3));

--- a/src/view/hstack.rs
+++ b/src/view/hstack.rs
@@ -201,8 +201,8 @@ macro_rules! count {
 macro_rules! impl_layout_for_hstack {
     ($(($n:tt, $type:ident)),+) => {
         paste! {
-        impl<$($type: Layout),+> Layout for HStack<($($type),+)> {
-            type Sublayout = ($(ResolvedLayout<$type::Sublayout>),+);
+        impl<$($type: Layout),+> Layout for HStack<($($type,)+)> {
+            type Sublayout = ($(ResolvedLayout<$type::Sublayout>,)+);
 
             fn layout(
                 &self,
@@ -231,15 +231,15 @@ macro_rules! impl_layout_for_hstack {
                 let total_size = layout_n(&mut subviews, *offer, self.spacing);
                 ResolvedLayout {
                     sublayouts: ($(
-                        [<c $n>] .unwrap()
-                    ),+),
+                        [<c $n>] .unwrap(),
+                    )+),
                     resolved_size: total_size,
                 }
             }
         }
 
-        impl<$($type: Renderable<C>),+, C> Renderable<C> for HStack<($($type),+)> {
-            type Renderables = ($($type::Renderables),+);
+        impl<$($type: Renderable<C>),+, C> Renderable<C> for HStack<($($type,)+)> {
+            type Renderables = ($($type::Renderables,)+);
 
             #[allow(unused_assignments)]
             fn render_tree(
@@ -271,13 +271,14 @@ macro_rules! impl_layout_for_hstack {
                     }
                 )+
 
-                ($([<subtree_$n>]),+)
+                ($([<subtree_$n>],)+)
             }
         }
     }
     }
 }
 
+impl_layout_for_hstack!((0, T0));
 impl_layout_for_hstack!((0, T0), (1, T1));
 impl_layout_for_hstack!((0, T0), (1, T1), (2, T2));
 impl_layout_for_hstack!((0, T0), (1, T1), (2, T2), (3, T3));

--- a/src/view/vstack.rs
+++ b/src/view/vstack.rs
@@ -190,8 +190,8 @@ use paste::paste;
 macro_rules! impl_layout_for_vstack {
     ($(($n:tt, $type:ident)),+) => {
         paste! {
-        impl<$($type: Layout),+> Layout for VStack<($($type),+)> {
-            type Sublayout = ($(ResolvedLayout<$type::Sublayout>),+);
+        impl<$($type: Layout),+> Layout for VStack<($($type,)+)> {
+            type Sublayout = ($(ResolvedLayout<$type::Sublayout>,)+);
 
             fn layout(
                 &self,
@@ -222,14 +222,14 @@ macro_rules! impl_layout_for_vstack {
 
                 let total_size = layout_n(&mut subviews, *offer, self.spacing);
                 ResolvedLayout {
-                    sublayouts: ($([<c$n>].unwrap()),+),
+                    sublayouts: ($([<c$n>].unwrap(),)+),
                     resolved_size: total_size,
                 }
             }
         }
 
-        impl<$($type: Renderable<C>),+, C> Renderable<C> for VStack<($($type),+)> {
-            type Renderables = ($($type::Renderables),+);
+        impl<$($type: Renderable<C>),+, C> Renderable<C> for VStack<($($type,)+)> {
+            type Renderables = ($($type::Renderables,)+);
 
             #[allow(unused_assignments)]
             fn render_tree(
@@ -262,7 +262,7 @@ macro_rules! impl_layout_for_vstack {
                     }
                 )+
 
-                ($([<subtree_$n>]),+)
+                ($([<subtree_$n>],)+)
             }
         }
     }
@@ -282,6 +282,7 @@ macro_rules! count {
     ($head:tt $(, $rest:tt)*) => (1 + count!($($rest),*));
 }
 
+impl_layout_for_vstack!((0, T0));
 impl_layout_for_vstack!((0, T0), (1, T1));
 impl_layout_for_vstack!((0, T0), (1, T1), (2, T2));
 impl_layout_for_vstack!((0, T0), (1, T1), (2, T2), (3, T3));

--- a/src/view/zstack.rs
+++ b/src/view/zstack.rs
@@ -81,8 +81,8 @@ impl<T> ZStack<T> {
 macro_rules! impl_layout_for_zstack {
     ($(($n:tt, $type:ident)),+) => {
         paste! {
-        impl<$($type: Layout),+> Layout for ZStack<($($type),+)> {
-            type Sublayout = ($(ResolvedLayout<$type::Sublayout>),+);
+        impl<$($type: Layout),+> Layout for ZStack<($($type,)+)> {
+            type Sublayout = ($(ResolvedLayout<$type::Sublayout>,)+);
 
             fn layout(
                 &self,
@@ -112,15 +112,15 @@ macro_rules! impl_layout_for_zstack {
 
                 ResolvedLayout {
                     sublayouts: ($(
-                        [<layout$n>]
-                    ),+),
+                        [<layout$n>],
+                    )+),
                     resolved_size: size.intersecting_proposal(offer),
                 }
             }
         }
 
-        impl<$($type: Renderable<C>),+, C> Renderable<C> for ZStack<($($type),+)> {
-            type Renderables = ($($type::Renderables),+);
+        impl<$($type: Renderable<C>),+, C> Renderable<C> for ZStack<($($type,)+)> {
+            type Renderables = ($($type::Renderables,)+);
 
             fn render_tree(
                 &self,
@@ -144,8 +144,8 @@ macro_rules! impl_layout_for_zstack {
 
                 (
                     $(
-                        self.items.$n.render_tree(&layout.sublayouts.$n, [<offset_$n>], env)
-                    ),+
+                        self.items.$n.render_tree(&layout.sublayouts.$n, [<offset_$n>], env),
+                    )+
                 )
             }
         }
@@ -153,6 +153,7 @@ macro_rules! impl_layout_for_zstack {
     }
 }
 
+impl_layout_for_zstack!((0, T0));
 impl_layout_for_zstack!((0, T0), (1, T1));
 impl_layout_for_zstack!((0, T0), (1, T1), (2, T2));
 impl_layout_for_zstack!((0, T0), (1, T1), (2, T2), (3, T3));


### PR DESCRIPTION
Hi, I tired centering a  single text in a VStack
```rs
fn title() -> impl EmbeddedGraphicsView<super::PixelColor> {
	// also tried VStack::new( Text::new("Main", &super::TITLE_FONT) )
	VStack::new((Text::new("Main", &super::TITLE_FONT),))
		.with_alignment(HorizontalAlignment::Center)
}
```
But such stack doesn't implement the `EmbeddedGraphicsView` trait.
I found why here
<img width="506" alt="{36AFAB51-7F18-4038-8400-1F6EAAA08AE3}" src="https://github.com/user-attachments/assets/86671aff-740d-4dbf-931b-50fb609c2e3e" />
This PR adds implementations for *stacks and collections to support the `(T, )` tuple type in addition to all the other already in use.

Did some testing and updated code seems to be working as expected