### PR TITLE
fix: make component state `'static` to allow more use cases

### DIFF
--- a/src/view.rs
+++ b/src/view.rs
@@ -120,12 +120,12 @@ pub trait ViewLayout<Captures: ?Sized>: ViewMarker {
     ///
     /// This state is created once when the view is first initialized and is intended
     /// to persist across multiple layout/render cycles.
-    type State;
+    type State: 'static;
 
     /// The computed layout of the view and its subviews.
     ///
     /// Size is represented here, but placement is deferred to the render tree.
-    type Sublayout: Clone + PartialEq;
+    type Sublayout: Clone + PartialEq + 'static;
 
     /// The layout priority of the view. Higher priority views are more likely to
     /// be given the size they want

--- a/src/view/modifier/animated.rs
+++ b/src/view/modifier/animated.rs
@@ -30,7 +30,7 @@ impl<InnerView: ViewMarker<Renderables: Clone>, U: Clone> ViewMarker for Animate
     type Transition = InnerView::Transition;
 }
 
-impl<Captures: ?Sized, InnerView, U: PartialEq + Clone> ViewLayout<Captures>
+impl<Captures: ?Sized, InnerView, U: PartialEq + Clone + 'static> ViewLayout<Captures>
     for Animated<InnerView, U>
 where
     InnerView: ViewLayout<Captures, Renderables: Clone>,


### PR DESCRIPTION
I had a component with logs and scrolling. Turns out, if `State` assoc is not `'static`, the borrow checker will force me to hold `&str` until the `state` is used. So basically it will work if you test with a constant, but will not if you want to borrow some buffer, render and remove the borrow.