### PR TITLE
AsDrawable trait to simplify static rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,7 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "buoyant"
-version = "0.5.0-alpha.3"
+version = "0.5.0-alpha.4"
 dependencies = [
  "crossterm",
  "embedded-graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "buoyant"
-version = "0.5.0-alpha.3"
+version = "0.5.0-alpha.4"
 authors = ["Riley Williams"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Get started with the [Book](https://riley-williams.github.io/buoyant/).
 
 ## Available render targets
 
+While this crate is primarily intended for use with embedded-graphics `DrawTarget`s, it
+can also be used to layout and render views to the terminal.
+
 - `DrawTarget`: `embedded-graphics` displays.
 - `TextBuffer`: A basic fixed-size `char` buffer. Does not respect graphemes.
   This is primarily useful for testing and debugging.
@@ -20,7 +23,7 @@ Get started with the [Book](https://riley-williams.github.io/buoyant/).
 
 ## Example
 
-Here's what an animated toggle button component could look like, implemented with Buoyant:
+Here's an animated toggle component, implemented with Buoyant:
 
 ![Toggle](./docs/images/toggle.gif)
 
@@ -54,28 +57,28 @@ fn toggle_button(is_on: bool) -> impl EmbeddedGraphicsView<Rgb565> {
 Static layout and animation between layouts are relatively feature-complete, aside from
 transitions. You should be able to construct most desired layouts and animations.
 
-- [x] Stacks of heterogeneous views (VStack, HStack, ZStack)
-- [x] Stacks of homogeneous views (ForEach) - partial, vertical only
-- [x] Common SwiftUI primitives (Spacer, Divider)
-- [x] Conditional views, with match variable binding
-- [x] Monospaced Text (whitespace-based line breaking)
-- [x] Images (fixed size)
-- [x] Interruptible Animations + Curves
-- [x] Common embedded-graphics shape primitives
-- [ ] Simulated alpha and antialiasing
-- [ ] Transitions
-- [ ] Shape stroke/fill
-- [ ] Shape styles (e.g. gradients)
-- [ ] Canvas for arbitrary path/shape/raster drawing
+- ✅ Stacks of heterogeneous views (VStack, HStack, ZStack)
+- ✅ Stacks of homogeneous views (ForEach) - partial, vertical only
+- ✅ Common SwiftUI primitives (Spacer, Divider)
+- ✅ Conditional views, with match variable binding
+- ✅ Text (embedded-graphics Monospace and [u8g2](https://crates.io/crates/u8g2-fonts) fonts)
+- ✅ Images (fixed size)
+- ✅ Interruptible Animations + Curves
+- ✅ Common embedded-graphics shape primitives
+- 🚧 Shape stroke+fill
+- 🚧 Canvas for arbitrary path/shape/raster drawing
+- 💤 Simulated alpha and antialiasing
+- 💤 Transitions
+- 💤 Shape styles (e.g. gradients)
 
 ### Interactivity
 
-No interactivity or state management currently exists, but it is the next major
+No native interactivity or state management currently exists, but it is the next major
 planned feature.
 
-- [ ] State management
-- [ ] Click/tap routing
-- [ ] Focus management + keyboard input (Text input view)
+- 💤 State management
+- 💤 Click/tap routing
+- 💤 Focus management + keyboard input (Text input view)
 
 ## Who should use this?
 

--- a/buoyant-examples/battery/src/bin/simulator.rs
+++ b/buoyant-examples/battery/src/bin/simulator.rs
@@ -29,8 +29,9 @@ fn main() {
     // Some display sizes to try:
     // Size::new(210, 110)
     // Size::new(110, 310)
-    let display: SimulatorDisplay<color::ColorFormat> = SimulatorDisplay::new(Size::new(210, 110));
-    let mut target = EmbeddedGraphicsRenderTarget::new(display);
+    let mut display: SimulatorDisplay<color::ColorFormat> =
+        SimulatorDisplay::new(Size::new(210, 110));
+    let mut target = EmbeddedGraphicsRenderTarget::new(&mut display);
     let app_start = Instant::now();
 
     let simulator = ChargeSim::new(1.0);

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -10,6 +10,7 @@
   - [Mixed Alignment](./building-views/mixed-alignment.md)
   - [Collections](./building-views/collections.md)
   - [Conditional Views](./building-views/conditional-views.md)
+  - [Manual View Lifecycle](./building-views/manual-view-lifecycle.md)
 - [Animation](./animation.md)
   - [Render Trees](./animation/render-trees.md)
   - [Compound Animation](./animation/compound-animation.md)

--- a/docs/book/src/animation/animated-render-loops.md
+++ b/docs/book/src/animation/animated-render-loops.md
@@ -22,8 +22,8 @@ To animate between two render trees, you can use the `render_animated()` method:
 # };
 # use embedded_graphics::{pixelcolor::Rgb888, prelude::RgbColor};
 # 
-# let display = embedded_graphics::mock_display::MockDisplay::new();
-# let mut target = EmbeddedGraphicsRenderTarget::new(display);
+# let mut display = embedded_graphics::mock_display::MockDisplay::new();
+# let mut target = EmbeddedGraphicsRenderTarget::new(&mut display);
 # let app_time = Duration::from_secs(0);
 # 
 # let environment = DefaultEnvironment::new(app_time);
@@ -78,8 +78,8 @@ is the same as rendering the two trees with `render_animated()`.
 # };
 # use embedded_graphics::{pixelcolor::Rgb888, prelude::RgbColor};
 # 
-# let display = embedded_graphics::mock_display::MockDisplay::new();
-# let mut target = EmbeddedGraphicsRenderTarget::new(display);
+# let mut display = embedded_graphics::mock_display::MockDisplay::new();
+# let mut target = EmbeddedGraphicsRenderTarget::new(&mut display);
 # let app_time = Duration::from_secs(0);
 # 
 # let environment = DefaultEnvironment::new(app_time);

--- a/docs/book/src/building-views/alignment.md
+++ b/docs/book/src/building-views/alignment.md
@@ -21,12 +21,7 @@ you could set ``VerticalAlignment::Top``.
 # extern crate buoyant;
 # extern crate embedded_graphics;
 # extern crate embedded_graphics_simulator;
-# use buoyant::{
-#     environment::DefaultEnvironment,
-#     layout::Layout,
-#     render::{Render as _, Renderable as _},
-#     render_target::{EmbeddedGraphicsRenderTarget, RenderTarget as _},
-# };
+# use buoyant::view::AsDrawable as _;
 # use embedded_graphics::{pixelcolor::Rgb888, prelude::*};
 # use embedded_graphics_simulator::{OutputSettings, SimulatorDisplay, Window};
 # 
@@ -35,21 +30,16 @@ you could set ``VerticalAlignment::Top``.
 # 
 # fn main() {
 #     let mut window = Window::new("Example", &OutputSettings::default());
-#     let display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(480, 320));
-#     let mut target = EmbeddedGraphicsRenderTarget::new(display);
+#     let mut display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(480, 320));
 # 
-#     target.clear(BACKGROUND_COLOR);
+#     display.clear(BACKGROUND_COLOR).unwrap();
 # 
-#     let environment = DefaultEnvironment::default();
-#     let origin = buoyant::primitives::Point::zero();
+#     view()
+#         .as_drawable(display.size(), DEFAULT_COLOR)
+#         .draw(&mut display)
+#         .unwrap();
 # 
-#     let view = view();
-#     let layout = view.layout(&target.size().into(), &environment);
-#     let render_tree = view.render_tree(&layout, origin, &environment);
-# 
-#     render_tree.render(&mut target, &DEFAULT_COLOR, origin);
-# 
-#     window.show_static(&target.display());
+#     window.show_static(&display);
 # }
 # 
 use buoyant::layout::VerticalAlignment;

--- a/docs/book/src/building-views/collections.md
+++ b/docs/book/src/building-views/collections.md
@@ -10,12 +10,7 @@ better choice. Use ForEach when you want to display a collection of like views.
 # extern crate buoyant;
 # extern crate embedded_graphics;
 # extern crate embedded_graphics_simulator;
-# use buoyant::{
-#     environment::DefaultEnvironment,
-#     layout::Layout,
-#     render::{Render, Renderable},
-#     render_target::{EmbeddedGraphicsRenderTarget, RenderTarget as _},
-# };
+# use buoyant::view::AsDrawable as _;
 # use embedded_graphics_simulator::{OutputSettings, SimulatorDisplay, Window};
 #
 # const BACKGROUND_COLOR: Rgb888 = Rgb888::CSS_DARK_SLATE_GRAY;
@@ -23,21 +18,16 @@ better choice. Use ForEach when you want to display a collection of like views.
 #
 # fn main() {
 #     let mut window = Window::new("Example", &OutputSettings::default());
-#     let display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(480, 320));
-#     let mut target = EmbeddedGraphicsRenderTarget::new(display);
+#     let mut display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(480, 320));
 #
-#     target.clear(BACKGROUND_COLOR);
+#     display.clear(BACKGROUND_COLOR).unwrap();
 #
-#     let environment = DefaultEnvironment::default();
-#     let origin = buoyant::primitives::Point::zero();
+#     view(&SWATCHES)
+#         .as_drawable(display.size(), DEFAULT_COLOR)
+#         .draw(&mut display)
+#         .unwrap();
 #
-#     let view = view(&SWATCHES);
-#     let layout = view.layout(&target.size().into(), &environment);
-#     let render_tree = view.render_tree(&layout, origin, &environment);
-#
-#     render_tree.render(&mut target, &DEFAULT_COLOR, origin);
-#
-#     window.show_static(&target.display());
+#     window.show_static(&display);
 # }
 #
 # mod spacing {

--- a/docs/book/src/building-views/conditional-views.md
+++ b/docs/book/src/building-views/conditional-views.md
@@ -6,7 +6,7 @@ If you try something like this:
 # extern crate buoyant;
 # extern crate embedded_graphics;
 # use buoyant::view::{Text, shape::Rectangle, View};
-# use embedded_graphics::{mono_font::ascii::FONT_9X15, pixelcolor::Rgb888, prelude::*};
+# use embedded_graphics::{mono_font::ascii::FONT_9X15, pixelcolor::Rgb888};
 #
 fn view(is_redacted: bool) -> impl View<Rgb888> {
     if is_redacted {
@@ -32,12 +32,7 @@ The `if_view!` macro allows you to write views as if you were writing a plain `i
 # extern crate buoyant;
 # extern crate embedded_graphics;
 # extern crate embedded_graphics_simulator;
-# use buoyant::{
-#     environment::DefaultEnvironment,
-#     layout::Layout,
-#     render::{Render, Renderable},
-#     render_target::{EmbeddedGraphicsRenderTarget, RenderTarget as _},
-# };
+# use buoyant::view::AsDrawable as _;
 # use embedded_graphics_simulator::{OutputSettings, SimulatorDisplay, Window};
 #
 # const BACKGROUND_COLOR: Rgb888 = Rgb888::CSS_DARK_SLATE_GRAY;
@@ -45,21 +40,16 @@ The `if_view!` macro allows you to write views as if you were writing a plain `i
 #
 # fn main() {
 #     let mut window = Window::new("Example", &OutputSettings::default());
-#     let display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(480, 320));
-#     let mut target = EmbeddedGraphicsRenderTarget::new(display);
+#     let mut display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(480, 320));
 #
-#     target.clear(BACKGROUND_COLOR);
+#     display.clear(BACKGROUND_COLOR).unwrap();
 #
-#     let environment = DefaultEnvironment::default();
-#     let origin = buoyant::primitives::Point::zero();
+#     view()
+#         .as_drawable(display.size(), DEFAULT_COLOR)
+#         .draw(&mut display)
+#         .unwrap();
 #
-#     let view = view();
-#     let layout = view.layout(&target.size().into(), &environment);
-#     let render_tree = view.render_tree(&layout, origin, &environment);
-#
-#     render_tree.render(&mut target, &DEFAULT_COLOR, origin);
-#
-#     window.show_static(&target.display());
+#     window.show_static(&display);
 # }
 #
 use buoyant::if_view;
@@ -101,13 +91,7 @@ variables in the match arms.
 # extern crate buoyant;
 # extern crate embedded_graphics;
 # extern crate embedded_graphics_simulator;
-# use buoyant::{
-#     environment::DefaultEnvironment,
-#     layout::Layout,
-#     render::{Render, Renderable},
-#     render_target::{EmbeddedGraphicsRenderTarget, RenderTarget as _},
-#     view::EmptyView,
-# };
+# use buoyant::view::AsDrawable as _;
 # use embedded_graphics_simulator::{OutputSettings, SimulatorDisplay, Window};
 #
 # const BACKGROUND_COLOR: Rgb888 = Rgb888::CSS_DARK_SLATE_GRAY;
@@ -115,26 +99,21 @@ variables in the match arms.
 #
 # fn main() {
 #     let mut window = Window::new("Example", &OutputSettings::default());
-#     let display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(480, 320));
-#     let mut target = EmbeddedGraphicsRenderTarget::new(display);
+#     let mut display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(480, 320));
 #
-#     target.clear(BACKGROUND_COLOR);
+#     display.clear(BACKGROUND_COLOR).unwrap();
 #
-#     let environment = DefaultEnvironment::default();
-#     let origin = buoyant::primitives::Point::zero();
+#     view()
+#         .as_drawable(display.size(), DEFAULT_COLOR)
+#         .draw(&mut display)
+#         .unwrap();
 #
-#     let view = view();
-#     let layout = view.layout(&target.size().into(), &environment);
-#     let render_tree = view.render_tree(&layout, origin, &environment);
-#
-#     render_tree.render(&mut target, &DEFAULT_COLOR, origin);
-#
-#     window.show_static(&target.display());
+#     window.show_static(&display);
 # }
 #
 use buoyant::match_view;
 use buoyant::view::shape::{Rectangle, RoundedRectangle};
-use buoyant::view::{padding::Edges, View, ViewExt as _, VStack};
+use buoyant::view::{padding::Edges, EmptyView, View, ViewExt as _, VStack};
 use embedded_graphics::{pixelcolor::Rgb888, prelude::*};
 
 #[derive(Debug, Clone, Copy)]

--- a/docs/book/src/building-views/manual-view-lifecycle.md
+++ b/docs/book/src/building-views/manual-view-lifecycle.md
@@ -1,0 +1,88 @@
+# Manual View Lifecycle
+
+While the `AsDrawable` trait is useful for quickly rendering a view, you can also manually
+manage the layout and rendering stages of a view.
+
+Looking back at the simple Hello World example, we can replace the `AsDrawable` trait usage
+with a manual view lifecycle.
+
+```rust,no_run
+# extern crate buoyant;
+# extern crate embedded_graphics;
+# extern crate embedded_graphics_simulator;
+use buoyant::{
+    environment::DefaultEnvironment,
+    layout::Layout,
+    render::{Render as _, Renderable as _},
+    render_target::EmbeddedGraphicsRenderTarget,
+    view::{padding::Edges, HStack, Spacer, Text, View, ViewExt as _},
+};
+use embedded_graphics::{mono_font::ascii::FONT_10X20, pixelcolor::Rgb888, prelude::*};
+use embedded_graphics_simulator::{OutputSettings, SimulatorDisplay, Window};
+
+const BACKGROUND_COLOR: Rgb888 = Rgb888::BLACK;
+const DEFAULT_COLOR: Rgb888 = Rgb888::WHITE;
+
+fn main() {
+    let size = Size::new(480, 320);
+    let mut window = Window::new("Hello World", &OutputSettings::default());
+    let mut display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(size);
+    let mut target = EmbeddedGraphicsRenderTarget::new(&mut display);
+
+    target.display_mut().clear(BACKGROUND_COLOR).unwrap();
+
+    let environment = DefaultEnvironment::default();
+    let origin = buoyant::primitives::Point::zero();
+
+    let view = hello_view();
+    let layout = view.layout(&size.into(), &environment);
+    let render_tree = view.render_tree(&layout, origin, &environment);
+
+    render_tree.render(&mut target, &DEFAULT_COLOR, origin);
+
+    window.show_static(target.display());
+}
+
+fn hello_view() -> impl View<Rgb888> {
+    HStack::new((
+        Text::new("Hello", &FONT_10X20).foreground_color(Rgb888::GREEN),
+        Spacer::default(),
+        Text::new("World", &FONT_10X20).foreground_color(Rgb888::YELLOW),
+    ))
+    .padding(Edges::All, 20)
+}
+```
+
+## Layout
+
+```rust,ignore
+let layout = view.layout(&size.into(), &environment);
+```
+
+The layout call resolves the sizes of all the views. It is a bug to try to reuse the layout
+after mutating the view, and Buoyant may panic if you do so.
+
+## Render Tree
+
+```rust,ignore
+let render_tree = view.render_tree(&layout, origin, &environment);
+```
+
+The render tree is a minimal snapshot of the view. It holds a copy of the resolved positions,
+sizes, colors, etc. of all the elements that are actually rendered to the screen.
+Relational elements like `Padding`, `Frame`s, alignment, and so on have been stripped.
+
+## Rendering
+
+```rust,ignore
+render_tree.render(&mut display, &DEFAULT_COLOR, origin);
+```
+
+Here, the snapshot is finally rendered to the display buffer. A default color, similar to SwiftUI's
+foreground color, is passed in. This is used for elements that don't have a color set.
+
+## Why?
+
+For just rendering a static view, this feels like (and is) a lot of boilerplate from Buoyant.
+However, as you'll see in the next section, having multiple snapshots allows you to create
+incredibly powerful animation between them with next to no effort.

--- a/docs/book/src/building-views/mixed-alignment.md
+++ b/docs/book/src/building-views/mixed-alignment.md
@@ -19,13 +19,7 @@ I'll briefly indulge this misconception.
 # extern crate buoyant;
 # extern crate embedded_graphics;
 # extern crate embedded_graphics_simulator;
-# use buoyant::{
-#     environment::DefaultEnvironment,
-#     layout::Layout as _,
-#     render::{Render as _, Renderable as _},
-#     render_target::{EmbeddedGraphicsRenderTarget, RenderTarget as _},
-# };
-#
+# use buoyant::view::AsDrawable as _;
 # use embedded_graphics::{pixelcolor::Rgb888, prelude::*};
 # use embedded_graphics_simulator::{OutputSettings, SimulatorDisplay, Window};
 # 
@@ -34,21 +28,16 @@ I'll briefly indulge this misconception.
 # 
 # fn main() {
 #     let mut window = Window::new("Example", &OutputSettings::default());
-#     let display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(480, 320));
-#     let mut target = EmbeddedGraphicsRenderTarget::new(display);
+#     let mut display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(480, 320));
 # 
-#     target.clear(BACKGROUND_COLOR);
+#     display.clear(BACKGROUND_COLOR).unwrap();
 # 
-#     let environment = DefaultEnvironment::default();
-#     let origin = buoyant::primitives::Point::zero();
+#     view()
+#         .as_drawable(display.size(), DEFAULT_COLOR)
+#         .draw(&mut display)
+#         .unwrap();
 # 
-#     let view = view();
-#     let layout = view.layout(&target.size().into(), &environment);
-#     let render_tree = view.render_tree(&layout, origin, &environment);
-# 
-#     render_tree.render(&mut target, &DEFAULT_COLOR, origin);
-# 
-#     window.show_static(&target.display());
+#     window.show_static(&display);
 # }
 # 
 // No!
@@ -110,13 +99,7 @@ as the previous code.
 # extern crate buoyant;
 # extern crate embedded_graphics;
 # extern crate embedded_graphics_simulator;
-#
-# use buoyant::{
-#     environment::DefaultEnvironment,
-#     layout::Layout as _,
-#     render::{Render, Renderable},
-#     render_target::{EmbeddedGraphicsRenderTarget, RenderTarget as _},
-# };
+# use buoyant::view::AsDrawable as _;
 # use embedded_graphics::{pixelcolor::Rgb888, prelude::*};
 # use embedded_graphics_simulator::{OutputSettings, SimulatorDisplay, Window};
 # 
@@ -125,21 +108,16 @@ as the previous code.
 # 
 # fn main() {
 #     let mut window = Window::new("Example", &OutputSettings::default());
-#     let display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(480, 320));
-#     let mut target = EmbeddedGraphicsRenderTarget::new(display);
+#     let mut display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(480, 320));
 # 
-#     target.clear(BACKGROUND_COLOR);
+#     display.clear(BACKGROUND_COLOR).unwrap();
 # 
-#     let environment = DefaultEnvironment::default();
-#     let origin = buoyant::primitives::Point::zero();
+#     view()
+#         .as_drawable(display.size(), DEFAULT_COLOR)
+#         .draw(&mut display)
+#         .unwrap();
 # 
-#     let view = view();
-#     let layout = view.layout(&target.size().into(), &environment);
-#     let render_tree = view.render_tree(&layout, origin, &environment);
-# 
-#     render_tree.render(&mut target, &DEFAULT_COLOR, origin);
-# 
-#     window.show_static(&target.display());
+#     window.show_static(&display);
 # }
 # 
 // Preferred

--- a/docs/book/src/building-views/separating-views.md
+++ b/docs/book/src/building-views/separating-views.md
@@ -10,12 +10,7 @@ Here, `Spacer` is used to push the two `Circle`s to either side.
 # extern crate buoyant;
 # extern crate embedded_graphics;
 # extern crate embedded_graphics_simulator;
-# use buoyant::{
-#     environment::DefaultEnvironment,
-#     layout::Layout,
-#     render::{Render as _, Renderable as _},
-#     render_target::{EmbeddedGraphicsRenderTarget, RenderTarget as _},
-# };
+# use buoyant::view::AsDrawable as _;
 # use embedded_graphics::{pixelcolor::Rgb888, prelude::*};
 # use embedded_graphics_simulator::{OutputSettings, SimulatorDisplay, Window};
 # 
@@ -24,21 +19,16 @@ Here, `Spacer` is used to push the two `Circle`s to either side.
 # 
 # fn main() {
 #     let mut window = Window::new("Example", &OutputSettings::default());
-#     let display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(480, 320));
-#     let mut target = EmbeddedGraphicsRenderTarget::new(display);
+#     let mut display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(480, 320));
 # 
-#     target.clear(BACKGROUND_COLOR);
+#     display.clear(BACKGROUND_COLOR).unwrap();
 # 
-#     let environment = DefaultEnvironment::default();
-#     let origin = buoyant::primitives::Point::zero();
+#     view()
+#         .as_drawable(display.size(), DEFAULT_COLOR)
+#         .draw(&mut display)
+#         .unwrap();
 # 
-#     let view = view();
-#     let layout = view.layout(&target.size().into(), &environment);
-#     let render_tree = view.render_tree(&layout, origin, &environment);
-# 
-#     render_tree.render(&mut target, &DEFAULT_COLOR, origin);
-# 
-#     window.show_static(&target.display());
+#     window.show_static(&display);
 # }
 # 
 use buoyant::layout::HorizontalAlignment;

--- a/docs/book/src/building-views/stack-spacing.md
+++ b/docs/book/src/building-views/stack-spacing.md
@@ -12,12 +12,7 @@ You can configure the spacing between child views using `.with_spacing`.
 # extern crate buoyant;
 # extern crate embedded_graphics;
 # extern crate embedded_graphics_simulator;
-# use buoyant::{
-#     environment::DefaultEnvironment,
-#     layout::Layout,
-#     render::{Render as _, Renderable as _},
-#     render_target::{EmbeddedGraphicsRenderTarget, RenderTarget as _},
-# };
+# use buoyant::view::AsDrawable as _;
 # use embedded_graphics::{pixelcolor::Rgb888, prelude::*};
 # use embedded_graphics_simulator::{OutputSettings, SimulatorDisplay, Window};
 # 
@@ -26,21 +21,16 @@ You can configure the spacing between child views using `.with_spacing`.
 # 
 # fn main() {
 #     let mut window = Window::new("Example", &OutputSettings::default());
-#     let display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(480, 320));
-#     let mut target = EmbeddedGraphicsRenderTarget::new(display);
+#     let mut display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(480, 320));
 # 
-#     target.clear(BACKGROUND_COLOR);
+#     display.clear(BACKGROUND_COLOR).unwrap();
 # 
-#     let environment = DefaultEnvironment::default();
-#     let origin = buoyant::primitives::Point::zero();
+#     view()
+#         .as_drawable(display.size(), DEFAULT_COLOR)
+#         .draw(&mut display)
+#         .unwrap();
 # 
-#     let view = view();
-#     let layout = view.layout(&target.size().into(), &environment);
-#     let render_tree = view.render_tree(&layout, origin, &environment);
-# 
-#     render_tree.render(&mut target, &DEFAULT_COLOR, origin);
-# 
-#     window.show_static(&target.display());
+#     window.show_static(&display);
 # }
 # 
 use buoyant::layout::HorizontalAlignment;
@@ -73,12 +63,7 @@ incrementally larger values for each class of separation.
 # extern crate buoyant;
 # extern crate embedded_graphics;
 # extern crate embedded_graphics_simulator;
-# use buoyant::{
-#     environment::DefaultEnvironment,
-#     layout::Layout,
-#     render::{Render as _, Renderable as _},
-#     render_target::{EmbeddedGraphicsRenderTarget, RenderTarget as _},
-# };
+# use buoyant::view::AsDrawable as _;
 # use embedded_graphics_simulator::{OutputSettings, SimulatorDisplay, Window};
 # 
 # const BACKGROUND_COLOR: Rgb888 = Rgb888::CSS_DARK_SLATE_GRAY;
@@ -86,21 +71,16 @@ incrementally larger values for each class of separation.
 # 
 # fn main() {
 #     let mut window = Window::new("Example", &OutputSettings::default());
-#     let display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(480, 320));
-#     let mut target = EmbeddedGraphicsRenderTarget::new(display);
+#     let mut display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(480, 320));
 # 
-#     target.clear(BACKGROUND_COLOR);
+#     display.clear(BACKGROUND_COLOR).unwrap();
 # 
-#     let environment = DefaultEnvironment::default();
-#     let origin = buoyant::primitives::Point::zero();
+#     view()
+#         .as_drawable(display.size(), DEFAULT_COLOR)
+#         .draw(&mut display)
+#         .unwrap();
 # 
-#     let view = view();
-#     let layout = view.layout(&target.size().into(), &environment);
-#     let render_tree = view.render_tree(&layout, origin, &environment);
-# 
-#     render_tree.render(&mut target, &DEFAULT_COLOR, origin);
-# 
-#     window.show_static(&target.display());
+#     window.show_static(&display);
 # }
 # 
 use buoyant::layout::{HorizontalAlignment, VerticalAlignment};

--- a/docs/book/src/building-views/stacks.md
+++ b/docs/book/src/building-views/stacks.md
@@ -11,12 +11,7 @@ Both stacks can contain a heterogeneous set of views and can be nested inside ot
 # extern crate buoyant;
 # extern crate embedded_graphics;
 # extern crate embedded_graphics_simulator;
-# use buoyant::{
-#     environment::DefaultEnvironment,
-#     layout::Layout as _,
-#     render::{Render as _, Renderable as _},
-#     render_target::{EmbeddedGraphicsRenderTarget, RenderTarget as _},
-# };
+# use buoyant::view::AsDrawable as _;
 # use embedded_graphics::{pixelcolor::Rgb888, prelude::*};
 # use embedded_graphics_simulator::{OutputSettings, SimulatorDisplay, Window};
 # 
@@ -25,21 +20,16 @@ Both stacks can contain a heterogeneous set of views and can be nested inside ot
 # 
 # fn main() {
 #     let mut window = Window::new("Example", &OutputSettings::default());
-#     let display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(480, 320));
-#     let mut target = EmbeddedGraphicsRenderTarget::new(display);
+#     let mut display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(480, 320));
 # 
-#     target.clear(BACKGROUND_COLOR);
+#     display.clear(BACKGROUND_COLOR).unwrap();
 # 
-#     let environment = DefaultEnvironment::default();
-#     let origin = buoyant::primitives::Point::zero();
+#     view()
+#         .as_drawable(display.size(), DEFAULT_COLOR)
+#         .draw(&mut display)
+#         .unwrap();
 # 
-#     let view = view();
-#     let layout = view.layout(&target.size().into(), &environment);
-#     let render_tree = view.render_tree(&layout, origin, &environment);
-# 
-#     render_tree.render(&mut target, &DEFAULT_COLOR, origin);
-# 
-#     window.show_static(&target.display());
+#     window.show_static(&display);
 # }
 # 
 use buoyant::view::shape::{Circle, Rectangle};
@@ -71,12 +61,7 @@ it can contain a heterogeneous set of views.
 # extern crate buoyant;
 # extern crate embedded_graphics;
 # extern crate embedded_graphics_simulator;
-# use buoyant::{
-#     environment::DefaultEnvironment,
-#     layout::Layout as _,
-#     render::{Render as _, Renderable as _},
-#     render_target::{EmbeddedGraphicsRenderTarget, RenderTarget as _},
-# };
+# use buoyant::view::AsDrawable as _;
 # use embedded_graphics::{pixelcolor::Rgb888, prelude::*};
 # use embedded_graphics_simulator::{OutputSettings, SimulatorDisplay, Window};
 # 
@@ -85,21 +70,16 @@ it can contain a heterogeneous set of views.
 # 
 # fn main() {
 #     let mut window = Window::new("Example", &OutputSettings::default());
-#     let display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(480, 320));
-#     let mut target = EmbeddedGraphicsRenderTarget::new(display);
+#     let mut display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(480, 320));
 # 
-#     target.clear(BACKGROUND_COLOR);
+#     display.clear(BACKGROUND_COLOR).unwrap();
 # 
-#     let environment = DefaultEnvironment::default();
-#     let origin = buoyant::primitives::Point::zero();
+#     view()
+#         .as_drawable(display.size(), DEFAULT_COLOR)
+#         .draw(&mut display)
+#         .unwrap();
 # 
-#     let view = view();
-#     let layout = view.layout(&target.size().into(), &environment);
-#     let render_tree = view.render_tree(&layout, origin, &environment);
-# 
-#     render_tree.render(&mut target, &DEFAULT_COLOR, origin);
-# 
-#     window.show_static(&target.display());
+#     window.show_static(&display);
 # }
 # 
 use buoyant::view::padding::Edges;
@@ -132,12 +112,7 @@ Stacks can be nested to create complex layouts.
 # extern crate buoyant;
 # extern crate embedded_graphics;
 # extern crate embedded_graphics_simulator;
-# use buoyant::{
-#     environment::DefaultEnvironment,
-#     layout::Layout as _,
-#     render::{Render as _, Renderable as _},
-#     render_target::{EmbeddedGraphicsRenderTarget, RenderTarget as _},
-# };
+# use buoyant::view::AsDrawable as _;
 # use embedded_graphics::{pixelcolor::Rgb888, prelude::*};
 # use embedded_graphics_simulator::{OutputSettings, SimulatorDisplay, Window};
 # 
@@ -146,21 +121,16 @@ Stacks can be nested to create complex layouts.
 # 
 # fn main() {
 #     let mut window = Window::new("Example", &OutputSettings::default());
-#     let display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(480, 320));
-#     let mut target = EmbeddedGraphicsRenderTarget::new(display);
+#     let mut display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(480, 320));
 # 
-#     target.clear(BACKGROUND_COLOR);
+#     display.clear(BACKGROUND_COLOR).unwrap();
 # 
-#     let environment = DefaultEnvironment::default();
-#     let origin = buoyant::primitives::Point::zero();
+#     view()
+#         .as_drawable(display.size(), DEFAULT_COLOR)
+#         .draw(&mut display)
+#         .unwrap();
 # 
-#     let view = view();
-#     let layout = view.layout(&target.size().into(), &environment);
-#     let render_tree = view.render_tree(&layout, origin, &environment);
-# 
-#     render_tree.render(&mut target, &DEFAULT_COLOR, origin);
-# 
-#     window.show_static(&target.display());
+#     window.show_static(&display);
 # }
 # 
 use buoyant::view::padding::Edges;

--- a/docs/book/src/quickstart.md
+++ b/docs/book/src/quickstart.md
@@ -11,7 +11,7 @@ README to install sdl2.
 # Cargo.toml
 
 [dependencies]
-buoyant = "0.4"
+buoyant = "0.5"
 embedded-graphics = "0.8"
 embedded-graphics-simulator = "0.7.0"
 ```
@@ -23,8 +23,6 @@ separated by as much space as possible, with 20 pixels of padding around the edg
 
 ![hello-world](images/hello-world.png)
 
-Here is the full example, which will be picked apart in the following sections:
-
 ```rust,no_run
 # extern crate buoyant;
 # extern crate embedded_graphics;
@@ -33,41 +31,16 @@ Here is the full example, which will be picked apart in the following sections:
 {{#include quickstart.rs:all}}
 ```
 
-## Simulator Boilerplate
-
 This is more or less the bare minimum to get a window up and running with the simulator.
 
-```rust,no_run
-# extern crate buoyant;
-# extern crate embedded_graphics;
-# extern crate embedded_graphics_simulator;
-#
-{{#include quickstart.rs:simulator}}
-    // Render to display...
-{{#include quickstart.rs:simulator2}}
-```
-
-A window and a display framebuffer are created. `display` importantly conforms to
+A window and a display framebuffer are created. `display` conforms to
 `embedded_graphics::DrawTarget<Color = Rgb888>` and is what you'll render content into.
 
-The framebuffer is cleared to the background color, content is rendered, and finally the framebuffer
-is displayed.
+The framebuffer is cleared to the background color, the view is rendered, and finally the
+framebuffer is displayed.
 
-## Environment
-
-```rust
-# extern crate buoyant;
-# use buoyant::environment::DefaultEnvironment;
-#
-let environment = DefaultEnvironment::default();
-let origin = buoyant::primitives::Point::zero();
-```
-
-For static views with no animation, the environment is mostly irrelevant and the default
-environment will suffice.
-
-If this view involved animation, the environment would be used to inject the time
-(as a duration), which you'd set every time you produce a new view.
+> `AsDrawable::as_drawable` is doing all the heavy lifting here. It takes care of laying
+> out the view within the provided size and then rendering it to the draw target.
 
 ## View Body
 
@@ -92,35 +65,3 @@ the same way built-in components like `Text` are used.
 Because embedded-graphics displays come in a wide variety of color spaces, component views
 must also specify a color space. Often it's useful to alias this to make migration to another
 screen easy, with e.g. `type color_space = Rgb888`.
-
-## Layout
-
-```rust,ignore
-let layout = view.layout(&display.size().into(), &environment);
-```
-
-The layout call resolves the sizes of all the views. It is a bug to try to reuse the layout
-after mutating the view, and Buoyant may panic if you do so.
-
-## Render Tree
-
-```rust,ignore
-let render_tree = view.render_tree(&layout, origin, &environment);
-```
-
-The render tree is a minimal snapshot of the view. It holds a copy of the resolved positions,
-sizes, colors, etc. of all the elements that are actually rendered to the screen.
-Relational elements like `Padding`, `Frame`s, alignment, and so on have been stripped.
-
-For rendering a static view, this feels like (and is) a lot of boilerplate from Buoyant.
-However, as you'll see later, having multiple snapshots allows incredibly powerful animation
-with next to no effort.
-
-## Rendering
-
-```rust,ignore
-render_tree.render(&mut display, &DEFAULT_COLOR, origin);
-```
-
-Here, the snapshot is finally rendered to the display buffer. A default color, similar to SwiftUI's
-foreground color, is passed in. This is used for elements that don't have a color set.

--- a/docs/book/src/quickstart.rs
+++ b/docs/book/src/quickstart.rs
@@ -2,10 +2,8 @@
 // ANCHOR: simulator
 use buoyant::{
     environment::DefaultEnvironment,
-    layout::Layout,
-    render::{Render as _, Renderable as _},
     render_target::{EmbeddedGraphicsRenderTarget, RenderTarget as _},
-    view::{padding::Edges, HStack, Spacer, Text, View, ViewExt as _},
+    view::{padding::Edges, AsDrawable as _, HStack, Spacer, Text, View, ViewExt as _},
 };
 use embedded_graphics::{mono_font::ascii::FONT_10X20, pixelcolor::Rgb888, prelude::*};
 use embedded_graphics_simulator::{OutputSettings, SimulatorDisplay, Window};
@@ -15,27 +13,18 @@ const DEFAULT_COLOR: Rgb888 = Rgb888::WHITE;
 
 fn main() {
     let mut window = Window::new("Hello World", &OutputSettings::default());
-    let display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(480, 320));
-    let mut target = EmbeddedGraphicsRenderTarget::new(display);
-    target.clear(BACKGROUND_COLOR);
+    let mut display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(480, 320));
+    display.clear(BACKGROUND_COLOR);
 
-    // ANCHOR_END: simulator
-    // ANCHOR: environment
-    let environment = DefaultEnvironment::default();
-    let origin = buoyant::primitives::Point::zero();
-    // ANCHOR_END: environment
+    hello_view()
+        .as_drawable(display.size(), DEFAULT_COLOR)
+        .draw(&mut display)
+        .unwrap();
 
-    let view = hello_view();
-    let layout = view.layout(&target.size().into(), &environment);
-    let render_tree = view.render_tree(&layout, origin, &environment);
-
-    render_tree.render(&mut target, &DEFAULT_COLOR, origin);
-    // ANCHOR: simulator2
-
-    window.show_static(&target.display());
+    window.show_static(&display);
 }
 
-// ANCHOR_END: simulator2
+// ANCHOR_END: simulator
 // ANCHOR: view
 fn hello_view() -> impl View<Rgb888> {
     HStack::new((

--- a/examples/crossterm.rs
+++ b/examples/crossterm.rs
@@ -1,9 +1,10 @@
+use buoyant::environment::DefaultEnvironment;
 use buoyant::font::CharacterBufferFont;
 use buoyant::primitives::Point;
 use buoyant::render::Render;
 use buoyant::view::padding::Edges;
 use buoyant::view::View;
-use buoyant::view::{make_render_tree, ViewExt};
+use buoyant::view::ViewExt;
 use buoyant::{
     layout::VerticalAlignment,
     render_target::CrosstermRenderTarget,
@@ -114,7 +115,9 @@ fn main() {
 fn render_view(target: &mut CrosstermRenderTarget, view: &impl View<Colors>) {
     target.clear();
     let size = target.size();
-    let tree = make_render_tree(view, size);
+    let env = DefaultEnvironment::default();
+    let layout = view.layout(&size.into(), &env);
+    let tree = view.render_tree(&layout, Point::zero(), &env);
     tree.render(
         target,
         &Colors {

--- a/examples/espresso.rs
+++ b/examples/espresso.rs
@@ -69,8 +69,8 @@ mod color {
 
 fn main() {
     let size = Size::new(480, 320);
-    let display: SimulatorDisplay<color::Space> = SimulatorDisplay::new(size);
-    let mut target = EmbeddedGraphicsRenderTarget::new(display);
+    let mut display: SimulatorDisplay<color::Space> = SimulatorDisplay::new(size);
+    let mut target = EmbeddedGraphicsRenderTarget::new(&mut display);
     let mut window = Window::new("Coffeeeee", &OutputSettings::default());
     let app_start = Instant::now();
 

--- a/examples/profiler.rs
+++ b/examples/profiler.rs
@@ -1,5 +1,5 @@
 use buoyant::primitives::Point;
-use buoyant::render::Render;
+use buoyant::render::{Render, Renderable as _};
 use buoyant::view::padding::Edges;
 use buoyant::{
     environment::DefaultEnvironment,
@@ -7,9 +7,7 @@ use buoyant::{
     layout::{Layout, VerticalAlignment},
     primitives::Size,
     render_target::FixedTextBuffer,
-    view::{
-        make_render_tree, Divider, HStack, HorizontalTextAlignment, Spacer, Text, VStack, ViewExt,
-    },
+    view::{Divider, HStack, HorizontalTextAlignment, Spacer, Text, VStack, ViewExt},
 };
 
 fn main() {
@@ -60,7 +58,8 @@ fn main() {
     for width in 1..100 {
         for height in 1..100 {
             size = Size::new(width, height);
-            let tree = make_render_tree(&stack, size);
+            let layout = stack.layout(&size.into(), &env);
+            let tree = stack.render_tree(&layout, Point::zero(), &env);
             tree.render(&mut target, &' ', Point::zero());
         }
     }

--- a/examples/quickstart.rs
+++ b/examples/quickstart.rs
@@ -5,13 +5,7 @@
 //! To run this example using the ``embedded_graphics_simulator``, you must have the `sdl2` package installed.
 //! See [SDL2](https://github.com/Rust-SDL2/rust-sdl2) for installation instructions.
 
-use buoyant::{
-    environment::DefaultEnvironment,
-    layout::Layout,
-    render::{Render as _, Renderable as _},
-    render_target::EmbeddedGraphicsRenderTarget,
-    view::{padding::Edges, HStack, Spacer, Text, View, ViewExt as _},
-};
+use buoyant::view::{padding::Edges, AsDrawable, HStack, Spacer, Text, View, ViewExt as _};
 use embedded_graphics::{mono_font::ascii::FONT_10X20, pixelcolor::Rgb888, prelude::*};
 use embedded_graphics_simulator::{OutputSettings, SimulatorDisplay, Window};
 
@@ -21,21 +15,15 @@ const DEFAULT_COLOR: Rgb888 = Rgb888::WHITE;
 fn main() {
     let size = Size::new(480, 320);
     let mut window = Window::new("Hello World", &OutputSettings::default());
-    let display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(size);
-    let mut target = EmbeddedGraphicsRenderTarget::new(display);
+    let mut display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(size);
+    display.clear(BACKGROUND_COLOR).unwrap();
 
-    target.display_mut().clear(BACKGROUND_COLOR).unwrap();
+    hello_view()
+        .as_drawable(display.size(), DEFAULT_COLOR)
+        .draw(&mut display)
+        .unwrap();
 
-    let environment = DefaultEnvironment::default();
-    let origin = buoyant::primitives::Point::zero();
-
-    let view = hello_view();
-    let layout = view.layout(&size.into(), &environment);
-    let render_tree = view.render_tree(&layout, origin, &environment);
-
-    render_tree.render(&mut target, &DEFAULT_COLOR, origin);
-
-    window.show_static(target.display());
+    window.show_static(&display);
 }
 
 fn hello_view() -> impl View<Rgb888> {

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,3 +1,7 @@
+//! Render primitives.
+//!
+//! If you are constructing views, this is probably not the module you want. Use ``View`` instead.
+
 use core::time::Duration;
 
 use crate::{

--- a/src/render_target.rs
+++ b/src/render_target.rs
@@ -100,7 +100,7 @@ pub trait RenderTarget {
     /// use crate::buoyant::surface::AsDrawTarget;
     ///
     /// # let mut display = MockDisplay::<Rgb888>::new();
-    /// # let mut target = EmbeddedGraphicsRenderTarget::new(display);
+    /// # let mut target = EmbeddedGraphicsRenderTarget::new(&mut display);
     /// // let mut target = EmbeddedGraphicsRenderTarget::new(...);
     /// # let data = include_bytes!("../tests/assets/rhombic-dodecahedron.tga");
     ///

--- a/src/view/image.rs
+++ b/src/view/image.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "embedded-graphics")]
 use embedded_graphics::{image::ImageDrawable, prelude::OriginDimensions};
 
 use crate::{
@@ -15,7 +14,6 @@ pub struct Image<'a, T> {
     image: &'a T,
 }
 
-#[cfg(feature = "embedded-graphics")]
 impl<'a, T: ImageDrawable> Image<'a, T> {
     #[must_use]
     pub const fn new(image: &'a T) -> Self {
@@ -23,7 +21,6 @@ impl<'a, T: ImageDrawable> Image<'a, T> {
     }
 }
 
-#[cfg(feature = "embedded-graphics")]
 impl<T: OriginDimensions> Layout for Image<'_, T> {
     type Sublayout = ();
 
@@ -40,7 +37,6 @@ impl<T: OriginDimensions> Layout for Image<'_, T> {
     }
 }
 
-#[cfg(feature = "embedded-graphics")]
 impl<'a, T: ImageDrawable> Renderable for Image<'a, T> {
     type Renderables = render::Image<'a, T>;
 

--- a/tests/animation.rs
+++ b/tests/animation.rs
@@ -10,10 +10,12 @@ use buoyant::{
     render::{AnimatedJoin, AnimationDomain, Render, Renderable},
     render_target::FixedTextBuffer,
     view::{
-        make_render_tree, shape::Rectangle, Divider, EmptyView, HorizontalTextAlignment, Text,
-        VStack, View, ViewExt, ZStack,
+        shape::Rectangle, Divider, EmptyView, HorizontalTextAlignment, Text, VStack, View, ViewExt,
+        ZStack,
     },
 };
+mod common;
+use common::make_render_tree;
 
 const FONT: CharacterBufferFont = CharacterBufferFont;
 

--- a/tests/background.rs
+++ b/tests/background.rs
@@ -5,10 +5,11 @@ use buoyant::{
     render::Render as _,
     render_target::FixedTextBuffer,
     view::{
-        make_render_tree, padding::Edges, shape::Rectangle, EmptyView, HorizontalTextAlignment,
-        Text, ViewExt as _,
+        padding::Edges, shape::Rectangle, EmptyView, HorizontalTextAlignment, Text, ViewExt as _,
     },
 };
+mod common;
+use common::make_render_tree;
 
 #[test]
 fn background_inherits_foreground_size() {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,9 +1,11 @@
 use std::time::Duration;
 
 use buoyant::{
-    environment::LayoutEnvironment,
+    environment::{DefaultEnvironment, LayoutEnvironment},
     layout::{Alignment, LayoutDirection},
+    primitives::{Point, Size},
     render_target::FixedTextBuffer,
+    view::View,
 };
 
 #[derive(Debug, Clone)]
@@ -59,4 +61,15 @@ pub fn collect_text<const W: usize, const H: usize>(buffer: &FixedTextBuffer<W, 
         .iter()
         .map(|chars| chars.iter().collect::<String>())
         .collect::<String>()
+}
+
+#[allow(dead_code)]
+#[must_use]
+pub fn make_render_tree<C, V>(view: &V, size: Size) -> V::Renderables
+where
+    V: View<C>,
+{
+    let env = DefaultEnvironment::default();
+    let layout = view.layout(&size.into(), &env);
+    view.render_tree(&layout, Point::zero(), &env)
 }

--- a/tests/fixed_frame.rs
+++ b/tests/fixed_frame.rs
@@ -4,9 +4,10 @@ use buoyant::{
     primitives::{Dimensions, Point, ProposedDimension, ProposedDimensions, Size},
     render::Render,
     render_target::FixedTextBuffer,
-    view::{make_render_tree, Text, ViewExt},
+    view::{Text, ViewExt},
 };
 mod common;
+use common::make_render_tree;
 
 #[test]
 fn test_fixed_width() {

--- a/tests/flex_frame.rs
+++ b/tests/flex_frame.rs
@@ -10,8 +10,10 @@ use buoyant::{
     layout::{HorizontalAlignment, Layout, VerticalAlignment},
     primitives::{ProposedDimension, ProposedDimensions, Size},
     render_target::FixedTextBuffer,
-    view::{make_render_tree, shape::Rectangle, Text, ViewExt},
+    view::{shape::Rectangle, Text, ViewExt},
 };
+mod common;
+use common::make_render_tree;
 
 #[test]
 fn test_min() {

--- a/tests/foreach.rs
+++ b/tests/foreach.rs
@@ -6,8 +6,10 @@ use buoyant::{
     font::CharacterBufferFont,
     layout::{HorizontalAlignment, VerticalAlignment},
     render_target::FixedTextBuffer,
-    view::{make_render_tree, HStack, Spacer, Text},
+    view::{HStack, Spacer, Text},
 };
+mod common;
+use common::make_render_tree;
 
 static FONT: CharacterBufferFont = CharacterBufferFont {};
 

--- a/tests/geometry_group.rs
+++ b/tests/geometry_group.rs
@@ -3,8 +3,10 @@ use buoyant::{
     primitives::Point,
     render::Render as _,
     render_target::FixedTextBuffer,
-    view::{make_render_tree, shape::Rectangle, Text, VStack, ViewExt as _},
+    view::{shape::Rectangle, Text, VStack, ViewExt as _},
 };
+mod common;
+use common::make_render_tree;
 
 #[test]
 fn geometry_group_retains_text_offset() {

--- a/tests/hidden.rs
+++ b/tests/hidden.rs
@@ -6,8 +6,10 @@ use buoyant::{
     primitives::Point,
     render::Render as _,
     render_target::FixedTextBuffer,
-    view::{make_render_tree, HStack, Text, ViewExt as _},
+    view::{HStack, Text, ViewExt as _},
 };
+mod common;
+use common::make_render_tree;
 
 #[test]
 fn background_renders_on_hidden_view() {

--- a/tests/hstack.rs
+++ b/tests/hstack.rs
@@ -6,10 +6,11 @@ use buoyant::layout::{Layout, VerticalAlignment};
 use buoyant::primitives::{Dimensions, Point, ProposedDimension, ProposedDimensions, Size};
 use buoyant::render::{Render, Renderable};
 use buoyant::render_target::FixedTextBuffer;
-use buoyant::view::make_render_tree;
 use buoyant::view::padding::Edges;
 use buoyant::view::View;
 use buoyant::view::{shape::Rectangle, Divider, EmptyView, HStack, Spacer, Text, ViewExt};
+mod common;
+use common::make_render_tree;
 
 #[test]
 fn test_greedy_layout_2() {

--- a/tests/padding.rs
+++ b/tests/padding.rs
@@ -9,11 +9,10 @@ use buoyant::{
     layout::Layout,
     primitives::{Dimensions, Size},
     render_target::FixedTextBuffer,
-    view::{
-        make_render_tree, shape::Rectangle, Divider, HorizontalTextAlignment, Spacer, Text, VStack,
-        ViewExt,
-    },
+    view::{shape::Rectangle, Divider, HorizontalTextAlignment, Spacer, Text, VStack, ViewExt},
 };
+mod common;
+use common::make_render_tree;
 
 #[test]
 fn test_clipped_text_trails_correctly() {

--- a/tests/spacer.rs
+++ b/tests/spacer.rs
@@ -5,10 +5,11 @@ use buoyant::primitives::{
 };
 use buoyant::render::Render;
 use buoyant::render_target::FixedTextBuffer;
-use buoyant::view::{make_render_tree, HStack, Spacer, Text, VStack, ViewExt as _};
+use buoyant::view::{HStack, Spacer, Text, VStack, ViewExt as _};
 use common::{collect_text, TestEnv};
 
 mod common;
+use common::make_render_tree;
 
 #[test]
 fn test_horizontal_layout() {

--- a/tests/text.rs
+++ b/tests/text.rs
@@ -8,8 +8,10 @@ use buoyant::{
     primitives::{Dimensions, Point},
     render::Renderable as _,
     render_target::FixedTextBuffer,
-    view::{make_render_tree, HorizontalTextAlignment, Text, ViewExt as _},
+    view::{HorizontalTextAlignment, Text, ViewExt as _},
 };
+mod common;
+use common::make_render_tree;
 
 #[test]
 fn test_render_wrapping_leading() {

--- a/tests/vstack.rs
+++ b/tests/vstack.rs
@@ -4,7 +4,6 @@ use buoyant::layout::{HorizontalAlignment, Layout, VerticalAlignment};
 use buoyant::primitives::{Dimensions, Point, ProposedDimension, ProposedDimensions, Size};
 use buoyant::render::Render;
 use buoyant::render_target::FixedTextBuffer;
-use buoyant::view::make_render_tree;
 use buoyant::view::padding::Edges;
 use buoyant::view::{
     shape::Rectangle, Divider, EmptyView, HStack, HorizontalTextAlignment, Spacer, Text, VStack,
@@ -12,7 +11,7 @@ use buoyant::view::{
 };
 
 mod common;
-use common::collect_text;
+use common::{collect_text, make_render_tree};
 
 #[test]
 fn test_greedy_layout_2() {

--- a/tests/zstack.rs
+++ b/tests/zstack.rs
@@ -6,7 +6,9 @@ use buoyant::render::Render;
 use buoyant::render_target::FixedTextBuffer;
 use buoyant::view::padding::Edges;
 use buoyant::view::shape::Rectangle;
-use buoyant::view::{make_render_tree, Divider, Spacer, Text, ViewExt, ZStack};
+use buoyant::view::{Divider, Spacer, Text, ViewExt, ZStack};
+mod common;
+use common::make_render_tree;
 
 #[test]
 fn test_layout_fills_two() {


### PR DESCRIPTION
This adds a new trait, `AsDrawable` which lets you render static views without all the boilerplate.