### PR TITLE
Removes NullRender trait

### DIFF
--- a/src/view/empty_view.rs
+++ b/src/view/empty_view.rs
@@ -1,7 +1,8 @@
 use crate::{
+    environment::LayoutEnvironment,
     layout::{Layout, ResolvedLayout},
-    primitives::{Dimensions, ProposedDimensions},
-    render::NullRender,
+    primitives::{Dimensions, Point, ProposedDimensions},
+    render::Renderable,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -30,4 +31,51 @@ impl Layout for EmptyView {
     }
 }
 
-impl NullRender for EmptyView {}
+impl Renderable for EmptyView {
+    type Renderables = ();
+
+    fn render_tree(
+        &self,
+        _layout: &ResolvedLayout<Self::Sublayout>,
+        _origin: Point,
+        _env: &impl LayoutEnvironment,
+    ) {
+    }
+}
+
+// The empty tuple can be used as an equivalent to empty view
+
+impl Layout for () {
+    type Sublayout = ();
+
+    fn layout(
+        &self,
+        _: &ProposedDimensions,
+        _: &impl crate::environment::LayoutEnvironment,
+    ) -> ResolvedLayout<Self::Sublayout> {
+        ResolvedLayout {
+            sublayouts: (),
+            resolved_size: Dimensions::zero(),
+        }
+    }
+
+    fn priority(&self) -> i8 {
+        i8::MIN
+    }
+
+    fn is_empty(&self) -> bool {
+        true
+    }
+}
+
+impl Renderable for () {
+    type Renderables = ();
+
+    fn render_tree(
+        &self,
+        _layout: &ResolvedLayout<Self::Sublayout>,
+        _origin: Point,
+        _env: &impl LayoutEnvironment,
+    ) {
+    }
+}

--- a/src/view/spacer.rs
+++ b/src/view/spacer.rs
@@ -1,8 +1,8 @@
 use crate::{
     environment::LayoutEnvironment,
     layout::{Layout, LayoutDirection, ResolvedLayout},
-    primitives::{Dimensions, ProposedDimensions},
-    render::NullRender,
+    primitives::{Dimensions, Point, ProposedDimensions},
+    render::Renderable,
 };
 
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -40,4 +40,14 @@ impl Layout for Spacer {
     }
 }
 
-impl NullRender for Spacer {}
+impl Renderable for Spacer {
+    type Renderables = ();
+
+    fn render_tree(
+        &self,
+        _layout: &ResolvedLayout<Self::Sublayout>,
+        _origin: Point,
+        _env: &impl LayoutEnvironment,
+    ) {
+    }
+}


### PR DESCRIPTION
Remove NullRender to get rid of misleading compiler errors when the wrong types are used