### PR TITLE
Refactored event mapping

### DIFF
--- a/examples/advanced_input/main.rs
+++ b/examples/advanced_input/main.rs
@@ -18,6 +18,7 @@ mod table;
 use std::process::exit;
 use std::time::{Duration, Instant};
 
+use buoyant::view::map_event::Mapping;
 use buoyant::{
     app::{App, Harness},
     event::{Event, Key, simulator::MouseTracker},
@@ -98,29 +99,29 @@ pub fn view<'a, 'b, C: GoodPixelColor, F: Fn(&State) + 'a + Copy>(
         .background_color(data.palette.dark_blue(), Rectangle)
     })
     .focus_touches()
-    .map_event::<(), _>(|event: &Event, _state| match event {
+    .map_event(|event: &Event, _state| match event {
         Event::KeyDown(key) => match key {
             Key::Character('h') | Key::LeftArrow => {
-                Some(FocusAction::Previous.into_event(focus::GROUP_1))
+                Mapping::Fallback(FocusAction::Previous.into_event(focus::GROUP_1))
             }
             Key::Character('l') | Key::RightArrow => {
-                Some(FocusAction::Next.into_event(focus::GROUP_1))
+                Mapping::Fallback(FocusAction::Next.into_event(focus::GROUP_1))
             }
             Key::Character('k') | Key::UpArrow => {
-                Some(FocusAction::Previous.into_event(focus::GROUP_0))
+                Mapping::Fallback(FocusAction::Previous.into_event(focus::GROUP_0))
             }
             Key::Character('j') | Key::DownArrow => {
-                Some(FocusAction::Next.into_event(focus::GROUP_0))
+                Mapping::Fallback(FocusAction::Next.into_event(focus::GROUP_0))
             }
-            Key::Character(' ' | '\n') => Some(FocusAction::Select.into_event(focus::GROUP_0)),
+            Key::Character(' ' | '\n') => {
+                Mapping::Fallback(FocusAction::Select.into_event(focus::GROUP_0))
+            }
             Key::Character('e') | Key::Backspace => {
-                Some(FocusAction::Blur.into_event(focus::GROUP_0))
+                Mapping::Fallback(FocusAction::Blur.into_event(focus::GROUP_0))
             }
-            // Ignore all other key down events, don't allow children to handle
-            _ => None,
+            _ => Mapping::Passthrough,
         },
-        Event::KeyUp(_) => None,
-        _ => Some(event.clone()),
+        _ => Mapping::Passthrough,
     })
 }
 

--- a/examples/espresso/main.rs
+++ b/examples/espresso/main.rs
@@ -14,6 +14,7 @@ use buoyant::app::{App, Harness};
 use buoyant::event::{Event, Key, simulator::MouseTracker};
 use buoyant::focus::{BoundaryBehavior, FocusAction, Role};
 use buoyant::render_target::{EmbeddedGraphicsRenderTarget, RenderTarget as _};
+use buoyant::view::map_event::Mapping;
 use buoyant::{animation::Animation, match_view, view::prelude::*};
 use embedded_graphics::prelude::*;
 use embedded_graphics_simulator::{OutputSettings, SimulatorDisplay, SimulatorEvent, Window};
@@ -167,16 +168,15 @@ fn root_view(state: &AppState) -> impl View<color::Space, AppState> + use<> {
     .popover(state.clean_overlay.as_ref(), view::clean::clean_overlay)
     .bound_focus(BoundaryBehavior::Wrap)
     .focus_touches()
-    .map_event::<(), _>(|event: &Event, _state| match event {
+    .map_event(|event: &Event, _state| match event {
         Event::KeyDown(key) => match key {
-            Key::UpArrow | Key::LeftArrow => Some(FocusAction::Previous.into()),
-            Key::DownArrow | Key::RightArrow => Some(FocusAction::Next.into()),
-            Key::Character(' ' | '\n') => Some(FocusAction::Select.into()),
-            Key::Backspace | Key::Delete => Some(FocusAction::Blur.into()),
-            _ => Some(event.clone()),
+            Key::UpArrow | Key::LeftArrow => Mapping::Fallback(FocusAction::Previous.into()),
+            Key::DownArrow | Key::RightArrow => Mapping::Fallback(FocusAction::Next.into()),
+            Key::Character(' ' | '\n') => Mapping::Fallback(FocusAction::Select.into()),
+            Key::Backspace | Key::Delete => Mapping::Fallback(FocusAction::Blur.into()),
+            _ => Mapping::Passthrough,
         },
-        Event::KeyUp(_) => None, // Eat key up events
-        _ => Some(event.clone()),
+        _ => Mapping::Passthrough,
     })
 }
 

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -98,6 +98,12 @@ impl FocusGroup {
     }
 }
 
+impl Default for FocusGroup {
+    fn default() -> Self {
+        Self::new_unchecked(0)
+    }
+}
+
 impl FocusGroupSet {
     /// Creates a focus group set matching no focus groups.
     #[must_use]

--- a/src/view.rs
+++ b/src/view.rs
@@ -38,6 +38,7 @@ pub use hstack::HStack;
 #[cfg(feature = "embedded-graphics")]
 pub use image::Image;
 pub use modifier::aspect_ratio;
+pub use modifier::map_event;
 pub use modifier::padding;
 pub use modifier::popover;
 pub use paginate::Paginate;

--- a/src/view/modifier.rs
+++ b/src/view/modifier.rs
@@ -22,7 +22,8 @@ mod foreground_color;
 mod geometry_group;
 mod hidden;
 mod hint_background;
-mod map_event;
+#[allow(missing_docs)]
+pub mod map_event;
 mod multiplex_focus;
 mod offset;
 mod opacity;
@@ -36,7 +37,10 @@ mod scale_effect;
 mod transition;
 mod unfocusable;
 
-use crate::focus::{BoundaryBehavior, FocusGroupSet};
+use crate::{
+    focus::{BoundaryBehavior, FocusGroupSet},
+    view::ViewLayout,
+};
 pub(crate) use animated::Animated;
 pub(crate) use aspect_ratio::AspectRatio;
 pub(crate) use background::BackgroundView;
@@ -528,10 +532,35 @@ pub trait ViewModifier: Sized + ViewMarker {
     }
 
     /// Maps an event, delegating handling of the event to the modified view.
-    fn map_event<S: Default, F: Fn(&Event, &mut S) -> Option<Event>>(
+    fn map_event<C: ?Sized, F: Fn(&Event, &mut C) -> map_event::Mapping>(
         self,
         mapping: F,
-    ) -> MapEvent<Self, F, S> {
+    ) -> MapEvent<Self, impl Fn(&Event, &mut C, &mut ()) -> map_event::Mapping, C, ()>
+    where
+        Self: ViewLayout<C>,
+    {
+        MapEvent::new(self, move |e: &Event, state: &mut C, _sm: &mut ()| {
+            (mapping)(e, state)
+        })
+    }
+
+    /// Maps an event, delegating handling of the event to the modified view.
+    ///
+    /// The mapping closure accepts three arguments:
+    /// - The event
+    /// - The captures
+    /// - A private persisted state, which is persisted for the lifetime of the view.
+    fn map_stateful_event<
+        C: ?Sized,
+        F: Fn(&Event, &mut C, &mut I) -> map_event::Mapping,
+        I: Default,
+    >(
+        self,
+        mapping: F,
+    ) -> MapEvent<Self, F, C, I>
+    where
+        Self: ViewLayout<C>,
+    {
         MapEvent::new(self, mapping)
     }
 

--- a/src/view/modifier/map_event.rs
+++ b/src/view/modifier/map_event.rs
@@ -5,33 +5,57 @@ use crate::{
     view::{ViewLayout, ViewMarker},
 };
 
-#[derive(Debug)]
-pub struct MapEvent<V, F, S> {
+#[derive(Debug, Clone)]
+pub struct MapEvent<V, F, C: ?Sized, I> {
     inner: V,
     mapping: F,
-    _state: PhantomData<S>,
+    _state: PhantomData<I>,
+    _captures: PhantomData<C>,
 }
 
-impl<V: ViewMarker, F: Fn(&Event, &mut S) -> Option<Event>, S: Default> MapEvent<V, F, S> {
+#[derive(Debug, Clone)]
+pub enum Mapping {
+    /// Pass through the event unmodified
+    Passthrough,
+    /// Replace the original event with the provided one
+    Replace(Event),
+    /// Use the mapped event only if the modified view is unable to handle the original event
+    Fallback(Event),
+    /// Defer the event without passing it through to the modified view.
+    ///
+    /// Prefer this over [`Mapping::Handled`] for event types which are unmapped/unhandled
+    /// but should not be passed to the modified view.
+    Defer,
+    /// Report the event as handled without passing through to the modified view.
+    ///
+    /// Returning this may prevent focus from moving or taps from being handled by subsequent views.
+    /// [`Mapping::Defer`] is typically the desired choice.
+    Handled,
+}
+
+impl<C: ?Sized, V: ViewLayout<C>, F: Fn(&Event, &mut C, &mut I) -> Mapping, I: Default>
+    MapEvent<V, F, C, I>
+{
     #[must_use]
     pub const fn new(inner: V, mapping: F) -> Self {
         Self {
             inner,
             mapping,
             _state: PhantomData,
+            _captures: PhantomData,
         }
     }
 }
 
-impl<V: ViewMarker, F: Fn(&Event, &mut S) -> Option<Event>, S> ViewMarker for MapEvent<V, F, S> {
+impl<V: ViewMarker, F, C: ?Sized, I> ViewMarker for MapEvent<V, F, C, I> {
     type Renderables = V::Renderables;
     type Transition = V::Transition;
 }
 
-impl<C: ?Sized, V: ViewLayout<C>, F: Fn(&Event, &mut S) -> Option<Event>, S: 'static + Default>
-    ViewLayout<C> for MapEvent<V, F, S>
+impl<C: ?Sized, V: ViewLayout<C>, F: Fn(&Event, &mut C, &mut I) -> Mapping, I: 'static + Default>
+    ViewLayout<C> for MapEvent<V, F, C, I>
 {
-    type State = (S, V::State);
+    type State = (I, V::State);
 
     type Sublayout = V::Sublayout;
 
@@ -50,7 +74,7 @@ impl<C: ?Sized, V: ViewLayout<C>, F: Fn(&Event, &mut S) -> Option<Event>, S: 'st
     }
 
     fn build_state(&self, captures: &mut C) -> Self::State {
-        (S::default(), self.inner.build_state(captures))
+        (I::default(), self.inner.build_state(captures))
     }
 
     fn layout(
@@ -84,18 +108,44 @@ impl<C: ?Sized, V: ViewLayout<C>, F: Fn(&Event, &mut S) -> Option<Event>, S: 'st
         state: &mut Self::State,
         focus: &mut Self::FocusTree,
     ) -> crate::event::EventResult {
-        let mapped_event = (self.mapping)(event, &mut state.0);
-        if let Some(mapped_event) = mapped_event {
-            self.inner.handle_event(
+        let mapped_event = (self.mapping)(event, captures, &mut state.0);
+        match mapped_event {
+            Mapping::Passthrough => {
+                self.inner
+                    .handle_event(event, context, render_tree, captures, &mut state.1, focus)
+            }
+            Mapping::Replace(mapped_event) => self.inner.handle_event(
                 &mapped_event,
                 context,
                 render_tree,
                 captures,
                 &mut state.1,
                 focus,
-            )
-        } else {
-            EventResult::Deferred
+            ),
+            Mapping::Fallback(mapped_event) => {
+                let result = self.inner.handle_event(
+                    event,
+                    context,
+                    render_tree,
+                    captures,
+                    &mut state.1,
+                    focus,
+                );
+                if result.is_handled() {
+                    result
+                } else {
+                    self.inner.handle_event(
+                        &mapped_event,
+                        context,
+                        render_tree,
+                        captures,
+                        &mut state.1,
+                        focus,
+                    )
+                }
+            }
+            Mapping::Defer => EventResult::Deferred,
+            Mapping::Handled => EventResult::handled_unfocused(),
         }
     }
 }

--- a/tests/focus/modifier/background.rs
+++ b/tests/focus/modifier/background.rs
@@ -5,7 +5,7 @@ use buoyant::{
     layout::Alignment,
     primitives::Size,
     render::ContentShape,
-    view::prelude::*,
+    view::{map_event::Mapping, prelude::*},
 };
 
 struct State {
@@ -111,10 +111,10 @@ fn key_activatable_button<S, F: Fn() -> S, A: Fn(&mut State)>(
 where
     S: View<(), State>,
 {
-    Button::new(action, move |_| shape()).map_event::<(), _>(move |event, ()| match event {
-        Event::KeyDown(Key::Character('\n')) => Some(Event::from(FocusAction::Select)),
-        Event::KeyUp(_) => None,
-        _ => Some(event.clone()),
+    Button::new(action, move |_| shape()).map_event(move |event, _: &mut State| match event {
+        Event::KeyDown(Key::Character('\n')) => Mapping::Replace(Event::from(FocusAction::Select)),
+        Event::KeyUp(_) => Mapping::Defer,
+        _ => Mapping::Passthrough,
     })
 }
 

--- a/tests/focus/modifier/overlay.rs
+++ b/tests/focus/modifier/overlay.rs
@@ -5,7 +5,7 @@ use buoyant::{
     layout::Alignment,
     primitives::Size,
     render::ContentShape,
-    view::prelude::*,
+    view::{map_event::Mapping, prelude::*},
 };
 
 struct State {
@@ -107,10 +107,10 @@ fn key_activatable_button<S>(
 where
     S: View<(), State> + 'static,
 {
-    Button::new(action, move |_| shape()).map_event::<(), _>(move |event, ()| match event {
-        Event::KeyDown(Key::Character('\n')) => Some(Event::from(FocusAction::Select)),
-        Event::KeyUp(_) => None,
-        _ => Some(event.clone()),
+    Button::new(action, move |_| shape()).map_event(move |event, _: &mut State| match event {
+        Event::KeyDown(Key::Character('\n')) => Mapping::Replace(Event::from(FocusAction::Select)),
+        Event::KeyUp(_) => Mapping::Defer,
+        _ => Mapping::Passthrough,
     })
 }
 

--- a/tests/focus/modifier/popover.rs
+++ b/tests/focus/modifier/popover.rs
@@ -4,7 +4,7 @@ use buoyant::{
     focus::{FocusAction, Role},
     primitives::Size,
     render::ContentShape,
-    view::{popover::Dismissal, prelude::*},
+    view::{map_event::Mapping, popover::Dismissal, prelude::*},
 };
 
 fn test_view(state: &State) -> impl View<(), State> + use<> {
@@ -123,10 +123,10 @@ fn key_activatable_button<S>(
 where
     S: View<(), State> + 'static,
 {
-    Button::new(action, move |_| shape()).map_event::<(), _>(move |event, ()| match event {
-        Event::KeyDown(Key::Character('\n')) => Some(Event::from(FocusAction::Select)),
-        Event::KeyUp(_) => None,
-        _ => Some(event.clone()),
+    Button::new(action, move |_| shape()).map_event(move |event, _: &mut State| match event {
+        Event::KeyDown(Key::Character('\n')) => Mapping::Replace(Event::from(FocusAction::Select)),
+        Event::KeyUp(_) => Mapping::Defer,
+        _ => Mapping::Passthrough,
     })
 }
 

--- a/tests/focus/view/foreach.rs
+++ b/tests/focus/view/foreach.rs
@@ -4,7 +4,7 @@ use buoyant::{
     focus::{FocusAction, Role},
     primitives::Size,
     render::ContentShape,
-    view::prelude::*,
+    view::{map_event::Mapping, prelude::*},
 };
 
 #[derive(Default)]
@@ -212,11 +212,13 @@ fn empty_list_end_focus_returns_deferred() {
 fn key_aware_foreach(_: &State) -> impl View<(), State> + use<> {
     ForEach::<3>::new_vertical(&THREE_ITEMS, |&item| {
         let index = item as usize;
-        Button::new(move |s: &mut State| s.selected = Some(index), |_| Circle).map_event::<(), _>(
-            move |event, ()| match event {
-                Event::KeyDown(Key::Character('\n')) => Some(Event::from(FocusAction::Select)),
-                Event::KeyUp(_) => None,
-                _ => Some(event.clone()),
+        Button::new(move |s: &mut State| s.selected = Some(index), |_| Circle).map_event(
+            move |event, _: &mut State| match event {
+                Event::KeyDown(Key::Character('\n')) => {
+                    Mapping::Replace(Event::from(FocusAction::Select))
+                }
+                Event::KeyUp(_) => Mapping::Defer,
+                _ => Mapping::Passthrough,
             },
         )
     })

--- a/tests/focus/view/hstack.rs
+++ b/tests/focus/view/hstack.rs
@@ -4,7 +4,7 @@ use buoyant::{
     focus::{FocusAction, Role},
     primitives::Size,
     render::ContentShape,
-    view::prelude::*,
+    view::{map_event::Mapping, prelude::*},
 };
 
 struct State {
@@ -127,10 +127,10 @@ fn key_activatable_button<S>(
 where
     S: View<(), State> + 'static,
 {
-    Button::new(action, move |_| shape()).map_event::<(), _>(move |event, ()| match event {
-        Event::KeyDown(Key::Character('\n')) => Some(Event::from(FocusAction::Select)),
-        Event::KeyUp(_) => None,
-        _ => Some(event.clone()),
+    Button::new(action, move |_| shape()).map_event(move |event, _: &mut State| match event {
+        Event::KeyDown(Key::Character('\n')) => Mapping::Replace(Event::from(FocusAction::Select)),
+        Event::KeyUp(_) => Mapping::Defer,
+        _ => Mapping::Passthrough,
     })
 }
 

--- a/tests/focus/view/vstack.rs
+++ b/tests/focus/view/vstack.rs
@@ -4,7 +4,7 @@ use buoyant::{
     focus::{FocusAction, Role},
     primitives::Size,
     render::ContentShape,
-    view::prelude::*,
+    view::{map_event::Mapping, prelude::*},
 };
 
 struct State {
@@ -155,10 +155,10 @@ fn key_activatable_button<S>(
 where
     S: View<(), State> + 'static,
 {
-    Button::new(action, move |_| shape()).map_event::<(), _>(move |event, ()| match event {
-        Event::KeyDown(Key::Character('\n')) => Some(Event::from(FocusAction::Select)),
-        Event::KeyUp(_) => None,
-        _ => Some(event.clone()),
+    Button::new(action, move |_| shape()).map_event(move |event, _: &mut State| match event {
+        Event::KeyDown(Key::Character('\n')) => Mapping::Replace(Event::from(FocusAction::Select)),
+        Event::KeyUp(_) => Mapping::Defer,
+        _ => Mapping::Passthrough,
     })
 }
 

--- a/tests/focus/view/zstack.rs
+++ b/tests/focus/view/zstack.rs
@@ -4,7 +4,7 @@ use buoyant::{
     focus::{FocusAction, Role},
     primitives::Size,
     render::ContentShape,
-    view::prelude::*,
+    view::{map_event::Mapping, prelude::*},
 };
 
 struct State {
@@ -277,10 +277,10 @@ fn key_activatable_button<S>(
 where
     S: View<(), State> + 'static,
 {
-    Button::new(action, move |_| shape()).map_event::<(), _>(move |event, ()| match event {
-        Event::KeyDown(Key::Character('\n')) => Some(Event::from(FocusAction::Select)),
-        Event::KeyUp(_) => None,
-        _ => Some(event.clone()),
+    Button::new(action, move |_| shape()).map_event(move |event, _: &mut State| match event {
+        Event::KeyDown(Key::Character('\n')) => Mapping::Replace(Event::from(FocusAction::Select)),
+        Event::KeyUp(_) => Mapping::Defer,
+        _ => Mapping::Passthrough,
     })
 }
 

--- a/tests/map_event.rs
+++ b/tests/map_event.rs
@@ -1,0 +1,189 @@
+use buoyant::{
+    app::{App, Harness},
+    event::{Event, EventResult, Key},
+    focus::{FocusAction, FocusGroup},
+    primitives::{Point, Size, geometry},
+    view::{map_event::Mapping, prelude::*},
+};
+use embedded_graphics::pixelcolor::Rgb888;
+
+#[derive(Clone, Default, PartialEq, Eq, Debug)]
+struct State {
+    taps: u8,
+    location: Point,
+}
+
+fn arrow_pointer() -> impl View<Rgb888, State> + use<> {
+    Circle.map_event(|event, state: &mut State| match event {
+        Event::KeyDown(key) => {
+            match key {
+                Key::UpArrow => state.location.y += 1,
+                Key::DownArrow => state.location.y -= 1,
+                Key::LeftArrow => state.location.x -= 1,
+                Key::RightArrow => state.location.x += 1,
+                _ => (),
+            }
+
+            if geometry::Rectangle::new(Point::new(-2, -2), Size::new(5, 5))
+                .contains(&state.location)
+            {
+                // "handle" events in the rect
+                Mapping::Handled
+            } else {
+                Mapping::Defer
+            }
+        }
+        Event::Focus { action, .. } => match action {
+            FocusAction::Focus(_) => Mapping::Handled,
+            _ => Mapping::Defer,
+        },
+        _ => Mapping::Passthrough,
+    })
+}
+
+fn view(_s: &State) -> impl View<Rgb888, State> + use<> {
+    VStack::new((
+        Button::new(|s: &mut State| s.taps += 1, |_| Rectangle),
+        arrow_pointer(),
+    ))
+    .map_event(|event, _: &mut State| match event {
+        Event::KeyDown(key) => match key {
+            Key::DownArrow | Key::RightArrow => Mapping::Fallback(Event::Focus {
+                action: FocusAction::Next,
+                group: FocusGroup::default(),
+            }),
+            Key::UpArrow | Key::LeftArrow => Mapping::Fallback(Event::Focus {
+                action: FocusAction::Previous,
+                group: FocusGroup::default(),
+            }),
+            _ => Mapping::Passthrough,
+        },
+        _ => Mapping::Passthrough,
+    })
+}
+
+#[test]
+fn map_events() {
+    let mut app = App::new(State::default(), Size::new(10, 10), view);
+    app.focus_forward();
+    app.select();
+    assert_eq!(app.state().taps, 1);
+    // move focus off button
+    app.key_down(Key::DownArrow);
+
+    app.key_down(Key::DownArrow);
+    app.key_down(Key::RightArrow);
+    app.key_down(Key::RightArrow);
+    assert_eq!(app.state().location, Point::new(2, -1));
+
+    // should do nothing, second view still focused
+    app.select();
+    assert_eq!(app.state().taps, 1);
+
+    // move focus to edge of valid rect
+    app.key_down(Key::UpArrow);
+    app.key_down(Key::UpArrow);
+    app.key_down(Key::UpArrow);
+    assert_eq!(app.state().location, Point::new(2, 2));
+
+    // should do nothing, second view still focused
+    app.select();
+    assert_eq!(app.state().taps, 1);
+
+    // moves outside rect, should fallback to outer focus movement
+    app.key_down(Key::UpArrow);
+    app.select();
+    assert_eq!(app.state().taps, 2);
+}
+
+fn replace_view(_s: &State) -> impl View<Rgb888, State> + use<> {
+    Button::new(|s: &mut State| s.taps += 1, |_| Rectangle).map_event(|event, _: &mut State| {
+        match event {
+            Event::KeyDown(Key::Character('\n')) => {
+                Mapping::Replace(Event::from(FocusAction::Select))
+            }
+            _ => Mapping::Passthrough,
+        }
+    })
+}
+
+#[test]
+fn replace_delivers_mapped_event() {
+    let mut app = App::new(State::default(), Size::new(10, 10), replace_view);
+    app.focus_forward();
+    // The mapped '\n' is replaced with Select, activating the focused button.
+    app.key_down(Key::Character('\n'));
+    assert_eq!(app.state().taps, 1);
+    // An unmapped key passes through; the button does not handle it.
+    app.key_down(Key::UpArrow);
+    assert_eq!(app.state().taps, 1);
+}
+
+fn defer_view(_s: &State) -> impl View<Rgb888, State> + use<> {
+    Button::new(|s: &mut State| s.taps += 1, |_| Rectangle).map_event(|event, _: &mut State| {
+        match event {
+            Event::Focus {
+                action: FocusAction::Select,
+                ..
+            } => Mapping::Defer,
+            _ => Mapping::Passthrough,
+        }
+    })
+}
+
+#[test]
+fn defer_withholds_event_from_view() {
+    let mut app = App::new(State::default(), Size::new(10, 10), defer_view);
+    app.focus_forward();
+    // Select is deferred: it never reaches the button and the result is Deferred.
+    let result = app.select();
+    assert_eq!(result, EventResult::Deferred);
+    assert_eq!(app.state().taps, 0);
+}
+
+/// Focus events are reported as handled. You can never leave.
+fn evil_focus_black_hole(_s: &State) -> impl View<Rgb888, State> + use<> {
+    Button::new(|s: &mut State| s.taps += 1, |_| Rectangle).map_event(|event, _: &mut State| {
+        match event {
+            Event::Focus {
+                action: FocusAction::Select,
+                ..
+            } => Mapping::Handled,
+            _ => Mapping::Passthrough,
+        }
+    })
+}
+
+#[test]
+fn handled_reports_handled_without_reaching_view() {
+    let mut app = App::new(State::default(), Size::new(10, 10), evil_focus_black_hole);
+    app.focus_forward();
+    // Select is reported as handled but never reaches the button.
+    let result = app.select();
+    assert!(result.is_handled());
+    assert_eq!(app.state().taps, 0);
+}
+
+fn stateful_view(_s: &State) -> impl View<Rgb888, State> + use<> {
+    Rectangle.map_stateful_event(|event, state: &mut State, count: &mut u8| match event {
+        Event::KeyDown(_) => {
+            *count += 1;
+            state.taps = *count;
+            Mapping::Handled
+        }
+        _ => Mapping::Passthrough,
+    })
+}
+/// Verifies that the private persisted state `I` accumulates across events
+/// rather than resetting.
+#[test]
+fn map_stateful_event_persists_internal_state() {
+    let mut app = App::new(State::default(), Size::new(10, 10), stateful_view);
+    app.focus_forward();
+    app.key_down(Key::UpArrow);
+    assert_eq!(app.state().taps, 1);
+    app.key_down(Key::DownArrow);
+    assert_eq!(app.state().taps, 2);
+    app.key_down(Key::LeftArrow);
+    assert_eq!(app.state().taps, 3);
+}


### PR DESCRIPTION
- Refactors map_event to return a more meaningful type, allowing nested event handling
- Provides view captures in map_event
- Added a new `map_stateful_event` which replaces the old functionality allowing a local persisted state

The most important change is the added `Mapping::Fallback(Event)` which gives child views an opportunity to handle the original event before it gets mapped to the fallback event.