### PR TITLE
Reduce layout size

### DIFF
--- a/buoyant-examples/battery/src/app.rs
+++ b/buoyant-examples/battery/src/app.rs
@@ -87,7 +87,7 @@ impl App {
         let mut state = view.build_state(&mut ());
         let layout = view.layout(&dimensions, &env, &mut (), &mut state);
         view.render_tree(
-            &layout,
+            &layout.sublayouts,
             buoyant::primitives::Point::zero(),
             &env,
             &mut (),

--- a/docs/book/src/animation/animated-render-loops.md
+++ b/docs/book/src/animation/animated-render-loops.md
@@ -29,12 +29,12 @@ To animate rendering between two render trees, use the `render_animated()` metho
 # let source_view = view();
 # let mut view_state = source_view.build_state(&mut ());
 # let source_layout = source_view.layout(&Size::new(200, 100).into(), &environment, &mut captures, &mut view_state);
-let source_render_tree = source_view.render_tree(&source_layout, Point::zero(), &environment, &mut captures, &mut view_state);
+let source_render_tree = source_view.render_tree(&source_layout.sublayouts, Point::zero(), &environment, &mut captures, &mut view_state);
 
 # let environment = DefaultEnvironment::new(app_time);
 # let target_view = view();
 # let target_layout = target_view.layout(&Size::new(200, 100).into(), &environment, &mut captures, &mut view_state);
-let target_render_tree = target_view.render_tree(&target_layout, Point::zero(), &environment, &mut captures, &mut view_state);
+let target_render_tree = target_view.render_tree(&target_layout.sublayouts, Point::zero(), &environment, &mut captures, &mut view_state);
 
 Render::render_animated(
     &mut target,
@@ -86,12 +86,12 @@ is the same as rendering the two trees with `render_animated()`.
 # let source_view = view();
 # let mut view_state = source_view.build_state(&mut ());
 # let source_layout = source_view.layout(&Size::new(200, 100).into(), &environment, &mut captures, &mut view_state);
-let source_render_tree = source_view.render_tree(&source_layout, Point::zero(), &environment, &mut captures, &mut view_state);
+let source_render_tree = source_view.render_tree(&source_layout.sublayouts, Point::zero(), &environment, &mut captures, &mut view_state);
 
 # let environment = DefaultEnvironment::new(app_time);
 # let target_view = view();
 # let target_layout = target_view.layout(&Size::new(200, 100).into(), &environment, &mut captures, &mut view_state);
-let mut target_render_tree = target_view.render_tree(&target_layout, Point::zero(), &environment, &mut captures, &mut view_state);
+let mut target_render_tree = target_view.render_tree(&target_layout.sublayouts, Point::zero(), &environment, &mut captures, &mut view_state);
 
 // Join two trees into the target
 target_render_tree.join_from(

--- a/docs/book/src/building-views/manual-view-lifecycle.md
+++ b/docs/book/src/building-views/manual-view-lifecycle.md
@@ -39,7 +39,7 @@ fn main() {
 
     let mut app_state = view.build_state(&mut app_data);
     let layout = view.layout(&size.into(), &environment, &mut app_data, &mut app_state);
-    let render_tree = view.render_tree(&layout, origin, &environment, &mut app_data, &mut app_state);
+    let render_tree = view.render_tree(&layout.sublayouts, origin, &environment, &mut app_data, &mut app_state);
 
     render_tree.render(&mut target, &DEFAULT_COLOR);
 

--- a/docs/book/src/interactivity/event-loops.rs
+++ b/docs/book/src/interactivity/event-loops.rs
@@ -34,10 +34,20 @@ fn main() {
     let env = DefaultEnvironment::new(time);
     let layout = view.layout(&size.into(), &env, &mut count, &mut state);
 
-    let mut source_tree =
-        &mut view.render_tree(&layout, Point::zero(), &env, &mut count, &mut state);
-    let mut target_tree =
-        &mut view.render_tree(&layout, Point::zero(), &env, &mut count, &mut state);
+    let mut source_tree = &mut view.render_tree(
+        &layout.sublayouts,
+        Point::zero(),
+        &env,
+        &mut count,
+        &mut state,
+    );
+    let mut target_tree = &mut view.render_tree(
+        &layout.sublayouts,
+        Point::zero(),
+        &env,
+        &mut count,
+        &mut state,
+    );
 
     // ANCHOR: event_loop
     // Main event loop
@@ -85,7 +95,13 @@ fn main() {
             view = counter_view(count);
             let env = DefaultEnvironment::new(time);
             let layout = view.layout(&size.into(), &env, &mut count, &mut state);
-            *target_tree = view.render_tree(&layout, Point::zero(), &env, &mut count, &mut state);
+            *target_tree = view.render_tree(
+                &layout.sublayouts,
+                Point::zero(),
+                &env,
+                &mut count,
+                &mut state,
+            );
         }
         // ANCHOR_END: recompute_view
 

--- a/examples/crossterm.rs
+++ b/examples/crossterm.rs
@@ -109,7 +109,7 @@ fn render_view(target: &mut CrosstermRenderTarget, view: &impl View<Colors, ()>)
     let env = DefaultEnvironment::default();
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&size.into(), &env, &mut (), &mut state);
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(
         target,
         &Colors {

--- a/examples/espresso/main.rs
+++ b/examples/espresso/main.rs
@@ -91,14 +91,14 @@ fn main() {
     let layout = view.layout(&target.size().into(), &env, &mut app_data, &mut view_state);
 
     let mut source_tree = &mut view.render_tree(
-        &layout,
+        &layout.sublayouts,
         Point::default(),
         &env,
         &mut app_data,
         &mut view_state,
     );
     let mut target_tree = &mut view.render_tree(
-        &layout,
+        &layout.sublayouts,
         Point::default(),
         &env,
         &mut app_data,
@@ -148,7 +148,7 @@ fn main() {
             let env = DefaultEnvironment::new(time);
             let layout = view.layout(&target.size().into(), &env, &mut app_data, &mut view_state);
             *target_tree = view.render_tree(
-                &layout,
+                &layout.sublayouts,
                 Point::default(),
                 &env,
                 &mut app_data,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -98,6 +98,18 @@ pub struct ResolvedLayout<C: Clone + PartialEq> {
     pub resolved_size: Dimensions,
 }
 
+impl<C: Clone + PartialEq> ResolvedLayout<C> {
+    pub fn nested(self) -> ResolvedLayout<Self> {
+        ResolvedLayout {
+            sublayouts: Self {
+                sublayouts: self.sublayouts,
+                resolved_size: self.resolved_size,
+            },
+            resolved_size: self.resolved_size,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Axis {
     FixedWidth(u32),

--- a/src/view.rs
+++ b/src/view.rs
@@ -168,7 +168,7 @@ pub trait ViewLayout<Captures: ?Sized>: ViewMarker {
     /// renderable objects that will be drawn to the screen.
     fn render_tree(
         &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
+        layout: &Self::Sublayout,
         origin: Point,
         env: &impl LayoutEnvironment,
         captures: &mut Captures,
@@ -223,7 +223,7 @@ where
 
     fn render_tree(
         &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
+        layout: &Self::Sublayout,
         origin: Point,
         env: &impl LayoutEnvironment,
         captures: &mut Captures,

--- a/src/view/as_drawable.rs
+++ b/src/view/as_drawable.rs
@@ -59,7 +59,13 @@ where
         let env = DefaultEnvironment::non_animated();
         let mut state = self.build_state(captures);
         let layout = self.layout(&size.into(), &env, captures, &mut state);
-        let render_tree = self.render_tree(&layout, Point::zero(), &env, captures, &mut state);
+        let render_tree = self.render_tree(
+            &layout.sublayouts,
+            Point::zero(),
+            &env,
+            captures,
+            &mut state,
+        );
         DrawableView {
             render_tree,
             default_color,

--- a/src/view/capturing.rs
+++ b/src/view/capturing.rs
@@ -74,7 +74,7 @@ impl<
 
     fn render_tree(
         &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
+        layout: &Self::Sublayout,
         origin: Point,
         env: &impl LayoutEnvironment,
         captures: &mut Captures,

--- a/src/view/divider.rs
+++ b/src/view/divider.rs
@@ -41,7 +41,7 @@ impl ViewMarker for Divider {
 
 impl<Captures: ?Sized> ViewLayout<Captures> for Divider {
     type State = ();
-    type Sublayout = ();
+    type Sublayout = Dimensions;
 
     fn priority(&self) -> i8 {
         i8::MAX
@@ -71,14 +71,14 @@ impl<Captures: ?Sized> ViewLayout<Captures> for Divider {
             },
         };
         ResolvedLayout {
-            sublayouts: (),
+            sublayouts: size,
             resolved_size: size,
         }
     }
 
     fn render_tree(
         &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
+        layout: &Self::Sublayout,
         origin: Point,
         _env: &impl LayoutEnvironment,
         _captures: &mut Captures,
@@ -86,7 +86,7 @@ impl<Captures: ?Sized> ViewLayout<Captures> for Divider {
     ) -> Self::Renderables {
         crate::render::Rect {
             origin,
-            size: layout.resolved_size.into(),
+            size: (*layout).into(),
         }
     }
 }

--- a/src/view/empty_view.rs
+++ b/src/view/empty_view.rs
@@ -80,7 +80,7 @@ impl<Captures: ?Sized> ViewLayout<Captures> for EmptyView {
 
     fn render_tree(
         &self,
-        _layout: &ResolvedLayout<Self::Sublayout>,
+        _layout: &Self::Sublayout,
         _origin: Point,
         _env: &impl LayoutEnvironment,
         _captures: &mut Captures,

--- a/src/view/foreach.rs
+++ b/src/view/foreach.rs
@@ -241,7 +241,7 @@ where
     V: ViewLayout<Captures>,
     F: Fn(&'a I) -> V,
 {
-    type Sublayout = heapless::Vec<ResolvedLayout<V::Sublayout>, N>;
+    type Sublayout = ResolvedLayout<heapless::Vec<ResolvedLayout<V::Sublayout>, N>>;
     type State = heapless::Vec<V::State, N>;
 
     fn transition(&self) -> Self::Transition {
@@ -311,11 +311,12 @@ where
             sublayouts,
             resolved_size: size,
         }
+        .nested()
     }
 
     fn render_tree(
         &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
+        layout: &Self::Sublayout,
         origin: Point,
         env: &impl LayoutEnvironment,
         captures: &mut Captures,
@@ -338,7 +339,7 @@ where
 
             // TODO: If we include an ID here, rows can be animated and transitioned
             let item = renderables.push(view.render_tree(
-                item_layout,
+                &item_layout.sublayouts,
                 aligned_origin,
                 env,
                 captures,

--- a/src/view/hstack.rs
+++ b/src/view/hstack.rs
@@ -246,7 +246,8 @@ macro_rules! impl_view_for_hstack {
             $($type: ViewLayout<Captures>),+
         {
             type State = ($($type::State),+);
-            type Sublayout = ($(ResolvedLayout<$type::Sublayout>),+);
+            // FIXME: Could just be height + sublayouts?
+            type Sublayout = ResolvedLayout<($(ResolvedLayout<$type::Sublayout>),+)>;
 
             fn transition(&self) -> Self::Transition {
                 crate::transition::Opacity
@@ -297,13 +298,13 @@ macro_rules! impl_view_for_hstack {
                         [<c $n>] .unwrap()
                     ),+),
                     resolved_size: total_size,
-                }
+                }.nested()
             }
 
             #[allow(unused_assignments)]
             fn render_tree(
                 &self,
-                layout: &ResolvedLayout<Self::Sublayout>,
+                layout: &Self::Sublayout,
                 origin: Point,
                 env: &impl LayoutEnvironment,
                 captures: &mut Captures,
@@ -321,7 +322,7 @@ macro_rules! impl_view_for_hstack {
                     );
 
                     let [<subtree_$n>] = self.items.$n.render_tree(
-                        &layout.sublayouts.$n,
+                        &layout.sublayouts.$n.sublayouts,
                         offset,
                         &env,
                         captures,
@@ -450,7 +451,7 @@ where
 
     fn render_tree(
         &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
+        layout: &Self::Sublayout,
         origin: Point,
         env: &impl LayoutEnvironment,
         captures: &mut Captures,

--- a/src/view/image.rs
+++ b/src/view/image.rs
@@ -58,7 +58,7 @@ where
 
     fn render_tree(
         &self,
-        _layout: &ResolvedLayout<Self::Sublayout>,
+        _layout: &Self::Sublayout,
         origin: crate::primitives::Point,
         _env: &impl crate::environment::LayoutEnvironment,
         _captures: &mut Captures,

--- a/src/view/match_view.rs
+++ b/src/view/match_view.rs
@@ -308,22 +308,22 @@ macro_rules! define_branch {
 
             fn render_tree(
                 &self,
-                layout: &ResolvedLayout<Self::Sublayout>,
+                layout: &Self::Sublayout,
                 origin: Point,
                 env: &impl crate::environment::LayoutEnvironment,
                 captures: &mut Captures,
                 state: &mut Self::State,
             ) -> Self::Renderables {
-                match (self, &layout.sublayouts) {
+                match (self, layout) {
                     $(
                     (Self::$variant(v), $name::$variant(l0)) => {
                         // apparently consumes a lot less stack than matching on state too
                         if let $name::$variant(s) = state {
-                            render::$name::$variant(v.render_tree(l0, origin, env, captures, s))
+                            render::$name::$variant(v.render_tree(&l0.sublayouts, origin, env, captures, s))
                         } else {
                             let mut s = v.build_state(captures);
                             let renderables =
-                                render::$name::$variant(v.render_tree(l0, origin, env, captures, &mut s));
+                                render::$name::$variant(v.render_tree(&l0.sublayouts, origin, env, captures, &mut s));
                             *state = $name::$variant(s);
                             renderables
                         }

--- a/src/view/modifier/animated.rs
+++ b/src/view/modifier/animated.rs
@@ -66,7 +66,7 @@ where
 
     fn render_tree(
         &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
+        layout: &Self::Sublayout,
         origin: Point,
         env: &impl LayoutEnvironment,
         captures: &mut Captures,

--- a/src/view/modifier/aspect_ratio.rs
+++ b/src/view/modifier/aspect_ratio.rs
@@ -173,7 +173,7 @@ where
 
     fn render_tree(
         &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
+        layout: &Self::Sublayout,
         origin: Point,
         env: &impl LayoutEnvironment,
         captures: &mut Captures,

--- a/src/view/modifier/background_color.rs
+++ b/src/view/modifier/background_color.rs
@@ -82,7 +82,7 @@ where
 
     fn render_tree(
         &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
+        layout: &Self::Sublayout,
         origin: Point,
         env: &impl LayoutEnvironment,
         captures: &mut Captures,
@@ -103,7 +103,7 @@ where
                 ),
             );
         let background_shape = self.background_shape.render_tree(
-            &background_layout,
+            &background_layout.sublayouts,
             background_origin,
             env,
             &mut (),

--- a/src/view/modifier/erase_captures.rs
+++ b/src/view/modifier/erase_captures.rs
@@ -71,7 +71,7 @@ impl<T: ViewLayout<()>, Captures: ?Sized> ViewLayout<Captures> for EraseCaptures
 
     fn render_tree(
         &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
+        layout: &Self::Sublayout,
         origin: Point,
         env: &impl LayoutEnvironment,
         _captures: &mut Captures,

--- a/src/view/modifier/fixed_size.rs
+++ b/src/view/modifier/fixed_size.rs
@@ -84,7 +84,7 @@ where
 
     fn render_tree(
         &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
+        layout: &Self::Sublayout,
         origin: Point,
         env: &impl LayoutEnvironment,
         captures: &mut Captures,

--- a/src/view/modifier/foreground_color.rs
+++ b/src/view/modifier/foreground_color.rs
@@ -62,7 +62,7 @@ impl<Color: Interpolate + Clone, Captures: ?Sized, Inner: ViewLayout<Captures>> 
 
     fn render_tree(
         &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
+        layout: &Self::Sublayout,
         origin: Point,
         env: &impl LayoutEnvironment,
         captures: &mut Captures,

--- a/src/view/modifier/geometry_group.rs
+++ b/src/view/modifier/geometry_group.rs
@@ -61,7 +61,7 @@ where
 
     fn render_tree(
         &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
+        layout: &Self::Sublayout,
         origin: Point,
         env: &impl LayoutEnvironment,
         captures: &mut Captures,

--- a/src/view/modifier/hidden.rs
+++ b/src/view/modifier/hidden.rs
@@ -29,7 +29,7 @@ impl<Captures: ?Sized, T> ViewLayout<Captures> for Hidden<T>
 where
     T: ViewLayout<Captures>,
 {
-    type Sublayout = T::Sublayout;
+    type Sublayout = ();
     type State = T::State;
 
     fn priority(&self) -> i8 {
@@ -55,12 +55,16 @@ where
         captures: &mut Captures,
         state: &mut Self::State,
     ) -> ResolvedLayout<Self::Sublayout> {
-        self.child.layout(offer, env, captures, state)
+        let layout = self.child.layout(offer, env, captures, state);
+        ResolvedLayout {
+            sublayouts: (),
+            resolved_size: layout.resolved_size,
+        }
     }
 
     fn render_tree(
         &self,
-        _layout: &ResolvedLayout<Self::Sublayout>,
+        _layout: &Self::Sublayout,
         _origin: Point,
         _env: &impl LayoutEnvironment,
         _captures: &mut Captures,

--- a/src/view/modifier/hint_background.rs
+++ b/src/view/modifier/hint_background.rs
@@ -65,7 +65,7 @@ where
 
     fn render_tree(
         &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
+        layout: &Self::Sublayout,
         origin: Point,
         env: &impl LayoutEnvironment,
         captures: &mut Captures,

--- a/src/view/modifier/offset.rs
+++ b/src/view/modifier/offset.rs
@@ -62,7 +62,7 @@ where
 
     fn render_tree(
         &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
+        layout: &Self::Sublayout,
         origin: crate::primitives::Point,
         env: &impl LayoutEnvironment,
         captures: &mut Captures,

--- a/src/view/modifier/opacity.rs
+++ b/src/view/modifier/opacity.rs
@@ -64,7 +64,7 @@ where
 
     fn render_tree(
         &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
+        layout: &Self::Sublayout,
         origin: Point,
         env: &impl LayoutEnvironment,
         captures: &mut Captures,

--- a/src/view/modifier/overlay.rs
+++ b/src/view/modifier/overlay.rs
@@ -39,7 +39,7 @@ where
     T: ViewLayout<Captures>,
     U: ViewLayout<Captures>,
 {
-    type Sublayout = (ResolvedLayout<T::Sublayout>, ResolvedLayout<U::Sublayout>);
+    type Sublayout = ResolvedLayout<T::Sublayout>;
     // Tuples are rendered first to last
     type State = (T::State, U::State);
 
@@ -70,6 +70,21 @@ where
     ) -> ResolvedLayout<Self::Sublayout> {
         let foreground_layout = self.foreground.layout(offer, env, captures, &mut state.0);
         let foreground_size = foreground_layout.resolved_size;
+        ResolvedLayout {
+            sublayouts: foreground_layout,
+            resolved_size: foreground_size,
+        }
+    }
+
+    fn render_tree(
+        &self,
+        layout: &Self::Sublayout,
+        origin: Point,
+        env: &impl LayoutEnvironment,
+        captures: &mut Captures,
+        state: &mut Self::State,
+    ) -> Self::Renderables {
+        let foreground_size = layout.resolved_size;
         // Propose the foreground size to the overlay
         // This would benefit from splitting layout into separate functions for the various offers
         let overlay_offer = ProposedDimensions {
@@ -80,37 +95,23 @@ where
             .overlay
             .layout(&overlay_offer, env, captures, &mut state.1);
 
-        ResolvedLayout {
-            sublayouts: (foreground_layout, overlay_layout),
-            resolved_size: foreground_size,
-        }
-    }
-
-    fn render_tree(
-        &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
-        origin: Point,
-        env: &impl LayoutEnvironment,
-        captures: &mut Captures,
-        state: &mut Self::State,
-    ) -> Self::Renderables {
         let new_origin = origin
             + Point::new(
                 self.alignment.horizontal().align(
                     layout.resolved_size.width.into(),
-                    layout.sublayouts.1.resolved_size.width.into(),
+                    overlay_layout.resolved_size.width.into(),
                 ),
                 self.alignment.vertical().align(
                     layout.resolved_size.height.into(),
-                    layout.sublayouts.1.resolved_size.height.into(),
+                    overlay_layout.resolved_size.height.into(),
                 ),
             );
 
         (
             self.foreground
-                .render_tree(&layout.sublayouts.0, origin, env, captures, &mut state.0),
+                .render_tree(&layout.sublayouts, origin, env, captures, &mut state.0),
             self.overlay.render_tree(
-                &layout.sublayouts.1,
+                &overlay_layout.sublayouts,
                 new_origin,
                 env,
                 captures,

--- a/src/view/modifier/padding.rs
+++ b/src/view/modifier/padding.rs
@@ -55,7 +55,7 @@ impl<Captures: ?Sized, V> ViewLayout<Captures> for Padding<V>
 where
     V: ViewLayout<Captures>,
 {
-    type Sublayout = ResolvedLayout<V::Sublayout>;
+    type Sublayout = V::Sublayout;
     type State = V::State;
 
     fn priority(&self) -> i8 {
@@ -96,17 +96,15 @@ where
             width: offer.width - extra_width,
             height: offer.height - extra_height,
         };
-        let child_layout = self.inner.layout(&padded_offer, env, captures, state);
+        let mut child_layout = self.inner.layout(&padded_offer, env, captures, state);
         let padding_size = child_layout.resolved_size + Size::new(extra_width, extra_height);
-        ResolvedLayout {
-            sublayouts: child_layout,
-            resolved_size: padding_size,
-        }
+        child_layout.resolved_size = padding_size;
+        child_layout
     }
 
     fn render_tree(
         &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
+        layout: &Self::Sublayout,
         origin: Point,
         env: &impl LayoutEnvironment,
         captures: &mut Captures,
@@ -119,7 +117,7 @@ where
             Edges::Bottom | Edges::Trailing => (0, 0),
         };
         self.inner.render_tree(
-            &layout.sublayouts,
+            layout,
             origin + Point::new(leading as i32, top as i32),
             env,
             captures,

--- a/src/view/modifier/priority.rs
+++ b/src/view/modifier/priority.rs
@@ -74,7 +74,7 @@ where
 
     fn render_tree(
         &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
+        layout: &Self::Sublayout,
         origin: Point,
         env: &impl LayoutEnvironment,
         captures: &mut Captures,

--- a/src/view/modifier/transition.rs
+++ b/src/view/modifier/transition.rs
@@ -65,7 +65,7 @@ where
 
     fn render_tree(
         &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
+        layout: &Self::Sublayout,
         origin: Point,
         env: &impl LayoutEnvironment,
         captures: &mut Captures,

--- a/src/view/option.rs
+++ b/src/view/option.rs
@@ -75,15 +75,15 @@ where
 
     fn render_tree(
         &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
+        layout: &Self::Sublayout,
         origin: Point,
         env: &impl crate::environment::LayoutEnvironment,
         captures: &mut Captures,
         state: &mut Self::State,
     ) -> Self::Renderables {
-        match (self, &layout.sublayouts, state) {
+        match (self, layout, state) {
             (Some(v), Some(l0), Some(s0)) => TransitionOption::new_some(
-                v.render_tree(l0, origin, env, captures, s0),
+                v.render_tree(&l0.sublayouts, origin, env, captures, s0),
                 l0.resolved_size.into(),
                 v.transition(),
             ),

--- a/src/view/shape.rs
+++ b/src/view/shape.rs
@@ -112,7 +112,7 @@ where
 
     fn render_tree(
         &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
+        layout: &Self::Sublayout,
         origin: Point,
         env: &impl LayoutEnvironment,
         captures: &mut Captures,

--- a/src/view/shape/capsule.rs
+++ b/src/view/shape/capsule.rs
@@ -1,7 +1,7 @@
 use crate::{
     environment::LayoutEnvironment,
     layout::ResolvedLayout,
-    primitives::{Point, ProposedDimensions},
+    primitives::{Dimensions, Point, ProposedDimensions},
     transition::Opacity,
     view::{ViewLayout, ViewMarker},
 };
@@ -21,7 +21,7 @@ impl ViewMarker for Capsule {
 
 impl<Captures: ?Sized> ViewLayout<Captures> for Capsule {
     type State = ();
-    type Sublayout = ();
+    type Sublayout = Dimensions;
 
     fn transition(&self) -> Self::Transition {
         Opacity
@@ -36,15 +36,16 @@ impl<Captures: ?Sized> ViewLayout<Captures> for Capsule {
         _captures: &mut Captures,
         _state: &mut Self::State,
     ) -> ResolvedLayout<Self::Sublayout> {
+        let dimensions = offer.resolve_most_flexible(0, 1);
         ResolvedLayout {
-            sublayouts: (),
+            sublayouts: dimensions,
             resolved_size: offer.resolve_most_flexible(0, 1),
         }
     }
 
     fn render_tree(
         &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
+        layout: &Self::Sublayout,
         origin: Point,
         _env: &impl LayoutEnvironment,
         _captures: &mut Captures,
@@ -52,7 +53,7 @@ impl<Captures: ?Sized> ViewLayout<Captures> for Capsule {
     ) -> Self::Renderables {
         crate::render::Capsule {
             origin,
-            size: layout.resolved_size.into(),
+            size: (*layout).into(),
         }
     }
 }

--- a/src/view/shape/circle.rs
+++ b/src/view/shape/circle.rs
@@ -29,7 +29,7 @@ impl ViewMarker for Circle {
 
 impl<Captures: ?Sized> ViewLayout<Captures> for Circle {
     type State = ();
-    type Sublayout = ();
+    type Sublayout = crate::primitives::Dimension;
 
     fn transition(&self) -> Self::Transition {
         Opacity
@@ -47,7 +47,7 @@ impl<Captures: ?Sized> ViewLayout<Captures> for Circle {
         let minimum_dimension = offer.width.min(offer.height).resolve_most_flexible(0, 1);
 
         ResolvedLayout {
-            sublayouts: (),
+            sublayouts: minimum_dimension,
             resolved_size: Dimensions {
                 width: minimum_dimension,
                 height: minimum_dimension,
@@ -57,7 +57,7 @@ impl<Captures: ?Sized> ViewLayout<Captures> for Circle {
 
     fn render_tree(
         &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
+        layout: &Self::Sublayout,
         origin: Point,
         _env: &impl LayoutEnvironment,
         _captures: &mut Captures,
@@ -65,7 +65,7 @@ impl<Captures: ?Sized> ViewLayout<Captures> for Circle {
     ) -> Self::Renderables {
         crate::render::Circle {
             origin,
-            diameter: layout.resolved_size.width.into(),
+            diameter: (*layout).into(),
         }
     }
 }

--- a/src/view/shape/rectangle.rs
+++ b/src/view/shape/rectangle.rs
@@ -1,7 +1,7 @@
 use crate::{
     environment::LayoutEnvironment,
     layout::ResolvedLayout,
-    primitives::{Point, ProposedDimensions},
+    primitives::{Dimensions, Point, ProposedDimensions},
     transition::Opacity,
     view::{ViewLayout, ViewMarker},
 };
@@ -32,7 +32,7 @@ impl ViewMarker for Rectangle {
 
 impl<Captures: ?Sized> ViewLayout<Captures> for Rectangle {
     type State = ();
-    type Sublayout = ();
+    type Sublayout = Dimensions;
 
     fn transition(&self) -> Self::Transition {
         Opacity
@@ -47,15 +47,16 @@ impl<Captures: ?Sized> ViewLayout<Captures> for Rectangle {
         _captures: &mut Captures,
         _state: &mut Self::State,
     ) -> ResolvedLayout<Self::Sublayout> {
+        let dimensions = offer.resolve_most_flexible(0, 1);
         ResolvedLayout {
-            sublayouts: (),
-            resolved_size: offer.resolve_most_flexible(0, 1),
+            sublayouts: dimensions,
+            resolved_size: dimensions,
         }
     }
 
     fn render_tree(
         &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
+        layout: &Self::Sublayout,
         origin: Point,
         _env: &impl LayoutEnvironment,
         _captures: &mut Captures,
@@ -63,7 +64,7 @@ impl<Captures: ?Sized> ViewLayout<Captures> for Rectangle {
     ) -> Self::Renderables {
         crate::render::Rect {
             origin,
-            size: layout.resolved_size.into(),
+            size: (*layout).into(),
         }
     }
 }

--- a/src/view/shape/rounded_rectangle.rs
+++ b/src/view/shape/rounded_rectangle.rs
@@ -1,7 +1,7 @@
 use crate::{
     environment::LayoutEnvironment,
     layout::ResolvedLayout,
-    primitives::{Point, ProposedDimensions},
+    primitives::{Dimensions, Point, ProposedDimensions},
     transition::Opacity,
     view::{ViewLayout, ViewMarker},
 };
@@ -30,7 +30,7 @@ impl ViewMarker for RoundedRectangle {
 }
 
 impl<Captures: ?Sized> ViewLayout<Captures> for RoundedRectangle {
-    type Sublayout = ();
+    type Sublayout = Dimensions;
     type State = ();
 
     fn transition(&self) -> Self::Transition {
@@ -46,15 +46,16 @@ impl<Captures: ?Sized> ViewLayout<Captures> for RoundedRectangle {
         _captures: &mut Captures,
         _state: &mut Self::State,
     ) -> ResolvedLayout<Self::Sublayout> {
+        let dimensions = offer.resolve_most_flexible(0, 1);
         ResolvedLayout {
-            sublayouts: (),
-            resolved_size: offer.resolve_most_flexible(0, 1),
+            sublayouts: dimensions,
+            resolved_size: dimensions,
         }
     }
 
     fn render_tree(
         &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
+        layout: &Self::Sublayout,
         origin: Point,
         _env: &impl LayoutEnvironment,
         _captures: &mut Captures,
@@ -62,7 +63,7 @@ impl<Captures: ?Sized> ViewLayout<Captures> for RoundedRectangle {
     ) -> Self::Renderables {
         crate::render::RoundedRect {
             origin,
-            size: layout.resolved_size.into(),
+            size: (*layout).into(),
             corner_radius: self.corner_radius,
         }
     }

--- a/src/view/spacer.rs
+++ b/src/view/spacer.rs
@@ -61,7 +61,7 @@ impl<Captures: ?Sized> ViewLayout<Captures> for Spacer {
 
     fn render_tree(
         &self,
-        _layout: &ResolvedLayout<Self::Sublayout>,
+        _layout: &Self::Sublayout,
         _origin: Point,
         _env: &impl LayoutEnvironment,
         _captures: &mut Captures,

--- a/src/view/text.rs
+++ b/src/view/text.rs
@@ -399,7 +399,7 @@ where
 
     fn render_tree(
         &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
+        layout: &Self::Sublayout,
         origin: Point,
         _env: &impl LayoutEnvironment,
         _captures: &mut Captures,
@@ -409,7 +409,7 @@ where
             manual_offset,
             wrap_size,
             line_count,
-        } = &layout.sublayouts;
+        } = &layout;
         render::Text {
             origin: origin + Point::new(manual_offset.0.into(), manual_offset.1.into()),
             size: *wrap_size,

--- a/src/view/view_that_fits.rs
+++ b/src/view/view_that_fits.rs
@@ -159,7 +159,7 @@ where
 
     fn render_tree(
         &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
+        layout: &Self::Sublayout,
         origin: Point,
         env: &impl LayoutEnvironment,
         captures: &mut Captures,
@@ -282,19 +282,27 @@ where
 
     fn render_tree(
         &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
+        layout: &Self::Sublayout,
         origin: Point,
         env: &impl LayoutEnvironment,
         captures: &mut Captures,
         state: &mut Self::State,
     ) -> Self::Renderables {
-        match (&layout.sublayouts, state) {
-            (OneOf2::V0(l0), OneOf2::V0(s0)) => {
-                render::OneOf2::V0(self.choices.0.render_tree(l0, origin, env, captures, s0))
-            }
-            (OneOf2::V1(l1), OneOf2::V1(s1)) => {
-                render::OneOf2::V1(self.choices.1.render_tree(l1, origin, env, captures, s1))
-            }
+        match (layout, state) {
+            (OneOf2::V0(l0), OneOf2::V0(s0)) => render::OneOf2::V0(self.choices.0.render_tree(
+                &l0.sublayouts,
+                origin,
+                env,
+                captures,
+                s0,
+            )),
+            (OneOf2::V1(l1), OneOf2::V1(s1)) => render::OneOf2::V1(self.choices.1.render_tree(
+                &l1.sublayouts,
+                origin,
+                env,
+                captures,
+                s1,
+            )),
             _ => panic!("Layout/state branch mismatch"),
         }
     }
@@ -437,22 +445,34 @@ where
 
     fn render_tree(
         &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
+        layout: &Self::Sublayout,
         origin: Point,
         env: &impl LayoutEnvironment,
         captures: &mut Captures,
         state: &mut Self::State,
     ) -> Self::Renderables {
-        match (&layout.sublayouts, state) {
-            (OneOf3::V0(l0), OneOf3::V0(s0)) => {
-                render::OneOf3::V0(self.choices.0.render_tree(l0, origin, env, captures, s0))
-            }
-            (OneOf3::V1(l1), OneOf3::V1(s1)) => {
-                render::OneOf3::V1(self.choices.1.render_tree(l1, origin, env, captures, s1))
-            }
-            (OneOf3::V2(l2), OneOf3::V2(s2)) => {
-                render::OneOf3::V2(self.choices.2.render_tree(l2, origin, env, captures, s2))
-            }
+        match (layout, state) {
+            (OneOf3::V0(l0), OneOf3::V0(s0)) => render::OneOf3::V0(self.choices.0.render_tree(
+                &l0.sublayouts,
+                origin,
+                env,
+                captures,
+                s0,
+            )),
+            (OneOf3::V1(l1), OneOf3::V1(s1)) => render::OneOf3::V1(self.choices.1.render_tree(
+                &l1.sublayouts,
+                origin,
+                env,
+                captures,
+                s1,
+            )),
+            (OneOf3::V2(l2), OneOf3::V2(s2)) => render::OneOf3::V2(self.choices.2.render_tree(
+                &l2.sublayouts,
+                origin,
+                env,
+                captures,
+                s2,
+            )),
             _ => panic!("Layout/state branch mismatch"),
         }
     }
@@ -628,25 +648,41 @@ where
 
     fn render_tree(
         &self,
-        layout: &ResolvedLayout<Self::Sublayout>,
+        layout: &Self::Sublayout,
         origin: Point,
         env: &impl LayoutEnvironment,
         captures: &mut Captures,
         state: &mut Self::State,
     ) -> Self::Renderables {
-        match (&layout.sublayouts, state) {
-            (OneOf4::V0(l0), OneOf4::V0(s0)) => {
-                render::OneOf4::V0(self.choices.0.render_tree(l0, origin, env, captures, s0))
-            }
-            (OneOf4::V1(l1), OneOf4::V1(s1)) => {
-                render::OneOf4::V1(self.choices.1.render_tree(l1, origin, env, captures, s1))
-            }
-            (OneOf4::V2(l2), OneOf4::V2(s2)) => {
-                render::OneOf4::V2(self.choices.2.render_tree(l2, origin, env, captures, s2))
-            }
-            (OneOf4::V3(l3), OneOf4::V3(s3)) => {
-                render::OneOf4::V3(self.choices.3.render_tree(l3, origin, env, captures, s3))
-            }
+        match (&layout, state) {
+            (OneOf4::V0(l0), OneOf4::V0(s0)) => render::OneOf4::V0(self.choices.0.render_tree(
+                &l0.sublayouts,
+                origin,
+                env,
+                captures,
+                s0,
+            )),
+            (OneOf4::V1(l1), OneOf4::V1(s1)) => render::OneOf4::V1(self.choices.1.render_tree(
+                &l1.sublayouts,
+                origin,
+                env,
+                captures,
+                s1,
+            )),
+            (OneOf4::V2(l2), OneOf4::V2(s2)) => render::OneOf4::V2(self.choices.2.render_tree(
+                &l2.sublayouts,
+                origin,
+                env,
+                captures,
+                s2,
+            )),
+            (OneOf4::V3(l3), OneOf4::V3(s3)) => render::OneOf4::V3(self.choices.3.render_tree(
+                &l3.sublayouts,
+                origin,
+                env,
+                captures,
+                s3,
+            )),
             _ => panic!("Layout/state branch mismatch"),
         }
     }

--- a/tests/animation.rs
+++ b/tests/animation.rs
@@ -235,13 +235,25 @@ fn partial_animation_join() {
     let mut env = DefaultEnvironment::new(Duration::from_millis(0));
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    let mut source_tree = view.render_tree(&layout, Point::default(), &env, &mut (), &mut state);
+    let mut source_tree = view.render_tree(
+        &layout.sublayouts,
+        Point::default(),
+        &env,
+        &mut (),
+        &mut state,
+    );
 
     // change both x and y
     // don't update the env app time, so both frames are generated at the same time
     view = stacked_bars_3_value(1, 1, 1, HorizontalAlignment::Trailing);
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    let mut target_tree = view.render_tree(&layout, Point::default(), &env, &mut (), &mut state);
+    let mut target_tree = view.render_tree(
+        &layout.sublayouts,
+        Point::default(),
+        &env,
+        &mut (),
+        &mut state,
+    );
 
     // initial render sets target animation times
     Render::render_animated(
@@ -288,7 +300,13 @@ fn partial_animation_join() {
     env.app_time = Duration::from_millis(1050);
     view = stacked_bars_3_value(1, 2, 1, HorizontalAlignment::Leading);
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    target_tree = view.render_tree(&layout, Point::default(), &env, &mut (), &mut state);
+    target_tree = view.render_tree(
+        &layout.sublayouts,
+        Point::default(),
+        &env,
+        &mut (),
+        &mut state,
+    );
 
     // The previous y animation should continue, but x should jump because the state changed
     // without a change in value
@@ -387,11 +405,23 @@ fn jump_toggle_animation() {
     let mut state = view.build_state(&mut ());
     let mut env = DefaultEnvironment::new(Duration::from_millis(0));
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    let mut source_tree = view.render_tree(&layout, Point::default(), &env, &mut (), &mut state);
+    let mut source_tree = view.render_tree(
+        &layout.sublayouts,
+        Point::default(),
+        &env,
+        &mut (),
+        &mut state,
+    );
 
     view = toggle_move(true, HorizontalAlignment::Trailing);
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    let mut target_tree = view.render_tree(&layout, Point::default(), &env, &mut (), &mut state);
+    let mut target_tree = view.render_tree(
+        &layout.sublayouts,
+        Point::default(),
+        &env,
+        &mut (),
+        &mut state,
+    );
 
     // initial render sets target animation times
     Render::render_animated(
@@ -434,7 +464,13 @@ fn jump_toggle_animation() {
     env.app_time = Duration::from_millis(550);
     view = toggle_move(true, HorizontalAlignment::Leading);
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    target_tree = view.render_tree(&layout, Point::default(), &env, &mut (), &mut state);
+    target_tree = view.render_tree(
+        &layout.sublayouts,
+        Point::default(),
+        &env,
+        &mut (),
+        &mut state,
+    );
 
     Render::render_animated(
         &mut buffer,
@@ -488,12 +524,24 @@ fn nested_toggle_animation() {
     let mut state = view.build_state(&mut ());
     let mut env = DefaultEnvironment::new(Duration::from_millis(0));
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    let mut source_tree = view.render_tree(&layout, Point::default(), &env, &mut (), &mut state);
+    let mut source_tree = view.render_tree(
+        &layout.sublayouts,
+        Point::default(),
+        &env,
+        &mut (),
+        &mut state,
+    );
 
     // don't update the env app time, so both frames are generated at the same time
     view = toggle_stack(true);
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    let mut target_tree = view.render_tree(&layout, Point::default(), &env, &mut (), &mut state);
+    let mut target_tree = view.render_tree(
+        &layout.sublayouts,
+        Point::default(),
+        &env,
+        &mut (),
+        &mut state,
+    );
 
     // initial render sets target animation times
     Render::render_animated(
@@ -546,7 +594,13 @@ fn nested_toggle_animation() {
     env.app_time = Duration::from_millis(550);
     view = toggle_stack(true);
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    target_tree = view.render_tree(&layout, Point::default(), &env, &mut (), &mut state);
+    target_tree = view.render_tree(
+        &layout.sublayouts,
+        Point::default(),
+        &env,
+        &mut (),
+        &mut state,
+    );
 
     Render::render_animated(
         &mut buffer,

--- a/tests/button.rs
+++ b/tests/button.rs
@@ -62,7 +62,13 @@ where
     let env = DefaultEnvironment::default();
     let view = (view)(app_state);
     let layout = view.layout(&size.into(), &env, app_state, view_state);
-    view.render_tree(&layout, Point::zero(), &env, app_state, view_state)
+    view.render_tree(
+        &layout.sublayouts,
+        Point::zero(),
+        &env,
+        app_state,
+        view_state,
+    )
 }
 
 #[test]

--- a/tests/common/helpers.rs
+++ b/tests/common/helpers.rs
@@ -78,5 +78,5 @@ pub fn tree<V: View<char, Data>, Data: ?Sized>(
 ) -> V::Renderables {
     let env = DefaultEnvironment::new(time);
     let layout = view.layout(&size.into(), &env, captures, state);
-    view.render_tree(&layout, Point::zero(), &env, captures, state)
+    view.render_tree(&layout.sublayouts, Point::zero(), &env, captures, state)
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -80,7 +80,13 @@ where
     let env = DefaultEnvironment::default();
     let mut state = view.build_state(captures);
     let layout = view.layout(&size.into(), &env, captures, &mut state);
-    view.render_tree(&layout, Point::zero(), &env, captures, &mut state)
+    view.render_tree(
+        &layout.sublayouts,
+        Point::zero(),
+        &env,
+        captures,
+        &mut state,
+    )
 }
 
 #[allow(dead_code)]
@@ -137,7 +143,7 @@ pub fn tap<V: View<char, Data>, Data: ?Sized>(
     );
 
     let mut tree = view.render_tree(
-        &layout,
+        &layout.sublayouts,
         Point::zero(),
         &DefaultEnvironment::default(),
         captures,

--- a/tests/conditional_view.rs
+++ b/tests/conditional_view.rs
@@ -27,7 +27,7 @@ fn test_conditional_view_layout() {
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
     assert_eq!(layout.resolved_size, Size::new(4, 2).into());
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &env.foreground_color);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "true ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "!!!  ");
@@ -38,7 +38,7 @@ fn test_conditional_view_layout() {
     let view = make_view(false);
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
     assert_eq!(layout.resolved_size, Size::new(1, 1).into());
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &env.foreground_color);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "f    ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "     ");
@@ -61,7 +61,7 @@ fn one_arm_if() {
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
     assert_eq!(layout.resolved_size, Size::new(4, 2).into());
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &env.foreground_color);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "true ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "!!!  ");
@@ -73,7 +73,7 @@ fn one_arm_if() {
     assert!(view.is_empty());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
     assert_eq!(layout.resolved_size, Size::new(0, 0).into());
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &env.foreground_color);
     assert_eq!(buffer.text[0].iter().collect::<String>(), "     ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "     ");

--- a/tests/divider.rs
+++ b/tests/divider.rs
@@ -31,7 +31,7 @@ fn test_horizontal_render() {
     let mut buffer = FixedTextBuffer::<5, 5>::default();
     let env = TestEnv::default().with_direction(LayoutDirection::Horizontal);
     let layout = divider.layout(&buffer.size().into(), &env, &mut (), &mut ());
-    let tree = divider.render_tree(&layout, Point::new(0, 0), &env, &mut (), &mut ());
+    let tree = divider.render_tree(&layout.sublayouts, Point::new(0, 0), &env, &mut (), &mut ());
     tree.render(&mut buffer, &' ');
     assert_eq!(buffer.text[0][0], '|');
     assert_eq!(buffer.text[4][0], '|');
@@ -44,7 +44,7 @@ fn test_vertical_render() {
     let mut buffer = FixedTextBuffer::<5, 5>::default();
     let env = TestEnv::default().with_direction(LayoutDirection::Vertical);
     let layout = divider.layout(&buffer.size().into(), &env, &mut (), &mut ());
-    let tree = divider.render_tree(&layout, Point::new(0, 0), &env, &mut (), &mut ());
+    let tree = divider.render_tree(&layout.sublayouts, Point::new(0, 0), &env, &mut (), &mut ());
     tree.render(&mut buffer, &' ');
     assert_eq!(buffer.text[0][0], '-');
     assert_eq!(buffer.text[0][4], '-');

--- a/tests/embedded_graphics_target/mod.rs
+++ b/tests/embedded_graphics_target/mod.rs
@@ -22,7 +22,7 @@ pub fn render_to_mock(view: &impl View<Rgb888, ()>, allow_overdraw: bool) -> Moc
     let env = DefaultEnvironment::default();
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&target.size().into(), &env, &mut (), &mut state);
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut target, &Rgb888::WHITE);
 
     display

--- a/tests/embedded_graphics_target/text/precise_bounds_character_wrap.rs
+++ b/tests/embedded_graphics_target/text/precise_bounds_character_wrap.rs
@@ -68,7 +68,7 @@ fn rendered_text_bounds(
         &mut state,
     );
     let render_tree = view.render_tree(
-        &layout,
+        &layout.sublayouts,
         Point::zero(),
         &DefaultEnvironment::default(),
         &mut (),

--- a/tests/embedded_graphics_target/text/precise_bounds_word_wrap.rs
+++ b/tests/embedded_graphics_target/text/precise_bounds_word_wrap.rs
@@ -64,7 +64,7 @@ fn rendered_text_bounds(
         &mut state,
     );
     let render_tree = view.render_tree(
-        &layout,
+        &layout.sublayouts,
         Point::zero(),
         &DefaultEnvironment::default(),
         &mut (),

--- a/tests/hstack.rs
+++ b/tests/hstack.rs
@@ -84,7 +84,7 @@ fn test_undersized_layout_3_left_pad() {
     assert_eq!(layout.resolved_size, Dimensions::new(10, 1));
     let mut buffer = FixedTextBuffer::<10, 1>::default();
     hstack
-        .render_tree(&layout, Point::zero(), &env, &mut (), &mut state)
+        .render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state)
         .render(&mut buffer, &' ');
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "1234567   ");
@@ -106,7 +106,7 @@ fn test_undersized_layout_3_right_pad_space() {
     assert_eq!(layout.resolved_size, Dimensions::new(10, 1));
     let mut buffer = FixedTextBuffer::<10, 1>::default();
     hstack
-        .render_tree(&layout, Point::zero(), &env, &mut (), &mut state)
+        .render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state)
         .render(&mut buffer, &' ');
     assert_eq!(buffer.text[0].iter().collect::<String>(), "  234 5678");
 }
@@ -129,7 +129,7 @@ fn test_oversized_layout_3_leading_pad_space() {
     assert_eq!(layout.resolved_size, Dimensions::new(10, 1));
     let mut buffer = FixedTextBuffer::<10, 1>::default();
     hstack
-        .render_tree(&layout, Point::zero(), &env, &mut (), &mut state)
+        .render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state)
         .render(&mut buffer, &' ');
     assert_eq!(buffer.text[0].iter().collect::<String>(), " 234 56789");
 }
@@ -150,7 +150,7 @@ fn test_undersized_layout_3_middle_pad() {
     assert_eq!(layout.resolved_size, Dimensions::new(10, 1));
     let mut buffer = FixedTextBuffer::<10, 1>::default();
     hstack
-        .render_tree(&layout, Point::zero(), &env, &mut (), &mut state)
+        .render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state)
         .render(&mut buffer, &' ');
     assert_eq!(buffer.text[0].iter().collect::<String>(), "234   5678");
 }
@@ -173,7 +173,7 @@ fn test_oversized_layout_3_middle_pad_space() {
     assert_eq!(layout.resolved_size, Dimensions::new(10, 1));
     let mut buffer = FixedTextBuffer::<10, 1>::default();
     hstack
-        .render_tree(&layout, Point::zero(), &env, &mut (), &mut state)
+        .render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state)
         .render(&mut buffer, &' ');
     assert_eq!(buffer.text[0].iter().collect::<String>(), "234  56789");
 }
@@ -196,7 +196,7 @@ fn test_oversized_layout_3_trailing_pad_space() {
     assert_eq!(layout.resolved_size, Dimensions::new(10, 1));
     let mut buffer = FixedTextBuffer::<10, 1>::default();
     hstack
-        .render_tree(&layout, Point::zero(), &env, &mut (), &mut state)
+        .render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state)
         .render(&mut buffer, &' ');
     assert_eq!(buffer.text[0].iter().collect::<String>(), "234 56789 ");
 }
@@ -217,7 +217,7 @@ fn test_layout_3_remainder_allocation() {
     let mut state = hstack.build_state(&mut ());
     let layout = hstack.layout(&offer.into(), &env, &mut (), &mut state);
     hstack
-        .render_tree(&layout, Point::zero(), &env, &mut (), &mut state)
+        .render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state)
         .render(&mut buffer, &' ');
     assert_eq!(buffer.text[0].iter().collect::<String>(), "aaabbcc   ");
 
@@ -225,7 +225,7 @@ fn test_layout_3_remainder_allocation() {
     let mut state = hstack.build_state(&mut ());
     let layout = hstack.layout(&offer.into(), &env, &mut (), &mut state);
     hstack
-        .render_tree(&layout, Point::zero(), &env, &mut (), &mut state)
+        .render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state)
         .render(&mut buffer, &' ');
     assert_eq!(buffer.text[0].iter().collect::<String>(), "aaabbbcc  ");
 
@@ -233,7 +233,7 @@ fn test_layout_3_remainder_allocation() {
     let mut state = hstack.build_state(&mut ());
     let layout = hstack.layout(&offer.into(), &env, &mut (), &mut state);
     hstack
-        .render_tree(&layout, Point::zero(), &env, &mut (), &mut state)
+        .render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state)
         .render(&mut buffer, &' ');
     assert_eq!(buffer.text[0].iter().collect::<String>(), "aaabbbccc ");
 
@@ -241,7 +241,7 @@ fn test_layout_3_remainder_allocation() {
     let mut state = hstack.build_state(&mut ());
     let layout = hstack.layout(&offer.into(), &env, &mut (), &mut state);
     hstack
-        .render_tree(&layout, Point::zero(), &env, &mut (), &mut state)
+        .render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state)
         .render(&mut buffer, &' ');
     assert_eq!(buffer.text[0].iter().collect::<String>(), "aaabbbccc ");
 }

--- a/tests/match_view.rs
+++ b/tests/match_view.rs
@@ -26,7 +26,7 @@ fn test_match_view_two_variants() {
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
     assert_eq!(layout.resolved_size, Size::new(4, 2).into());
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &' ');
     assert_eq!(buffer.text[0].iter().collect::<String>(), "zero ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "!!!  ");
@@ -38,7 +38,7 @@ fn test_match_view_two_variants() {
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
     assert_eq!(layout.resolved_size, Size::new(5, 1).into());
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &' ');
     assert_eq!(buffer.text[0].iter().collect::<String>(), "other");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "     ");
@@ -71,7 +71,7 @@ fn test_match_view_three_variants() {
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
     assert_eq!(layout.resolved_size, Size::new(3, 1).into());
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &' ');
     assert_eq!(buffer.text[0].iter().collect::<String>(), "AAA  ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "     ");
@@ -81,7 +81,7 @@ fn test_match_view_three_variants() {
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
     assert_eq!(layout.resolved_size, Size::new(3, 1).into());
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &' ');
     assert_eq!(buffer.text[0].iter().collect::<String>(), "BBB  ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "     ");
@@ -93,7 +93,7 @@ fn test_match_view_three_variants() {
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
     assert_eq!(layout.resolved_size, Size::new(3, 1).into());
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &' ');
     assert_eq!(buffer.text[0].iter().collect::<String>(), "CCC  ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "     ");
@@ -131,7 +131,13 @@ fn test_match_view_borrow() {
     let mut view_state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut view_state);
     assert_eq!(layout.resolved_size, Size::new(3, 1).into());
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut view_state);
+    let tree = view.render_tree(
+        &layout.sublayouts,
+        Point::zero(),
+        &env,
+        &mut (),
+        &mut view_state,
+    );
     tree.render(&mut buffer, &' ');
     assert_eq!(buffer.text[0].iter().collect::<String>(), "BBB  ");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "     ");
@@ -160,7 +166,7 @@ fn test_match_view_two_variants_invalid_layout() {
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
 
     let view = make_view(1);
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &' ');
     assert_eq!(buffer.text[0].iter().collect::<String>(), "other");
     assert_eq!(buffer.text[1].iter().collect::<String>(), "     ");

--- a/tests/opacity.rs
+++ b/tests/opacity.rs
@@ -21,7 +21,7 @@ fn nonzero_opacity_hands_off_event() {
         &mut state,
     );
     let mut tree = view.render_tree(
-        &layout,
+        &layout.sublayouts,
         Point::zero(),
         &DefaultEnvironment::default(),
         &mut x,
@@ -68,7 +68,7 @@ fn zero_opacity_skips_event_handling() {
         &mut state,
     );
     let mut tree = view.render_tree(
-        &layout,
+        &layout.sublayouts,
         Point::zero(),
         &DefaultEnvironment::default(),
         &mut x,

--- a/tests/priority.rs
+++ b/tests/priority.rs
@@ -19,9 +19,18 @@ fn oversized_layout_vstack() {
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&offer.into(), &env, &mut (), &mut state);
     assert_eq!(layout.resolved_size, Dimensions::new(10, 10));
-    assert_eq!(layout.sublayouts.0.resolved_size, Dimensions::new(5, 1));
-    assert_eq!(layout.sublayouts.1.resolved_size, Dimensions::new(10, 2));
-    assert_eq!(layout.sublayouts.2.resolved_size, Dimensions::new(10, 9));
+    assert_eq!(
+        layout.sublayouts.sublayouts.0.resolved_size,
+        Dimensions::new(5, 1)
+    );
+    assert_eq!(
+        layout.sublayouts.sublayouts.1.resolved_size,
+        Dimensions::new(10, 2)
+    );
+    assert_eq!(
+        layout.sublayouts.sublayouts.2.resolved_size,
+        Dimensions::new(10, 9)
+    );
 }
 
 /// The greedy lower priority view with a non-zero min size results in a layout overflow
@@ -38,7 +47,16 @@ fn oversized_layout_hstack() {
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&offer.into(), &env, &mut (), &mut state);
     assert_eq!(layout.resolved_size, Dimensions::new(10, 10));
-    assert_eq!(layout.sublayouts.0.resolved_size, Dimensions::new(5, 1));
-    assert_eq!(layout.sublayouts.1.resolved_size, Dimensions::new(2, 10));
-    assert_eq!(layout.sublayouts.2.resolved_size, Dimensions::new(5, 10));
+    assert_eq!(
+        layout.sublayouts.sublayouts.0.resolved_size,
+        Dimensions::new(5, 1)
+    );
+    assert_eq!(
+        layout.sublayouts.sublayouts.1.resolved_size,
+        Dimensions::new(2, 10)
+    );
+    assert_eq!(
+        layout.sublayouts.sublayouts.2.resolved_size,
+        Dimensions::new(5, 10)
+    );
 }

--- a/tests/text.rs
+++ b/tests/text.rs
@@ -87,7 +87,7 @@ fn test_clipped_text_is_centered_correctly() {
 
     assert_eq!(layout.resolved_size, Dimensions::new(13, 2));
 
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut ());
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut ());
     tree.render(&mut buffer, &' ');
 
     let lines = [
@@ -119,7 +119,7 @@ fn test_clipped_text_trails_correctly() {
 
     assert_eq!(layout.resolved_size, Dimensions::new(13, 2));
 
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut ());
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut ());
     tree.render(&mut buffer, &' ');
 
     let lines = [

--- a/tests/view_that_fits.rs
+++ b/tests/view_that_fits.rs
@@ -46,7 +46,7 @@ fn single_variant_fits() {
 
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &' ');
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "Single variant");
@@ -61,7 +61,7 @@ fn single_variant_clipped() {
 
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &' ');
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "Single    ");
@@ -76,7 +76,7 @@ fn two_variant_first_fits() {
 
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &' ');
 
     assert_eq!(
@@ -94,7 +94,7 @@ fn two_variant_first_wraps() {
 
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &' ');
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "This is the  ");
@@ -110,7 +110,7 @@ fn two_variant_second_chosen() {
 
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &' ');
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "Second variant");
@@ -125,7 +125,7 @@ fn two_variant_second_clipped() {
 
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &' ');
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "Second    ");
@@ -141,7 +141,7 @@ fn three_variant_first_fits() {
 
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &' ');
 
     assert_eq!(
@@ -159,7 +159,7 @@ fn three_variant_second_chosen() {
 
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &' ');
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "Medium length ");
@@ -174,7 +174,7 @@ fn three_variant_third_chosen() {
 
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &' ');
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "Short");
@@ -189,7 +189,7 @@ fn three_variant_third_clipped() {
 
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &' ');
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "Sho");
@@ -205,7 +205,7 @@ fn four_variant_vertical_first_fully_fits() {
     // Full width, first option should fit
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &' ');
 
     assert_eq!(
@@ -232,7 +232,7 @@ fn four_variant_vertical_wrapping_first() {
     // First option should fit, wrapping 3x
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &' ');
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "12 hours, 16");
@@ -250,7 +250,7 @@ fn four_variant_vertical_second() {
     // First option should fit, wrapping 3x
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &' ');
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "12h 16m 3s ");
@@ -268,7 +268,7 @@ fn four_variant_vertical_third() {
     // First option should fit, wrapping 3x
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &' ');
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "12h  ");
@@ -286,7 +286,7 @@ fn four_variant_vertical_fourth() {
     // First option should fit, wrapping 3x
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &' ');
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "~12h  ");
@@ -302,7 +302,7 @@ fn four_variant_vertical_fourth_clipping() {
     // First option should fit, wrapping 3x
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &' ');
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "~12");
@@ -373,7 +373,7 @@ fn fit_rects_abc() {
     // First option should fit, wrapping 3x
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &' ');
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "aaaabb");
@@ -394,7 +394,7 @@ fn fit_rects_ac() {
     // First option should fit, wrapping 3x
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &' ');
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "aaaaa");
@@ -413,7 +413,7 @@ fn fit_rects_ab() {
     // First option should fit, wrapping 3x
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &' ');
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "aaaabb");
@@ -431,7 +431,7 @@ fn fit_rects_a() {
     // First option should fit, wrapping 3x
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &' ');
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "aaaaa");
@@ -449,7 +449,7 @@ fn fit_rects_a_clip() {
     // First option should fit, wrapping 3x
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &' ');
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "aa");
@@ -472,7 +472,7 @@ fn oversized_height_ignored_for_horizontal() {
     // First option should fit, wrapping 3x
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &' ');
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "aaaa");
@@ -495,7 +495,7 @@ fn oversized_width_ignored_for_vertical() {
     // First option should fit, wrapping 3x
     let mut state = view.build_state(&mut ());
     let layout = view.layout(&buffer.size().into(), &env, &mut (), &mut state);
-    let tree = view.render_tree(&layout, Point::zero(), &env, &mut (), &mut state);
+    let tree = view.render_tree(&layout.sublayouts, Point::zero(), &env, &mut (), &mut state);
     tree.render(&mut buffer, &' ');
 
     assert_eq!(buffer.text[0].iter().collect::<String>(), "aaa");


### PR DESCRIPTION
Breaking change to `render_tree` to accept `Self::Sublayout` instead of `ResolvedLayout<Self::Sublayout>`
Significant improvements in layout size and likely speed by deferring computation to render.

This creates an small but annoying breaking change in the render loop
```diff
let layout = view.layout(...);
- let tree = view.render_tree(&layout, ...);
+ let tree = view.render_tree(&layout.sublayouts, ...);
```