### PR TITLE
Reduce jitter when interpolating shapes

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -126,6 +126,16 @@ impl core::ops::AddAssign for Point {
     }
 }
 
+impl core::ops::Add<Size> for Point {
+    type Output = Self;
+    fn add(self, rhs: Size) -> Self {
+        Self {
+            x: self.x + rhs.width as i32,
+            y: self.y + rhs.height as i32,
+        }
+    }
+}
+
 impl Point {
     #[must_use]
     pub const fn new(x: i32, y: i32) -> Self {

--- a/src/render/shape/capsule.rs
+++ b/src/render/shape/capsule.rs
@@ -41,7 +41,16 @@ impl AsShapePrimitive for Capsule {
 impl AnimatedJoin for Capsule {
     fn join(source: Self, target: Self, domain: &AnimationDomain) -> Self {
         let origin = Point::interpolate(source.origin, target.origin, domain.factor);
-        let size = Size::interpolate(source.size, target.size, domain.factor);
+        // Avoid directly interpolating the size as it can lead to jitter from lack of precision
+        let bottom_right = Point::interpolate(
+            source.origin + source.size,
+            target.origin + target.size,
+            domain.factor,
+        );
+        let size = Size::new(
+            bottom_right.x.abs_diff(origin.x),
+            bottom_right.y.abs_diff(origin.y),
+        );
         Self::new(origin, size)
     }
 }
@@ -112,5 +121,17 @@ mod tests {
         // Inset larger than size should not result in negative dimensions
         assert_eq!(inset_capsule.origin, Point::new(210, 220));
         assert_eq!(inset_capsule.size, Size::new(0, 0));
+    }
+
+    #[test]
+    fn trailing_corner_does_not_jitter() {
+        let source = Capsule::new(Point::new(990, 990), Size::new(10, 10));
+        let target = Capsule::new(Point::new(0, 0), Size::new(1000, 1000));
+
+        for factor in 0..=255 {
+            let result =
+                AnimatedJoin::join(source.clone(), target.clone(), &animation_domain(factor));
+            assert_eq!(result.origin + result.size, Point::new(1000, 1000));
+        }
     }
 }


### PR DESCRIPTION
Nonlinear animation curves which interpolate shape lengths and positions simultaneously can result in unexpected changes in shape dimensions. Rather than interpolating length and width, x_end and y_end are used for interpolation then converted back to width and height.

It seems like storing width/height actually results in more problems and work...Looking into changing this later to store the start and end dimensions instead.