### PR TITLE
Allow drag interaction with elements inside a scroll view

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "buoyant"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Riley Williams"]
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/examples/espresso/main.rs
+++ b/examples/espresso/main.rs
@@ -111,8 +111,8 @@ fn main() {
             // Render animated transition between source and target trees
             app.render_animated(&mut target, &color::Space::WHITE);
 
-            // Draw focus overlay
-            app.draw_focus_overlay(&mut target, color::Space::CSS_YELLOW, 1);
+            // Draws a focus overlay
+            // app.draw_focus_overlay(&mut target, color::Space::CSS_YELLOW, 1);
 
             // Send to the display
             window.update(target.display());

--- a/src/view/scroll_view.rs
+++ b/src/view/scroll_view.rs
@@ -195,9 +195,23 @@ enum ScrollInteraction {
     Dragging {
         drag_start: Point,
         last_point: Point,
-        is_exclusive: bool,
+        target: InteractionTarget,
         touch_id: u8,
     },
+}
+
+/// Tracks the intended target.
+///
+/// This allows inner elements like nested scroll views or sliders
+/// to capture focus
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
+enum InteractionTarget {
+    /// The user is interacting with the scroll view itself
+    Scroll,
+    /// Some element inside the scroll view is being interacted with
+    Inner,
+    #[default]
+    Unknown,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -503,7 +517,7 @@ impl<Inner: ViewLayout<Captures>, Captures> ViewLayout<Captures> for ScrollView<
                             state.interaction = ScrollInteraction::Dragging {
                                 drag_start: point,
                                 last_point: point,
-                                is_exclusive: false,
+                                target: InteractionTarget::Unknown,
                                 touch_id: touch.id,
                             };
 
@@ -529,7 +543,7 @@ impl<Inner: ViewLayout<Captures>, Captures> ViewLayout<Captures> for ScrollView<
                         ScrollInteraction::Dragging {
                             drag_start,
                             last_point,
-                            is_exclusive,
+                            target,
                             ..
                         } => {
                             let delta = point - *last_point;
@@ -539,27 +553,74 @@ impl<Inner: ViewLayout<Captures>, Captures> ViewLayout<Captures> for ScrollView<
 
                             context.request_redraw();
                             // 4 pixels of wiggle without cancelling inner
-                            if !*is_exclusive
-                                && (total_scroll.x.abs() >= 4 || total_scroll.y.abs() >= 4)
-                            {
-                                // cancel inner interaction once we're sure the user intended to scroll
-                                *is_exclusive = true;
-                                let mut cancel_event = touch.clone();
-                                cancel_event.phase = Phase::Cancelled;
-                                // returning the inner result here would move focus before we're committed to scrolling
-                                {
-                                    let _inner_result = self.inner.handle_event(
-                                        &Event::Touch(cancel_event),
+                            match target {
+                                InteractionTarget::Scroll => {
+                                    (EventResult::handled_unfocused(), delta)
+                                }
+                                InteractionTarget::Inner => {
+                                    let inner_result = self.inner.handle_event(
+                                        &event.offset(
+                                            -render_tree.offset() - render_tree.inner.offset,
+                                        ),
                                         context,
                                         render_tree.inner_mut(),
                                         captures,
                                         &mut state.inner_state,
                                         focus,
                                     );
-                                    (EventResult::handled_unfocused(), delta)
+                                    (inner_result, Point::zero())
                                 }
-                            } else {
-                                (EventResult::handled_unfocused(), delta)
+                                InteractionTarget::Unknown => {
+                                    let horizontal_intent = total_scroll.x.abs() >= 4
+                                        && self.direction != ScrollDirection::Vertical;
+                                    let vertical_intent = total_scroll.y.abs() >= 4
+                                        && self.direction != ScrollDirection::Horizontal;
+
+                                    if horizontal_intent || vertical_intent {
+                                        // cancel inner interaction once we're sure the user intended to scroll
+                                        *target = InteractionTarget::Scroll;
+                                        let mut cancel_event = touch.clone();
+                                        cancel_event.phase = Phase::Cancelled;
+                                        // returning the inner result here would move focus before we're committed to scrolling
+                                        {
+                                            let _inner_result = self.inner.handle_event(
+                                                &Event::Touch(cancel_event),
+                                                context,
+                                                render_tree.inner_mut(),
+                                                captures,
+                                                &mut state.inner_state,
+                                                focus,
+                                            );
+                                            (EventResult::handled_unfocused(), delta)
+                                        }
+                                    } else {
+                                        let horizontal_intent = total_scroll.x.abs() >= 8
+                                            && self.direction == ScrollDirection::Vertical;
+                                        let vertical_intent = total_scroll.y.abs() >= 8
+                                            && self.direction == ScrollDirection::Horizontal;
+
+                                        // notify inner of result, don't commit
+                                        let inner_result = self.inner.handle_event(
+                                            &event.offset(
+                                                -render_tree.offset() - render_tree.inner.offset,
+                                            ),
+                                            context,
+                                            render_tree.inner_mut(),
+                                            captures,
+                                            &mut state.inner_state,
+                                            focus,
+                                        );
+                                        let result = if (horizontal_intent || vertical_intent)
+                                            && inner_result.is_handled()
+                                        {
+                                            *target = InteractionTarget::Inner;
+                                            inner_result
+                                        } else {
+                                            EventResult::handled_unfocused()
+                                        };
+                                        (result, delta)
+                                    }
+                                }
                             }
                         }
                         ScrollInteraction::Idle => {
@@ -570,7 +631,7 @@ impl<Inner: ViewLayout<Captures>, Captures> ViewLayout<Captures> for ScrollView<
                         ScrollInteraction::Dragging {
                             drag_start: _,
                             last_point,
-                            is_exclusive,
+                            target,
                             ..
                         } => {
                             state.interaction = ScrollInteraction::Idle;
@@ -578,7 +639,7 @@ impl<Inner: ViewLayout<Captures>, Captures> ViewLayout<Captures> for ScrollView<
                             let delta = point - last_point;
 
                             context.request_view_rebuild();
-                            if is_exclusive {
+                            if target == InteractionTarget::Scroll {
                                 // If we don't set this, the scroll view will not animate the
                                 // snap back
                                 render_tree.inner.subtree.value = true;

--- a/tests/scroll_view/embedded_button.rs
+++ b/tests/scroll_view/embedded_button.rs
@@ -94,10 +94,18 @@ fn button_action_cancelled_by_scroll() {
         &buffer.text
     );
 
-    // cancel touch by moving touch
+    // cancel touch by moving touch up and back
     let ctx = EventContext::new(Duration::from_secs(3));
     view.handle_event(
-        &touch_move(20, 3),
+        &touch_move(2, -4),
+        &ctx,
+        &mut tree,
+        &mut captures,
+        &mut state,
+        &mut DefaultFocus::default_first(),
+    );
+    view.handle_event(
+        &touch_move(2, 3),
         &ctx,
         &mut tree,
         &mut captures,
@@ -129,7 +137,7 @@ fn button_action_cancelled_by_scroll() {
 
     let ctx = EventContext::new(Duration::from_secs(4));
     view.handle_event(
-        &touch_move(2, 2),
+        &touch_move(2, 3),
         &ctx,
         &mut tree,
         &mut captures,

--- a/tests/scroll_view/mod.rs
+++ b/tests/scroll_view/mod.rs
@@ -2,5 +2,6 @@ mod animated_drop;
 mod bounds;
 mod constrained_movement;
 mod embedded_button;
+mod nesting;
 mod pinning;
 mod snapping;

--- a/tests/scroll_view/nesting.rs
+++ b/tests/scroll_view/nesting.rs
@@ -1,0 +1,88 @@
+use buoyant::{
+    app::{App, Harness as _},
+    font::CharacterBufferFont,
+    primitives::{Point, Size},
+    render::Render as _,
+    render_target::FixedTextBuffer,
+    view::{
+        prelude::*,
+        scroll_view::{ScrollBarVisibility, ScrollDirection},
+    },
+};
+
+use crate::assert_str_grid_eq;
+
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn nested_scroll(_: &()) -> impl View<char, ()> + use<> {
+    ScrollView::new(
+        VStack::new((
+            Text::new("1\n2", &CharacterBufferFont),
+            ScrollView::new(Text::new("sideways scrolling text", &CharacterBufferFont))
+                .with_direction(ScrollDirection::Horizontal)
+                .with_bar_visibility(ScrollBarVisibility::Never)
+                .frame()
+                .with_height(2),
+            Text::new("3\n4\n5\n6", &CharacterBufferFont),
+        ))
+        .with_alignment(HorizontalAlignment::Leading),
+    )
+    .with_direction(ScrollDirection::Vertical)
+    .with_bar_visibility(ScrollBarVisibility::Never)
+}
+
+#[test]
+fn nested_horizontal_view() {
+    let state = ();
+    let mut harness = App::new(state, Size::new(12, 5), nested_scroll);
+
+    let mut buffer = FixedTextBuffer::<12, 5>::default();
+
+    harness.finalize_view();
+    harness.render_trees().target().render(&mut buffer, &' ');
+
+    assert_str_grid_eq!(
+        [
+            "1           ",
+            "2           ",
+            "sideways scr",
+            "            ",
+            "3           ",
+        ],
+        &buffer.text
+    );
+
+    harness.drag(Point::new(1, 2), Point::new(-10, 2));
+
+    harness.finalize_view();
+    buffer.clear();
+    harness.render_trees().target().render(&mut buffer, &' ');
+
+    assert_str_grid_eq!(
+        [
+            "1           ",
+            "2           ",
+            "rolling text",
+            "            ",
+            "3           ",
+        ],
+        &buffer.text
+    );
+
+    // Diagonal scroll within the "wiggle" bounds interacts with both
+    harness.drag(Point::new(1, 2), Point::new(3, 1));
+
+    harness.finalize_view();
+    buffer.clear();
+    harness.render_trees().target().render(&mut buffer, &' ');
+
+    assert_str_grid_eq!(
+        [
+            "2           ",
+            "scrolling te",
+            "            ",
+            "3           ",
+            "4           ",
+        ],
+        &buffer.text
+    );
+}


### PR DESCRIPTION
Allows dragging elements like sliders or nested scroll views in the axis perpendicular to scrolling