### PR TITLE
Consolidate Layout/RenderExtensions into ViewExt

### DIFF
--- a/docs/book/src/animation/compound-animation.md
+++ b/docs/book/src/animation/compound-animation.md
@@ -33,7 +33,7 @@ together relative to the geometry group frame.
 #     view::{
 #         padding::Edges,
 #         shape::{Capsule, Circle},
-#         LayoutExtensions as _, RenderExtensions as _, ZStack,
+#         ViewExt as _, ZStack,
 #     },
 # };
 # use embedded_graphics::{pixelcolor::Rgb888, prelude::RgbColor as _};

--- a/docs/book/src/animation/render-trees.md
+++ b/docs/book/src/animation/render-trees.md
@@ -18,7 +18,7 @@ This tree is what is actually rendered.
 #     view::{
 #         padding::Edges,
 #         shape::{Capsule, Circle},
-#         LayoutExtensions as _, RenderExtensions as _, ZStack,
+#         ViewExt as _, ZStack,
 #     },
 # };
 # use embedded_graphics::{pixelcolor::Rgb888, prelude::RgbColor as _};

--- a/docs/book/src/animation/transitions.md
+++ b/docs/book/src/animation/transitions.md
@@ -17,7 +17,7 @@ views when all the branches are the same type:
 # use buoyant::{
 #     if_view,
 #     render::EmbeddedGraphicsView,
-#     view::{shape::Rectangle, LayoutExtensions},
+#     view::{shape::Rectangle, ViewExt},
 # };
 # use embedded_graphics::pixelcolor::Rgb888;
 # 

--- a/docs/book/src/building-views/alignment.md
+++ b/docs/book/src/building-views/alignment.md
@@ -53,7 +53,7 @@ you could set ``VerticalAlignment::Top``.
 use buoyant::layout::VerticalAlignment;
 use buoyant::view::shape::{Circle, Rectangle};
 use buoyant::view::HStack;
-use buoyant::view::RenderExtensions as _;
+use buoyant::view::ViewExt as _;
 use buoyant::render::EmbeddedGraphicsView;
 
 fn view() -> impl EmbeddedGraphicsView<Rgb888> {

--- a/docs/book/src/building-views/collections.md
+++ b/docs/book/src/building-views/collections.md
@@ -51,7 +51,7 @@ better choice. Use ForEach when you want to display a collection of like views.
 use buoyant::layout::HorizontalAlignment;
 use buoyant::view::padding::Edges;
 use buoyant::view::{shape::RoundedRectangle, ForEach, HStack, Text};
-use buoyant::view::{LayoutExtensions as _, RenderExtensions as _};
+use buoyant::view::{ViewExt as _};
 use embedded_graphics::{mono_font::ascii::FONT_9X15, pixelcolor::Rgb888, prelude::*};
 
 static SWATCHES: [Swatch; 4] = [

--- a/docs/book/src/building-views/conditional-views.md
+++ b/docs/book/src/building-views/conditional-views.md
@@ -62,7 +62,7 @@ The `if_view!` macro allows you to write views as if you were writing a plain `i
 # }
 #
 use buoyant::if_view;
-use buoyant::view::{padding::Edges, shape::RoundedRectangle, LayoutExtensions as _, Text, VStack};
+use buoyant::view::{padding::Edges, shape::RoundedRectangle, ViewExt as _, Text, VStack};
 use embedded_graphics::{mono_font::ascii::FONT_9X15, pixelcolor::Rgb888, prelude::*};
 
 fn secret_message(message: &str, is_redacted: bool) -> impl EmbeddedGraphicsView<Rgb888> + use<'_> {
@@ -131,7 +131,7 @@ variables in the match arms.
 #
 use buoyant::match_view;
 use buoyant::view::shape::{Rectangle, RoundedRectangle};
-use buoyant::view::{padding::Edges, LayoutExtensions as _, RenderExtensions as _, VStack};
+use buoyant::view::{padding::Edges, ViewExt as _, VStack};
 use embedded_graphics::{pixelcolor::Rgb888, prelude::*};
 
 #[derive(Debug, Clone, Copy)]

--- a/docs/book/src/building-views/mixed-alignment.md
+++ b/docs/book/src/building-views/mixed-alignment.md
@@ -52,7 +52,7 @@ I'll briefly indulge this misconception.
 // No!
 use buoyant::layout::HorizontalAlignment;
 use buoyant::view::shape::Circle;
-use buoyant::view::RenderExtensions as _;
+use buoyant::view::ViewExt as _;
 use buoyant::view::{HStack, Spacer, VStack};
 use buoyant::render::EmbeddedGraphicsView;
 
@@ -143,7 +143,7 @@ as the previous code.
 use buoyant::layout::HorizontalAlignment;
 use buoyant::view::shape::Circle;
 use buoyant::view::VStack;
-use buoyant::view::{LayoutExtensions as _, RenderExtensions as _};
+use buoyant::view::ViewExt as _;
 use buoyant::render::EmbeddedGraphicsView;
 
 fn view() -> impl EmbeddedGraphicsView<Rgb888> {
@@ -173,7 +173,7 @@ the alignment in one call.
 ```rust
 # extern crate buoyant;
 # use buoyant::layout::HorizontalAlignment;
-# use buoyant::view::LayoutExtensions as _;
+# use buoyant::view::ViewExt as _;
 # use buoyant::view::{shape::Circle, HStack, Spacer};
 # let content = Circle;
 // Avoid:
@@ -201,7 +201,7 @@ content
 ```rust
 # extern crate buoyant;
 # use buoyant::layout::VerticalAlignment;
-# use buoyant::view::LayoutExtensions as _;
+# use buoyant::view::ViewExt as _;
 # use buoyant::view::{shape::Circle, VStack, Spacer};
 # let content = Circle;
 // Avoid:

--- a/docs/book/src/building-views/separating-views.md
+++ b/docs/book/src/building-views/separating-views.md
@@ -41,7 +41,7 @@ Here, `Spacer` is used to push the two `Circle`s to either side.
 # 
 use buoyant::layout::HorizontalAlignment;
 use buoyant::view::shape::{Capsule, Circle, Rectangle};
-use buoyant::view::RenderExtensions as _;
+use buoyant::view::ViewExt as _;
 use buoyant::view::{HStack, Spacer, VStack};
 use buoyant::render::EmbeddedGraphicsView;
 

--- a/docs/book/src/building-views/stack-spacing.md
+++ b/docs/book/src/building-views/stack-spacing.md
@@ -43,7 +43,7 @@ You can configure the spacing between child views using `.with_spacing`.
 # 
 use buoyant::layout::HorizontalAlignment;
 use buoyant::view::shape::{Capsule, Circle, Rectangle};
-use buoyant::view::RenderExtensions as _;
+use buoyant::view::ViewExt as _;
 use buoyant::view::VStack;
 use buoyant::render::EmbeddedGraphicsView;
 
@@ -104,7 +104,7 @@ use buoyant::layout::{HorizontalAlignment, VerticalAlignment};
 use buoyant::view::padding::Edges;
 use buoyant::view::shape::Circle;
 use buoyant::view::{HStack, Text, VStack};
-use buoyant::view::{LayoutExtensions as _, RenderExtensions as _};
+use buoyant::view::ViewExt as _;
 use buoyant::render::EmbeddedGraphicsView;
 use embedded_graphics::{
     mono_font::ascii::{FONT_7X13, FONT_9X15, FONT_9X15_BOLD},

--- a/docs/book/src/building-views/stacks.md
+++ b/docs/book/src/building-views/stacks.md
@@ -42,7 +42,7 @@ Both stacks can contain a heterogeneous set of views and can be nested inside ot
 # 
 use buoyant::view::shape::{Circle, Rectangle};
 use buoyant::view::HStack;
-use buoyant::view::RenderExtensions as _;
+use buoyant::view::ViewExt as _;
 use buoyant::render::EmbeddedGraphicsView;
 
 fn view() -> impl EmbeddedGraphicsView<Rgb888> {
@@ -101,7 +101,7 @@ it can contain a heterogeneous set of views.
 # 
 use buoyant::view::padding::Edges;
 use buoyant::view::shape::{Circle, Rectangle};
-use buoyant::view::{LayoutExtensions as _, RenderExtensions as _};
+use buoyant::view::ViewExt as _;
 use buoyant::view::ZStack;
 use buoyant::render::EmbeddedGraphicsView;
 
@@ -161,7 +161,7 @@ Stacks can be nested to create complex layouts.
 # 
 use buoyant::view::padding::Edges;
 use buoyant::view::shape::{Circle, Rectangle};
-use buoyant::view::{LayoutExtensions as _, RenderExtensions as _};
+use buoyant::view::ViewExt as _;
 use buoyant::view::{HStack, VStack, ZStack};
 use buoyant::render::EmbeddedGraphicsView;
 

--- a/docs/book/src/quickstart.md
+++ b/docs/book/src/quickstart.md
@@ -75,7 +75,7 @@ If this view involved animation, the environment would be used to inject the tim
 # extern crate buoyant;
 # extern crate embedded_graphics;
 #
-# use buoyant::view::{padding::Edges, HStack, LayoutExtensions as _, RenderExtensions as _, Spacer, Text};
+# use buoyant::view::{padding::Edges, HStack, ViewExt as _, Spacer, Text};
 # use buoyant::render::EmbeddedGraphicsView;
 # use embedded_graphics::{mono_font::ascii::FONT_10X20, pixelcolor::Rgb888, prelude::*};
 #

--- a/docs/book/src/quickstart.rs
+++ b/docs/book/src/quickstart.rs
@@ -4,7 +4,7 @@ use buoyant::{
     environment::DefaultEnvironment,
     layout::Layout,
     render::{EmbeddedGraphicsRender as _, EmbeddedGraphicsView, Renderable as _},
-    view::{padding::Edges, HStack, LayoutExtensions as _, RenderExtensions as _, Spacer, Text},
+    view::{padding::Edges, HStack, Spacer, Text, ViewExt as _},
 };
 use embedded_graphics::{mono_font::ascii::FONT_10X20, pixelcolor::Rgb888, prelude::*};
 use embedded_graphics_simulator::{OutputSettings, SimulatorDisplay, Window};

--- a/examples/crossterm.rs
+++ b/examples/crossterm.rs
@@ -4,7 +4,7 @@ use buoyant::render::CharacterRender;
 use buoyant::render::CharacterRenderTarget;
 use buoyant::render::CharacterView;
 use buoyant::view::padding::Edges;
-use buoyant::view::{make_render_tree, LayoutExtensions, RenderExtensions};
+use buoyant::view::{make_render_tree, ViewExt};
 use buoyant::{
     layout::VerticalAlignment,
     render_target::CrosstermRenderTarget,

--- a/examples/espresso.rs
+++ b/examples/espresso.rs
@@ -22,8 +22,7 @@ use buoyant::{
     view::{
         padding::Edges,
         shape::{Circle, Rectangle},
-        HStack, HorizontalTextAlignment, LayoutExtensions as _, RenderExtensions, Text, VStack,
-        ZStack,
+        HStack, HorizontalTextAlignment, Text, VStack, ViewExt as _, ZStack,
     },
 };
 use embedded_graphics::prelude::*;

--- a/examples/profiler.rs
+++ b/examples/profiler.rs
@@ -8,8 +8,7 @@ use buoyant::{
     primitives::Size,
     render_target::FixedTextBuffer,
     view::{
-        make_render_tree, Divider, HStack, HorizontalTextAlignment, LayoutExtensions,
-        RenderExtensions as _, Spacer, Text, VStack,
+        make_render_tree, Divider, HStack, HorizontalTextAlignment, Spacer, Text, VStack, ViewExt,
     },
 };
 

--- a/examples/quickstart.rs
+++ b/examples/quickstart.rs
@@ -9,7 +9,7 @@ use buoyant::{
     environment::DefaultEnvironment,
     layout::Layout,
     render::{EmbeddedGraphicsRender as _, EmbeddedGraphicsView, Renderable as _},
-    view::{padding::Edges, HStack, LayoutExtensions as _, RenderExtensions as _, Spacer, Text},
+    view::{padding::Edges, HStack, Spacer, Text, ViewExt as _},
 };
 use embedded_graphics::{mono_font::ascii::FONT_10X20, pixelcolor::Rgb888, prelude::*};
 use embedded_graphics_simulator::{OutputSettings, SimulatorDisplay, Window};

--- a/src/view.rs
+++ b/src/view.rs
@@ -244,6 +244,80 @@ pub trait ViewExt: Sized {
 
 impl<T: crate::layout::Layout> ViewExt for T {}
 
+#[deprecated(
+    since = "0.5.0",
+    note = "`RenderExtensions` has been replaced with `ViewExt`"
+)]
+pub trait RenderExtensions: ViewExt {
+    fn foreground_color<C>(self, color: C) -> ForegroundStyle<Self, C> {
+        <Self as ViewExt>::foreground_color(self, color)
+    }
+}
+
+#[allow(deprecated)]
+impl<T: crate::layout::Layout> RenderExtensions for T {}
+
+#[deprecated(
+    since = "0.5.0",
+    note = "`LayoutExtensions` has been replaced with `ViewExt`"
+)]
+pub trait LayoutExtensions: ViewExt {
+    fn padding(self, edges: padding::Edges, amount: u16) -> Padding<Self> {
+        <Self as ViewExt>::padding(self, edges, amount)
+    }
+
+    fn frame(self) -> FixedFrame<Self> {
+        <Self as ViewExt>::frame(self)
+    }
+
+    fn frame_sized(self, width: u16, height: u16) -> FixedFrame<Self> {
+        <Self as ViewExt>::frame_sized(self, width, height)
+    }
+
+    fn flex_frame(self) -> FlexFrame<Self> {
+        <Self as ViewExt>::flex_frame(self)
+    }
+
+    fn flex_infinite_width(self, alignment: HorizontalAlignment) -> FlexFrame<Self> {
+        <Self as ViewExt>::flex_infinite_width(self, alignment)
+    }
+
+    fn flex_infinite_height(self, alignment: VerticalAlignment) -> FlexFrame<Self> {
+        <Self as ViewExt>::flex_infinite_height(self, alignment)
+    }
+
+    fn fixed_size(self, horizontal: bool, vertical: bool) -> FixedSize<Self> {
+        <Self as ViewExt>::fixed_size(self, horizontal, vertical)
+    }
+
+    fn priority(self, priority: i8) -> Priority<Self> {
+        <Self as ViewExt>::priority(self, priority)
+    }
+
+    fn animated<T: PartialEq + Clone>(self, animation: Animation, value: T) -> Animated<Self, T> {
+        <Self as ViewExt>::animated(self, animation, value)
+    }
+
+    fn geometry_group(self) -> GeometryGroup<Self> {
+        <Self as ViewExt>::geometry_group(self)
+    }
+
+    fn background<U>(
+        self,
+        alignment: Alignment,
+        background: impl FnOnce() -> U,
+    ) -> BackgroundView<Self, U> {
+        <Self as ViewExt>::background(self, alignment, background)
+    }
+
+    fn hidden(self) -> Hidden<Self> {
+        <Self as ViewExt>::hidden(self)
+    }
+}
+
+#[allow(deprecated)]
+impl<T: crate::layout::Layout> LayoutExtensions for T {}
+
 // TODO: Remove this
 pub fn make_render_tree<C, V>(view: &V, size: Size) -> V::Renderables
 where

--- a/src/view.rs
+++ b/src/view.rs
@@ -39,7 +39,7 @@ use crate::{
 };
 
 /// Modifiers that extend the functionality of views.
-pub trait LayoutExtensions: Sized {
+pub trait ViewExt: Sized {
     /// Applies padding to the specified edges
     fn padding(self, edges: padding::Edges, amount: u16) -> Padding<Self> {
         Padding::new(edges, amount, self)
@@ -55,7 +55,7 @@ pub trait LayoutExtensions: Sized {
     /// This is a shortcut for:
     ///
     /// ```
-    /// # use buoyant::view::LayoutExtensions as _;
+    /// # use buoyant::view::ViewExt as _;
     /// # let my_view = buoyant::view::shape::Rectangle;
     /// # let width = 100;
     /// # let height = 100;
@@ -74,7 +74,7 @@ pub trait LayoutExtensions: Sized {
     /// Examples:
     ///
     /// ```
-    /// # use buoyant::view::LayoutExtensions as _;
+    /// # use buoyant::view::ViewExt as _;
     /// # use buoyant::layout::Alignment;
     /// # let my_view = buoyant::view::shape::Rectangle;
     /// my_view
@@ -93,7 +93,7 @@ pub trait LayoutExtensions: Sized {
     /// This is a shortcut for:
     ///
     /// ```
-    /// # use buoyant::view::LayoutExtensions as _;
+    /// # use buoyant::view::ViewExt as _;
     /// # let my_view = buoyant::view::shape::Rectangle;
     /// # let alignment = buoyant::layout::HorizontalAlignment::Center;
     /// my_view
@@ -113,7 +113,7 @@ pub trait LayoutExtensions: Sized {
     /// This is a shortcut for:
     ///
     /// ```
-    /// # use buoyant::view::LayoutExtensions as _;
+    /// # use buoyant::view::ViewExt as _;
     /// # use buoyant::layout::VerticalAlignment;
     /// # let my_view = buoyant::view::shape::Rectangle;
     /// # let alignment = VerticalAlignment::Center;
@@ -164,7 +164,7 @@ pub trait LayoutExtensions: Sized {
     ///
     /// ```
     /// use core::time::Duration;
-    /// use buoyant::view::{shape::{Circle, Capsule}, ZStack, padding, LayoutExtensions as _, RenderExtensions as _};
+    /// use buoyant::view::{shape::{Circle, Capsule}, ZStack, padding, ViewExt as _};
     /// use buoyant::animation::Animation;
     /// use buoyant::layout::HorizontalAlignment;
     /// use buoyant::render::{EmbeddedGraphicsView, Renderable};
@@ -200,7 +200,7 @@ pub trait LayoutExtensions: Sized {
     /// Example:
     ///
     /// ```
-    /// use buoyant::view::{padding::Edges, shape::RoundedRectangle, Text, LayoutExtensions as _, RenderExtensions as _};
+    /// use buoyant::view::{padding::Edges, shape::RoundedRectangle, Text, ViewExt as _};
     /// use buoyant::layout::Alignment;
     /// use buoyant::render::{EmbeddedGraphicsView};
     /// use embedded_graphics::{prelude::*, pixelcolor::Rgb565, mono_font::ascii::FONT_9X15_BOLD};
@@ -235,17 +235,14 @@ pub trait LayoutExtensions: Sized {
     fn hidden(self) -> Hidden<Self> {
         Hidden::new(self)
     }
-}
 
-pub trait RenderExtensions<C>: Sized {
     /// Sets the foreground color
-    fn foreground_color(self, color: C) -> ForegroundStyle<Self, C> {
+    fn foreground_color<C>(self, color: C) -> ForegroundStyle<Self, C> {
         ForegroundStyle::new(color, self)
     }
 }
 
-impl<T: crate::layout::Layout> LayoutExtensions for T {}
-impl<T: Renderable, C> RenderExtensions<C> for T {}
+impl<T: crate::layout::Layout> ViewExt for T {}
 
 // TODO: Remove this
 pub fn make_render_tree<C, V>(view: &V, size: Size) -> V::Renderables

--- a/src/view/zstack.rs
+++ b/src/view/zstack.rs
@@ -16,7 +16,7 @@ use paste::paste;
 /// ```rust
 /// use buoyant::font::CharacterBufferFont;
 /// use buoyant::layout::Alignment;
-/// use buoyant::view::{ZStack, shape::Rectangle, Text, RenderExtensions as _};
+/// use buoyant::view::{ZStack, shape::Rectangle, Text, ViewExt as _};
 ///
 /// /// A fish at the bottom right corner of an 'o'cean
 /// let font = CharacterBufferFont {};
@@ -98,7 +98,7 @@ macro_rules! impl_layout_for_zstack {
                     // FIXME: The `.into()` here is almost certainly wrong.
                     // While it would be unusual for a view to respond requesting infinite
                     // width or height in response to a compact request, this does not
-                    // effectively handle it. This also increases the liklihood of overflow
+                    // effectively handle it. This also increases the likelihood of overflow
                     // due to the way Dimension is implemented
                     let offer = ProposedDimensions {
                         width: ProposedDimension::Exact(size.width.into()),

--- a/tests/animation.rs
+++ b/tests/animation.rs
@@ -13,8 +13,8 @@ use buoyant::{
     },
     render_target::FixedTextBuffer,
     view::{
-        make_render_tree, shape::Rectangle, Divider, EmptyView, HorizontalTextAlignment,
-        LayoutExtensions, RenderExtensions as _, Text, VStack, ZStack,
+        make_render_tree, shape::Rectangle, Divider, EmptyView, HorizontalTextAlignment, Text,
+        VStack, ViewExt, ZStack,
     },
 };
 
@@ -373,12 +373,8 @@ fn toggle_switch(is_on: bool, subtext: &str) -> impl CharacterView<char> + use<'
 
     VStack::new((
         ZStack::new((
-            Rectangle
-                .foreground_color('_')
-                .frame_sized(5, 1),
-            Rectangle
-                .foreground_color('#')
-                .frame_sized(1, 1),
+            Rectangle.foreground_color('_').frame_sized(5, 1),
+            Rectangle.foreground_color('#').frame_sized(1, 1),
         ))
         .with_horizontal_alignment(alignment)
         .animated(Animation::linear(Duration::from_secs(1)), is_on),

--- a/tests/background.rs
+++ b/tests/background.rs
@@ -6,7 +6,7 @@ use buoyant::{
     render_target::FixedTextBuffer,
     view::{
         make_render_tree, padding::Edges, shape::Rectangle, EmptyView, HorizontalTextAlignment,
-        LayoutExtensions as _, RenderExtensions as _, Text,
+        Text, ViewExt as _,
     },
 };
 

--- a/tests/conditional_view.rs
+++ b/tests/conditional_view.rs
@@ -5,7 +5,7 @@ use buoyant::primitives::{Point, Size};
 use buoyant::render::CharacterRenderTarget;
 use buoyant::render::{CharacterRender as _, Renderable as _};
 use buoyant::render_target::FixedTextBuffer;
-use buoyant::view::{RenderExtensions as _, Text};
+use buoyant::view::{Text, ViewExt as _};
 use common::TestEnv;
 
 mod common;

--- a/tests/divider.rs
+++ b/tests/divider.rs
@@ -2,7 +2,7 @@ use buoyant::layout::{Layout, LayoutDirection};
 use buoyant::primitives::{Point, Size};
 use buoyant::render::{CharacterRender, CharacterRenderTarget as _, Renderable as _};
 use buoyant::render_target::FixedTextBuffer;
-use buoyant::view::{Divider, RenderExtensions as _};
+use buoyant::view::{Divider, ViewExt as _};
 
 mod common;
 use common::TestEnv;

--- a/tests/fixed_frame.rs
+++ b/tests/fixed_frame.rs
@@ -4,7 +4,7 @@ use buoyant::{
     primitives::{Dimensions, Point, ProposedDimension, ProposedDimensions, Size},
     render::{CharacterRender, CharacterRenderTarget},
     render_target::FixedTextBuffer,
-    view::{make_render_tree, LayoutExtensions, RenderExtensions as _, Text},
+    view::{make_render_tree, Text, ViewExt},
 };
 mod common;
 
@@ -70,8 +70,7 @@ fn test_fixed_height() {
 #[test]
 fn test_fixed_frame_compact_width_height() {
     let font = CharacterBufferFont {};
-    let content = Text::new("123456", &font)
-        .frame_sized(2, 2);
+    let content = Text::new("123456", &font).frame_sized(2, 2);
     let env = common::TestEnv::default();
 
     assert_eq!(
@@ -117,8 +116,7 @@ fn test_fixed_frame_compact_width_height() {
 #[test]
 fn test_fixed_frame_infinite_width_height() {
     let font = CharacterBufferFont {};
-    let content = Text::new("123456", &font)
-        .frame_sized(25, 25);
+    let content = Text::new("123456", &font).frame_sized(25, 25);
     let env = common::TestEnv::default();
 
     assert_eq!(

--- a/tests/flex_frame.rs
+++ b/tests/flex_frame.rs
@@ -3,7 +3,6 @@ use buoyant::primitives::Point;
 use buoyant::render::CharacterRender;
 use buoyant::render::CharacterRenderTarget;
 use buoyant::view::HStack;
-use buoyant::view::RenderExtensions;
 use buoyant::view::Spacer;
 use buoyant::view::VStack;
 use buoyant::{
@@ -12,7 +11,7 @@ use buoyant::{
     layout::{HorizontalAlignment, Layout, VerticalAlignment},
     primitives::{ProposedDimension, ProposedDimensions, Size},
     render_target::FixedTextBuffer,
-    view::{make_render_tree, shape::Rectangle, LayoutExtensions, Text},
+    view::{make_render_tree, shape::Rectangle, Text, ViewExt},
 };
 
 #[test]

--- a/tests/foreach.rs
+++ b/tests/foreach.rs
@@ -2,7 +2,7 @@ use buoyant::primitives::Point;
 use buoyant::render::CharacterRender;
 use buoyant::render::CharacterRenderTarget;
 use buoyant::view::ForEach;
-use buoyant::view::RenderExtensions as _;
+use buoyant::view::ViewExt as _;
 use buoyant::{
     font::CharacterBufferFont,
     layout::{HorizontalAlignment, VerticalAlignment},

--- a/tests/geometry_group.rs
+++ b/tests/geometry_group.rs
@@ -3,7 +3,7 @@ use buoyant::{
     primitives::Point,
     render::{CharacterRender as _, CharacterRenderTarget as _},
     render_target::FixedTextBuffer,
-    view::{make_render_tree, LayoutExtensions as _, RenderExtensions as _, Text, VStack},
+    view::{make_render_tree, Text, VStack, ViewExt as _},
 };
 
 #[test]

--- a/tests/hidden.rs
+++ b/tests/hidden.rs
@@ -6,7 +6,7 @@ use buoyant::{
     primitives::Point,
     render::{CharacterRender as _, CharacterRenderTarget as _},
     render_target::FixedTextBuffer,
-    view::{make_render_tree, HStack, LayoutExtensions as _, RenderExtensions as _, Text},
+    view::{make_render_tree, HStack, Text, ViewExt as _},
 };
 
 #[test]

--- a/tests/hstack.rs
+++ b/tests/hstack.rs
@@ -7,9 +7,9 @@ use buoyant::primitives::{Dimensions, Point, ProposedDimension, ProposedDimensio
 use buoyant::render::{CharacterRender, Renderable};
 use buoyant::render::{CharacterRenderTarget, CharacterView};
 use buoyant::render_target::FixedTextBuffer;
+use buoyant::view::make_render_tree;
 use buoyant::view::padding::Edges;
-use buoyant::view::{make_render_tree, RenderExtensions as _};
-use buoyant::view::{shape::Rectangle, Divider, EmptyView, HStack, LayoutExtensions, Spacer, Text};
+use buoyant::view::{shape::Rectangle, Divider, EmptyView, HStack, Spacer, Text, ViewExt};
 
 #[test]
 fn test_greedy_layout_2() {

--- a/tests/match_view.rs
+++ b/tests/match_view.rs
@@ -6,7 +6,7 @@ use buoyant::primitives::{Point, Size};
 use buoyant::render::{CharacterRender, CharacterView};
 use buoyant::render::{CharacterRenderTarget, Renderable};
 use buoyant::render_target::FixedTextBuffer;
-use buoyant::view::{RenderExtensions as _, Text};
+use buoyant::view::{Text, ViewExt as _};
 use std::string::String;
 
 #[test]

--- a/tests/padding.rs
+++ b/tests/padding.rs
@@ -11,8 +11,8 @@ use buoyant::{
     primitives::{Dimensions, Size},
     render_target::FixedTextBuffer,
     view::{
-        make_render_tree, shape::Rectangle, Divider, HorizontalTextAlignment, LayoutExtensions,
-        RenderExtensions, Spacer, Text, VStack,
+        make_render_tree, shape::Rectangle, Divider, HorizontalTextAlignment, Spacer, Text, VStack,
+        ViewExt,
     },
 };
 
@@ -52,9 +52,7 @@ fn test_clipped_text_trails_correctly() {
 
 #[test]
 fn test_padding_is_oversized_for_oversized_child() {
-    let view = Rectangle
-        .frame_sized(10, 10)
-        .padding(Edges::All, 2);
+    let view = Rectangle.frame_sized(10, 10).padding(Edges::All, 2);
 
     let env = DefaultEnvironment::non_animated();
 

--- a/tests/priority.rs
+++ b/tests/priority.rs
@@ -3,7 +3,7 @@ use buoyant::{
     font::CharacterBufferFont,
     layout::Layout as _,
     primitives::{Dimensions, Size},
-    view::{shape::Rectangle, HStack, LayoutExtensions, Text, VStack},
+    view::{shape::Rectangle, HStack, Text, VStack, ViewExt},
 };
 
 /// The greedy lower priority view with a non-zero min size results in a layout overflow

--- a/tests/spacer.rs
+++ b/tests/spacer.rs
@@ -6,7 +6,7 @@ use buoyant::primitives::{
 use buoyant::render::CharacterRender;
 use buoyant::render::CharacterRenderTarget;
 use buoyant::render_target::FixedTextBuffer;
-use buoyant::view::{make_render_tree, HStack, RenderExtensions as _, Spacer, Text, VStack};
+use buoyant::view::{make_render_tree, HStack, Spacer, Text, VStack, ViewExt as _};
 use common::{collect_text, TestEnv};
 
 mod common;

--- a/tests/text.rs
+++ b/tests/text.rs
@@ -9,10 +9,7 @@ use buoyant::{
     primitives::{Dimensions, Point, ProposedDimension, ProposedDimensions, Size},
     render::Renderable as _,
     render_target::FixedTextBuffer,
-    view::{
-        make_render_tree, HorizontalTextAlignment, LayoutExtensions as _, RenderExtensions as _,
-        Text,
-    },
+    view::{make_render_tree, HorizontalTextAlignment, Text, ViewExt as _},
 };
 
 #[derive(Debug)]

--- a/tests/vstack.rs
+++ b/tests/vstack.rs
@@ -5,11 +5,11 @@ use buoyant::primitives::{Dimensions, Point, ProposedDimension, ProposedDimensio
 use buoyant::render::CharacterRender;
 use buoyant::render::CharacterRenderTarget;
 use buoyant::render_target::FixedTextBuffer;
+use buoyant::view::make_render_tree;
 use buoyant::view::padding::Edges;
-use buoyant::view::{make_render_tree, RenderExtensions as _};
 use buoyant::view::{
-    shape::Rectangle, Divider, EmptyView, HStack, HorizontalTextAlignment, LayoutExtensions,
-    Spacer, Text, VStack,
+    shape::Rectangle, Divider, EmptyView, HStack, HorizontalTextAlignment, Spacer, Text, VStack,
+    ViewExt,
 };
 
 mod common;

--- a/tests/zstack.rs
+++ b/tests/zstack.rs
@@ -7,9 +7,7 @@ use buoyant::render::CharacterRenderTarget;
 use buoyant::render_target::FixedTextBuffer;
 use buoyant::view::padding::Edges;
 use buoyant::view::shape::Rectangle;
-use buoyant::view::{
-    make_render_tree, Divider, LayoutExtensions, RenderExtensions as _, Spacer, Text, ZStack,
-};
+use buoyant::view::{make_render_tree, Divider, Spacer, Text, ViewExt, ZStack};
 
 #[test]
 fn test_layout_fills_two() {


### PR DESCRIPTION
Large breaking change to consolidate `RenderExtensions` and `LayoutExtensions` into one type, `ViewExt`.
@vic1707, related to your work to remove unnecessary generics.