### PR TITLE
feat(text): improve `Text` memory footprint

### DIFF
--- a/src/primitives/size.rs
+++ b/src/primitives/size.rs
@@ -85,6 +85,15 @@ impl From<Size> for embedded_graphics_core::geometry::Size {
     }
 }
 
+impl<T: Into<u32>> From<(T, T)> for Size {
+    fn from(value: (T, T)) -> Self {
+        Self {
+            width: value.0.into(),
+            height: value.1.into(),
+        }
+    }
+}
+
 impl Interpolate for Size {
     fn interpolate(from: Self, to: Self, amount: u8) -> Self {
         Self {


### PR DESCRIPTION
- Removes cached lines
- Make `new_fmt` use `u8` for the capacity
- Add `new_fmt_long` to allow other length types (i.e. u16)
- Make fields smaller