### PR TITLE
Add ViewMarker bounds to view constructors

### DIFF
--- a/src/view.rs
+++ b/src/view.rs
@@ -251,3 +251,29 @@ where
         (*self).handle_event(event, context, render_tree, captures, state)
     }
 }
+
+// This implementation of ViewMarker intentionally has no associated ViewLayout Implementation.
+// This allows the Stack::new to add bounds on the constructor for better error messages
+macro_rules! impl_marker_for_tuple {
+    ($($type:ident),+) => {
+
+        impl<$($type),+> ViewMarker for ($($type),+,)
+        where
+            $($type: ViewMarker),+
+        {
+            type Renderables = ();
+            type Transition = crate::transition::Opacity;
+        }
+    }
+}
+
+impl_marker_for_tuple!(T0);
+impl_marker_for_tuple!(T0, T1);
+impl_marker_for_tuple!(T0, T1, T2);
+impl_marker_for_tuple!(T0, T1, T2, T3);
+impl_marker_for_tuple!(T0, T1, T2, T3, T4);
+impl_marker_for_tuple!(T0, T1, T2, T3, T4, T5);
+impl_marker_for_tuple!(T0, T1, T2, T3, T4, T5, T6);
+impl_marker_for_tuple!(T0, T1, T2, T3, T4, T5, T6, T7);
+impl_marker_for_tuple!(T0, T1, T2, T3, T4, T5, T6, T7, T8);
+impl_marker_for_tuple!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9);

--- a/src/view/button.rs
+++ b/src/view/button.rs
@@ -90,7 +90,7 @@ pub struct Button<ViewFn, Inner, Action> {
     action: Action,
 }
 
-impl<ViewFn, Inner, Action> Button<ViewFn, Inner, Action> {
+impl<ViewFn, Inner: ViewMarker, Action> Button<ViewFn, Inner, Action> {
     #[allow(missing_docs)]
     pub fn new(action: Action, view: ViewFn) -> Self
     where

--- a/src/view/capturing.rs
+++ b/src/view/capturing.rs
@@ -14,7 +14,7 @@ pub struct Lens<InnerView, CaptureFn> {
     capture_fn: CaptureFn,
 }
 
-impl<InnerView, CaptureFn> Lens<InnerView, CaptureFn> {
+impl<InnerView: ViewMarker, CaptureFn> Lens<InnerView, CaptureFn> {
     #[allow(missing_docs)]
     #[must_use]
     pub fn new<OuterCapture, InnerCapture>(inner: InnerView, capture_fn: CaptureFn) -> Self

--- a/src/view/foreach.rs
+++ b/src/view/foreach.rs
@@ -128,6 +128,7 @@ impl<const N: usize> ForEach<N> {
     pub fn new<'a, I, V, F>(items: &'a [I], build_view: F) -> ForEachView<'a, N, I, V, F, Vertical>
     where
         F: Fn(&'a I) -> V,
+        V: ViewMarker,
     {
         Self::new_vertical(items, build_view)
     }
@@ -139,6 +140,7 @@ impl<const N: usize> ForEach<N> {
     ) -> ForEachView<'a, N, I, V, F, Vertical>
     where
         F: Fn(&'a I) -> V,
+        V: ViewMarker,
     {
         ForEachView {
             items,

--- a/src/view/geometry_reader.rs
+++ b/src/view/geometry_reader.rs
@@ -75,7 +75,7 @@ pub struct GeometryReader<ViewFn, Inner> {
     _view_marker: PhantomData<Inner>,
 }
 
-impl<ViewFn: Fn(Size) -> Inner, Inner> GeometryReader<ViewFn, Inner> {
+impl<ViewFn: Fn(Size) -> Inner, Inner: ViewMarker> GeometryReader<ViewFn, Inner> {
     #[allow(missing_docs)]
     #[must_use]
     pub fn new(inner: ViewFn) -> Self {

--- a/src/view/hstack.rs
+++ b/src/view/hstack.rs
@@ -43,7 +43,7 @@ impl<'a, T: LayoutEnvironment> From<&'a T> for HorizontalEnvironment<'a, T> {
     }
 }
 
-impl<T> HStack<T> {
+impl<T: ViewMarker> HStack<T> {
     #[allow(missing_docs)]
     #[must_use]
     pub fn new(items: T) -> Self {
@@ -72,7 +72,10 @@ impl<T> HStack<T> {
     /// available space. However, child views which have no intrinsic ideal size, such as
     /// shapes, may become zero-sized if not contained within e.g. `.fixed_frame`.
     #[must_use]
-    pub fn lazy(self) -> FixedSize<Self> {
+    pub fn lazy(self) -> FixedSize<Self>
+    where
+        Self: ViewMarker,
+    {
         FixedSize::new(true, false, self)
     }
 }

--- a/src/view/modifier.rs
+++ b/src/view/modifier.rs
@@ -57,7 +57,7 @@ use crate::{
 impl<T> ViewModifier for T where T: ViewMarker {}
 
 /// Modifiers that extend the functionality of views.
-pub trait ViewModifier: Sized {
+pub trait ViewModifier: Sized + ViewMarker {
     /// Applies an animation to a view tree. All views in the tree will be animated according to
     /// the animation curve provided when the value changes. The elapsed duration will be reset
     /// if the value changes before the animation is complete.
@@ -168,7 +168,11 @@ pub trait ViewModifier: Sized {
     ///         .foreground_color(Rgb565::WHITE)
     /// }
     /// ```
-    fn background<U>(self, alignment: Alignment, background: U) -> BackgroundView<Self, U> {
+    fn background<U: ViewMarker>(
+        self,
+        alignment: Alignment,
+        background: U,
+    ) -> BackgroundView<Self, U> {
         BackgroundView::new(self, background, alignment)
     }
 
@@ -464,10 +468,7 @@ pub trait ViewModifier: Sized {
     /// }
     /// ```
     fn opacity(self, opacity: u8) -> Opacity<Self> {
-        opacity::Opacity {
-            inner: self,
-            opacity,
-        }
+        opacity::Opacity::new(self, opacity)
     }
 
     /// Overlay uses the modified view to compute bounds, and renders the overlay
@@ -514,7 +515,7 @@ pub trait ViewModifier: Sized {
     ///         .background_color(Rgb888::RED, Capsule)
     /// }
     /// ```
-    fn overlay<U>(self, alignment: Alignment, overlay: U) -> OverlayView<Self, U> {
+    fn overlay<U: ViewMarker>(self, alignment: Alignment, overlay: U) -> OverlayView<Self, U> {
         OverlayView::new(self, overlay, alignment)
     }
 

--- a/src/view/modifier/animated.rs
+++ b/src/view/modifier/animated.rs
@@ -15,7 +15,7 @@ pub struct Animated<InnerView, Value> {
     value: Value,
 }
 
-impl<InnerView, Value: PartialEq> Animated<InnerView, Value> {
+impl<InnerView: ViewMarker, Value: PartialEq> Animated<InnerView, Value> {
     pub const fn new(inner: InnerView, animation: Animation, value: Value) -> Self {
         Self {
             inner,

--- a/src/view/modifier/aspect_ratio.rs
+++ b/src/view/modifier/aspect_ratio.rs
@@ -35,7 +35,7 @@ pub struct AspectRatio<T> {
     child: T,
 }
 
-impl<T> AspectRatio<T> {
+impl<T: ViewMarker> AspectRatio<T> {
     #[allow(missing_docs)]
     #[must_use]
     pub const fn new(child: T, aspect_ratio: Ratio, content_mode: ContentMode) -> Self {

--- a/src/view/modifier/background.rs
+++ b/src/view/modifier/background.rs
@@ -15,7 +15,7 @@ pub struct BackgroundView<T, U> {
     alignment: Alignment,
 }
 
-impl<T, U> BackgroundView<T, U> {
+impl<T: ViewMarker, U: ViewMarker> BackgroundView<T, U> {
     pub const fn new(foreground: T, background: U, alignment: Alignment) -> Self {
         Self {
             foreground,

--- a/src/view/modifier/background_color.rs
+++ b/src/view/modifier/background_color.rs
@@ -18,7 +18,7 @@ pub struct BackgroundColor<T, C, S> {
     background_shape: S,
 }
 
-impl<T, C, S: Shape> BackgroundColor<T, C, S> {
+impl<T: ViewMarker, C, S: Shape> BackgroundColor<T, C, S> {
     pub const fn new(foreground: T, background_color: C, background_shape: S) -> Self {
         Self {
             foreground,

--- a/src/view/modifier/erase_captures.rs
+++ b/src/view/modifier/erase_captures.rs
@@ -23,7 +23,7 @@ pub struct EraseCaptures<T> {
     inner: T,
 }
 
-impl<T> EraseCaptures<T> {
+impl<T: ViewMarker> EraseCaptures<T> {
     #[allow(missing_docs)]
     #[must_use]
     pub fn new(inner: T) -> Self {

--- a/src/view/modifier/fixed_frame.rs
+++ b/src/view/modifier/fixed_frame.rs
@@ -15,7 +15,7 @@ pub struct FixedFrame<T> {
     child: T,
 }
 
-impl<T> FixedFrame<T> {
+impl<T: ViewMarker> FixedFrame<T> {
     pub const fn new(child: T) -> Self {
         Self {
             width: None,

--- a/src/view/modifier/fixed_size.rs
+++ b/src/view/modifier/fixed_size.rs
@@ -15,7 +15,7 @@ pub struct FixedSize<T> {
     child: T,
 }
 
-impl<T> FixedSize<T> {
+impl<T: ViewMarker> FixedSize<T> {
     pub const fn new(horizontal: bool, vertical: bool, child: T) -> Self {
         Self {
             horizontal,

--- a/src/view/modifier/flex_frame.rs
+++ b/src/view/modifier/flex_frame.rs
@@ -19,7 +19,7 @@ pub struct FlexFrame<T> {
     vertical_alignment: VerticalAlignment,
 }
 
-impl<T> FlexFrame<T> {
+impl<T: ViewMarker> FlexFrame<T> {
     pub fn new(child: T) -> Self {
         Self {
             child,
@@ -63,6 +63,13 @@ impl<T> FlexFrame<T> {
     /// Sets the frame to expand to fill as much horizontal space as possible.
     pub const fn with_infinite_max_width(mut self) -> Self {
         self.max_width = Some(Dimension::infinite());
+        self
+    }
+
+    /// Sets the frame to expand to fill as much space as possible.
+    pub const fn with_infinite_max_dimensions(mut self) -> Self {
+        self.max_width = Some(Dimension::infinite());
+        self.max_height = Some(Dimension::infinite());
         self
     }
 

--- a/src/view/modifier/foreground_color.rs
+++ b/src/view/modifier/foreground_color.rs
@@ -14,7 +14,7 @@ pub struct ForegroundStyle<V, S> {
     style: S,
 }
 
-impl<V, S> ForegroundStyle<V, S> {
+impl<V: ViewMarker, S> ForegroundStyle<V, S> {
     pub const fn new(style: S, inner: V) -> Self {
         Self { inner, style }
     }

--- a/src/view/modifier/geometry_group.rs
+++ b/src/view/modifier/geometry_group.rs
@@ -12,7 +12,7 @@ pub struct GeometryGroup<InnerView> {
     inner: InnerView,
 }
 
-impl<InnerView> GeometryGroup<InnerView> {
+impl<InnerView: ViewMarker> GeometryGroup<InnerView> {
     pub const fn new(view: InnerView) -> Self {
         Self { inner: view }
     }

--- a/src/view/modifier/hidden.rs
+++ b/src/view/modifier/hidden.rs
@@ -11,7 +11,7 @@ pub struct Hidden<T> {
     child: T,
 }
 
-impl<T> Hidden<T> {
+impl<T: ViewMarker> Hidden<T> {
     pub const fn new(child: T) -> Self {
         Self { child }
     }

--- a/src/view/modifier/hint_background.rs
+++ b/src/view/modifier/hint_background.rs
@@ -14,7 +14,7 @@ pub struct HintBackground<T, C> {
     hint_color: C,
 }
 
-impl<T, C> HintBackground<T, C> {
+impl<T: ViewMarker, C> HintBackground<T, C> {
     pub const fn new(inner: T, hint_color: C) -> Self {
         Self { inner, hint_color }
     }

--- a/src/view/modifier/offset.rs
+++ b/src/view/modifier/offset.rs
@@ -13,7 +13,7 @@ pub struct Offset<T> {
     offset: Point,
 }
 
-impl<T> Offset<T> {
+impl<T: ViewMarker> Offset<T> {
     pub const fn new(child: T, offset: Point) -> Self {
         Self { child, offset }
     }

--- a/src/view/modifier/opacity.rs
+++ b/src/view/modifier/opacity.rs
@@ -9,8 +9,16 @@ use crate::{
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Opacity<V> {
-    pub inner: V,
-    pub opacity: u8,
+    inner: V,
+    opacity: u8,
+}
+
+impl<V: ViewMarker> Opacity<V> {
+    #[allow(missing_docs)]
+    #[must_use]
+    pub const fn new(inner: V, opacity: u8) -> Self {
+        Self { inner, opacity }
+    }
 }
 
 impl<V> ViewMarker for Opacity<V>

--- a/src/view/modifier/overlay.rs
+++ b/src/view/modifier/overlay.rs
@@ -15,7 +15,7 @@ pub struct OverlayView<T, U> {
     alignment: Alignment,
 }
 
-impl<T, U> OverlayView<T, U> {
+impl<T: ViewMarker, U: ViewMarker> OverlayView<T, U> {
     pub const fn new(foreground: T, overlay: U, alignment: Alignment) -> Self {
         Self {
             foreground,

--- a/src/view/modifier/padding.rs
+++ b/src/view/modifier/padding.rs
@@ -29,7 +29,7 @@ pub struct Padding<T> {
     inner: T,
 }
 
-impl<T> Padding<T> {
+impl<T: ViewMarker> Padding<T> {
     #[allow(missing_docs)]
     pub const fn new(edges: Edges, padding: u32, inner: T) -> Self {
         Self {

--- a/src/view/modifier/priority.rs
+++ b/src/view/modifier/priority.rs
@@ -18,7 +18,7 @@ pub struct Priority<T> {
     child: T,
 }
 
-impl<T> Priority<T> {
+impl<T: ViewMarker> Priority<T> {
     #[allow(missing_docs)]
     pub const fn new(priority: i8, child: T) -> Self {
         Self { priority, child }

--- a/src/view/modifier/scale_effect.rs
+++ b/src/view/modifier/scale_effect.rs
@@ -21,7 +21,7 @@ pub struct ScaleEffect<V> {
     pub anchor: UnitPoint,
 }
 
-impl<V> ScaleEffect<V> {
+impl<V: ViewMarker> ScaleEffect<V> {
     pub fn new(inner: V, scale: ScaleFactor, anchor: UnitPoint) -> Self {
         Self {
             inner,

--- a/src/view/modifier/transition.rs
+++ b/src/view/modifier/transition.rs
@@ -13,7 +13,7 @@ pub struct Transition<V, T> {
     transition: T,
 }
 
-impl<V, T> Transition<V, T> {
+impl<V: ViewMarker, T> Transition<V, T> {
     #[allow(missing_docs)]
     pub const fn new(transition: T, child: V) -> Self {
         Self { child, transition }

--- a/src/view/scroll_view.rs
+++ b/src/view/scroll_view.rs
@@ -124,7 +124,7 @@ pub struct ScrollView<Inner> {
     direction: ScrollDirection,
 }
 
-impl<Inner> ScrollView<Inner> {
+impl<Inner: ViewMarker> ScrollView<Inner> {
     /// Constructs a new [`ScrollView`] with the given inner view.
     #[must_use]
     pub fn new(inner: Inner) -> Self {

--- a/src/view/shape.rs
+++ b/src/view/shape.rs
@@ -15,7 +15,7 @@ use crate::{
     layout::ResolvedLayout,
     primitives::{Point, ProposedDimensions},
     render::{
-        StrokedShape,
+        AnimatedJoin, StrokedShape,
         shape::{AsShapePrimitive, Inset},
     },
     transition::Opacity,
@@ -27,6 +27,8 @@ pub trait Shape:
     ViewMarker<Renderables: Inset + AsShapePrimitive> + ViewLayout<(), State = ()>
 {
     /// Draws a shape with a stroke instead of filling it.
+    ///
+    /// The stroke is drawn inside the shape's bounds.
     #[must_use]
     fn stroked(self, line_width: u32) -> Stroked<Self> {
         Stroked::new(self, StrokeOffset::Inner, line_width)
@@ -66,7 +68,7 @@ pub struct Stroked<T> {
     line_width: u32,
 }
 
-impl<T> Stroked<T> {
+impl<T: ViewMarker<Renderables: Inset + AsShapePrimitive>> Stroked<T> {
     /// Creates a new stroked shape with the given style and line width.
     const fn new(shape: T, style: StrokeOffset, line_width: u32) -> Self {
         Self {
@@ -85,7 +87,7 @@ impl<T: ViewMarker> ViewMarker for Stroked<T> {
 impl<T, Captures: ?Sized> ViewLayout<Captures> for Stroked<T>
 where
     T: ViewLayout<Captures>,
-    T::Renderables: Inset + crate::render::AnimatedJoin + Clone + AsShapePrimitive,
+    T::Renderables: Inset + AnimatedJoin + Clone + AsShapePrimitive,
 {
     type Sublayout = T::Sublayout;
     type State = T::State;

--- a/src/view/view_that_fits.rs
+++ b/src/view/view_that_fits.rs
@@ -86,7 +86,7 @@ pub struct ViewThatFits<T> {
     choices: T,
 }
 
-impl<T> ViewThatFits<(T,)> {
+impl<T: ViewMarker> ViewThatFits<(T,)> {
     #[allow(missing_docs)]
     #[must_use]
     pub const fn new(axis: FitAxis, view: T) -> Self {
@@ -97,10 +97,10 @@ impl<T> ViewThatFits<(T,)> {
     }
 }
 
-impl<T> ViewThatFits<(T,)> {
+impl<T: ViewMarker> ViewThatFits<(T,)> {
     /// An alternative view to use if the first one does not fit.
     #[must_use]
-    pub fn or<V>(self, alternate: V) -> ViewThatFits<(T, V)> {
+    pub fn or<V: ViewMarker>(self, alternate: V) -> ViewThatFits<(T, V)> {
         ViewThatFits {
             axis: self.axis,
             choices: (self.choices.0, alternate),
@@ -113,7 +113,7 @@ macro_rules! derive_or {
         impl<T0, $($type),*> ViewThatFits<(T0, $($type),*)> {
             /// An alternative view to use if the first one does not fit.
             #[must_use]
-            pub fn or<V>(self, alternate: V) -> ViewThatFits<(T0, $($type),*, V)> {
+            pub fn or<V: ViewMarker>(self, alternate: V) -> ViewThatFits<(T0, $($type),*, V)> {
                 ViewThatFits {
                     axis: self.axis,
                     choices: (self.choices.0, $(self.choices.$n),*, alternate),

--- a/src/view/vstack.rs
+++ b/src/view/vstack.rs
@@ -49,7 +49,7 @@ impl<T> PartialEq for VStack<T> {
     }
 }
 
-impl<T> VStack<T> {
+impl<T: ViewMarker> VStack<T> {
     #[allow(missing_docs)]
     #[must_use]
     pub fn new(items: T) -> Self {
@@ -79,7 +79,10 @@ impl<T> VStack<T> {
     /// available space. However, child views which have no intrinsic ideal size, such as
     /// shapes, may become zero-sized if not contained within e.g. `.fixed_frame`.
     #[must_use]
-    pub fn lazy(self) -> FixedSize<Self> {
+    pub fn lazy(self) -> FixedSize<Self>
+    where
+        Self: ViewMarker,
+    {
         FixedSize::new(false, true, self)
     }
 }

--- a/src/view/zstack.rs
+++ b/src/view/zstack.rs
@@ -72,7 +72,7 @@ impl<T> ZStack<T> {
     }
 }
 
-impl<T> ZStack<T> {
+impl<T: ViewMarker> ZStack<T> {
     #[allow(missing_docs)]
     pub fn new(items: T) -> Self {
         Self {


### PR DESCRIPTION
Adds `: ViewMarker` bounds to constructor implementations to try and reduce occurrences of giant cryptic errors