### PR TITLE
Fix stack focus to not perform DFS on key events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "buoyant"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "crossterm",
  "embedded-graphics",

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -23,3 +23,5 @@
   - [App](./event-loops/app.md)
   - [Manual View Lifecycle](./event-loops/manual-view-lifecycle.md)
   - [Manually Animated Render Loops](./event-loops/animated-render-loops.md)
+- [Custom Views](./custom-views.md)
+  - [Event Handling](./custom-views/event-handling.md)

--- a/docs/book/src/custom-views.md
+++ b/docs/book/src/custom-views.md
@@ -1,0 +1,3 @@
+# Building Custom Views
+
+This documentation is in progress ~

--- a/docs/book/src/custom-views/event-handling.md
+++ b/docs/book/src/custom-views/event-handling.md
@@ -1,0 +1,75 @@
+# Event Handling
+
+## `KeyDown` and `KeyUp`
+
+Key events should be routed to the currently focused element. Containers proxy the event to
+the currently focused child only and return `Deferred` if no child is focused. Containers
+should generally not mutate the focus tree or search for a handler.
+
+## `Touch`
+
+Touch events should be routed with depth first search. Non-matching elements should
+return `Deferred`. Elements can signal to the `focus_touches()` modifier that they
+should acquire focus by returning `EventResult::handled_focused()`. Elements like Button
+should return `EventResult::handled_unfocused()` on touch down to indicate the touch
+was handled but focus should not be moved.
+
+## `Focus(_)`
+
+Obtain the current element, or the next one in the specified direction if the current
+element is non-matching.
+
+Leaf views matching the requested role should return `EventResult::handled_focused()`,
+otherwise `Deferred`.
+
+Containers should search, starting with the currently focused child, until a child doesn't
+return `Deferred`. If the container's children are exhausted, it should also return `Deferred`.
+
+### `Next` and `Previous`
+
+Obtain the next or previous matching element.
+
+Leaf views should always return `Deferred`. A leaf only receives `Next` if it is the
+currently focused element.
+
+Containers should search, starting with the currently focused child, until a child doesn't
+return `Deferred`. If the container's children are exhausted, it should also return `Deferred`.
+
+Containers receiving `Next` and `Previous` first pass the event to the currently focused child.
+If the child returns `Deferred`, the container initializes the default focus of the next
+child. The event is exchanged for the corresponding `Focus(Forward/Backward)` so that the
+newly-initialized child can attempt to accept focus. Without this exchange, the first
+element in the new child subtree would never be able to accept focus.
+
+### `Select`
+
+Perform a primary action.
+
+Leaf views matching the requested role should return `EventResult::handled_focused()`,
+otherwise `Deferred`.
+
+Containers should proxy the event to the currently focused child, but should not mutate
+the focus tree nor attempt to locate a previously unfocused child which handles the event.
+
+### `Blur`
+
+Most elements should simply pass the event to the currently focused child and return the result.
+
+Elements which can capture focus should first pass the event to their currently focused
+child. If the child responds with `Deferred`, the captive element should release focus and
+return `EventResult::handled_focused()`. If the child indicates the event was handled,
+captive focus should not be released and the child result returned.
+
+### `Teardown`
+
+Secondary state that tracked an element as being focused should be reset. A stale focus tree
+is about to be dropped, e.g. as a result of a touch causing focus to jump.
+
+`Teardown` should not normally need to be called. It should be assumed that a `Focus(_)` event
+will follow, reasserting focus, if the element is still focused in the new tree. I think
+this (and its associated weirdness) can be removed by adding an `Option<&mut Self::FocusTree>`
+arg to `layout` and `render_tree`. This would alleviate the pesky need to track any extra
+non-source-of-truth state.
+
+Containers must not wrap navigation on `Teardown`: they proxy the event to the currently
+focused child and return the result without looping.

--- a/src/app/harness.rs
+++ b/src/app/harness.rs
@@ -1,7 +1,7 @@
 use embedded_touch::{Tool, Touch};
 
 use crate::{
-    event::{Event, EventResult},
+    event::{Event, EventResult, Key},
     focus::{FocusAction, FocusDirection, FocusGroup},
     primitives::Point,
 };
@@ -81,6 +81,22 @@ pub trait Harness {
     /// Blurs (exits) the current focus in the specified group.
     fn blur_group(&mut self, group: FocusGroup) -> EventResult {
         self.send(FocusAction::Blur.into_event(group))
+    }
+
+    /// Sends a key down event to the currently focused element.
+    fn key_down(&mut self, key: Key) -> EventResult {
+        self.send(Event::KeyDown(key))
+    }
+
+    /// Sends a key up event to the currently focused element.
+    fn key_up(&mut self, key: Key) -> EventResult {
+        self.send(Event::KeyUp(key))
+    }
+
+    /// Sends a key press (down followed by up) to the currently focused element.
+    fn key_press(&mut self, key: Key) -> EventResult {
+        self.send(Event::KeyDown(key));
+        self.send(Event::KeyUp(key))
     }
 
     /// Sends a tap (touch down + touch up) at the given point.

--- a/src/view/foreach.rs
+++ b/src/view/foreach.rs
@@ -392,6 +392,7 @@ where
         renderables
     }
 
+    #[allow(clippy::too_many_lines)]
     fn handle_event(
         &self,
         event: &Event,
@@ -489,6 +490,27 @@ where
                     }
                 }
             }
+        }
+
+        // Key events route only to the currently focused child, not via DFS
+        if matches!(event, Event::KeyDown(_) | Event::KeyUp(_)) {
+            // Unresolved "last" sentinel - no focused child yet
+            if focus.index == usize::MAX {
+                return EventResult::Deferred;
+            }
+            if focus.index >= self.items.len() {
+                return EventResult::Deferred;
+            }
+            let item = &self.items[focus.index];
+            let view = (self.build_view)(item);
+            return view.handle_event(
+                event,
+                context,
+                &mut render_tree[focus.index],
+                captures,
+                &mut state[focus.index],
+                &mut focus.tree,
+            );
         }
 
         // For non-focus events (touch, scroll, etc.), use DFS approach

--- a/src/view/hstack.rs
+++ b/src/view/hstack.rs
@@ -425,6 +425,20 @@ macro_rules! impl_view_for_hstack {
                             }
                         }
                     }
+                } else if matches!(event, Event::KeyDown(_) | Event::KeyUp(_)) {
+                    use super::match_view::[<OneOf $ct>];
+                    return match focus {
+                        $(
+                            [<OneOf $ct>]::[<V $n>](f) => self.items.$n.handle_event(
+                                event,
+                                context,
+                                &mut render_tree.$n,
+                                captures,
+                                &mut state.$n,
+                                f,
+                            ),
+                        )+
+                    };
                 }
 
                 // For non-focus events (touch, scroll, etc.), use DFS approach

--- a/src/view/modifier/background.rs
+++ b/src/view/modifier/background.rs
@@ -148,13 +148,12 @@ where
         state: &mut Self::State,
         focus: &mut Self::FocusTree,
     ) -> EventResult {
-        // Handle focus events specially - they need to route through the focus tree
-        if let Event::Focus {
-            action: focus_event,
-            group,
-        } = event
-        {
-            match focus {
+        match event {
+            // Focus events are routed through the focus tree.
+            Event::Focus {
+                action: focus_event,
+                group,
+            } => match focus {
                 BackgroundFocus::Background(background_focus) => {
                     let result = self.background.handle_event(
                         event,
@@ -234,10 +233,28 @@ where
                         | FocusAction::Teardown => EventResult::Deferred,
                     }
                 }
-            }
-        } else {
-            // For non-focus events (touch, scroll, etc.), perform DFS back to front
-            match focus {
+            },
+            // Key events are focus-routed: deliver only to the currently focused layer.
+            Event::KeyDown(_) | Event::KeyUp(_) => match focus {
+                BackgroundFocus::Background(background_focus) => self.background.handle_event(
+                    event,
+                    context,
+                    &mut render_tree.0,
+                    captures,
+                    &mut state.1,
+                    background_focus,
+                ),
+                BackgroundFocus::Foreground(foreground_focus) => self.foreground.handle_event(
+                    event,
+                    context,
+                    &mut render_tree.1,
+                    captures,
+                    &mut state.0,
+                    foreground_focus,
+                ),
+            },
+            // For hit-test events (touch, scroll), perform DFS back to front
+            Event::Touch(_) | Event::Scroll(_) => match focus {
                 BackgroundFocus::Background(_) => {
                     // Start with background (back)
                     let background_result = self.background.handle_event(
@@ -299,7 +316,7 @@ where
                         },
                     )
                 }
-            }
+            },
         }
     }
 }

--- a/src/view/modifier/overlay.rs
+++ b/src/view/modifier/overlay.rs
@@ -148,13 +148,12 @@ where
         state: &mut Self::State,
         focus: &mut Self::FocusTree,
     ) -> EventResult {
-        // Handle focus events specially - they need to route through the focus tree
-        if let Event::Focus {
-            action: focus_event,
-            group,
-        } = event
-        {
-            match focus {
+        match event {
+            // Focus events are routed through the focus tree.
+            Event::Focus {
+                action: focus_event,
+                group,
+            } => match focus {
                 OverlayFocus::Overlay(overlay_focus) => {
                     let result = self.overlay.handle_event(
                         event,
@@ -234,10 +233,28 @@ where
                         | FocusAction::Teardown => EventResult::Deferred,
                     }
                 }
-            }
-        } else {
-            // For non-focus events (touch, scroll, etc.), perform DFS
-            match focus {
+            },
+            // Key events are focus-routed: deliver only to the currently focused child.
+            Event::KeyDown(_) | Event::KeyUp(_) => match focus {
+                OverlayFocus::Overlay(overlay_focus) => self.overlay.handle_event(
+                    event,
+                    context,
+                    &mut render_tree.1,
+                    captures,
+                    &mut state.1,
+                    overlay_focus,
+                ),
+                OverlayFocus::Foreground(foreground_focus) => self.foreground.handle_event(
+                    event,
+                    context,
+                    &mut render_tree.0,
+                    captures,
+                    &mut state.0,
+                    foreground_focus,
+                ),
+            },
+            // For hit-test events (touch, scroll), perform DFS
+            Event::Touch(_) | Event::Scroll(_) => match focus {
                 OverlayFocus::Overlay(_) => {
                     // Start with overlay
                     let overlay_result = self.overlay.handle_event(
@@ -299,7 +316,7 @@ where
                         },
                     )
                 }
-            }
+            },
         }
     }
 }

--- a/src/view/vstack.rs
+++ b/src/view/vstack.rs
@@ -421,6 +421,20 @@ macro_rules! impl_view_for_vstack {
                             }
                         }
                     }
+                } else if matches!(event, Event::KeyDown(_) | Event::KeyUp(_)) {
+                    use super::match_view::[<OneOf $ct>];
+                    return match focus {
+                        $(
+                            [<OneOf $ct>]::[<V $n>](f) => self.items.$n.handle_event(
+                                event,
+                                context,
+                                &mut render_tree.$n,
+                                captures,
+                                &mut state.$n,
+                                f,
+                            ),
+                        )+
+                    };
                 }
 
                 // For non-focus events (touch, scroll, etc.), use DFS approach

--- a/src/view/zstack.rs
+++ b/src/view/zstack.rs
@@ -267,6 +267,19 @@ macro_rules! impl_view_for_zstack {
                             }
                         }
                     }
+                } else if matches!(event, Event::KeyDown(_) | Event::KeyUp(_)) {
+                    return match focus {
+                        $(
+                            [<OneOf $ct>]::[<V $n>](f) => self.items.$n.handle_event(
+                                event,
+                                context,
+                                &mut render_tree.$n,
+                                captures,
+                                &mut state.$n,
+                                f,
+                            ),
+                        )+
+                    };
                 }
 
                 // For non-focus events (touch, scroll, etc.), use DFS approach

--- a/tests/focus/modifier/background.rs
+++ b/tests/focus/modifier/background.rs
@@ -1,7 +1,7 @@
 use buoyant::{
     app::{App, Harness as _},
-    event::EventResult,
-    focus::Role,
+    event::{Event, EventResult, Key},
+    focus::{FocusAction, Role},
     layout::Alignment,
     primitives::Size,
     render::ContentShape,
@@ -101,4 +101,54 @@ fn empty_background_skips_to_foreground() {
         harness.focus_forward().shape(),
         Some(ContentShape::Circle(_))
     ));
+}
+
+/// A button which can be selected with the newline key down
+fn key_activatable_button<S, F: Fn() -> S, A: Fn(&mut State)>(
+    action: A,
+    shape: F,
+) -> impl View<(), State> + use<S, F, A>
+where
+    S: View<(), State>,
+{
+    Button::new(action, move |_| shape()).map_event::<(), _>(move |event, ()| match event {
+        Event::KeyDown(Key::Character('\n')) => Some(Event::from(FocusAction::Select)),
+        Event::KeyUp(_) => None,
+        _ => Some(event.clone()),
+    })
+}
+
+fn key_aware_background_view(_: &State) -> impl View<(), State> + use<> {
+    key_activatable_button(|s: &mut State| s.foreground_tapped = true, || Circle).background(
+        Alignment::Center,
+        key_activatable_button(|s: &mut State| s.background_tapped = true, || Rectangle),
+    )
+}
+
+#[test]
+fn key_down_routes_to_focused_background_child() {
+    let state = State {
+        foreground_tapped: false,
+        background_tapped: false,
+    };
+    let mut harness =
+        App::new(state, Size::new(100, 100), key_aware_background_view).with_roles(Role::Button);
+
+    // Background receives focus first.
+    assert!(matches!(
+        harness.focus_forward().shape(),
+        Some(ContentShape::Rectangle(_))
+    ));
+    // A key event reaches the focused background button and not the foreground.
+    harness.key_down(Key::Character('\n'));
+    assert!(harness.state().background_tapped);
+    assert!(!harness.state().foreground_tapped);
+
+    // Move to foreground; key now activates foreground only.
+    assert!(matches!(
+        harness.next().shape(),
+        Some(ContentShape::Circle(_))
+    ));
+    harness.key_down(Key::Character('\n'));
+    assert!(harness.state().foreground_tapped);
 }

--- a/tests/focus/modifier/overlay.rs
+++ b/tests/focus/modifier/overlay.rs
@@ -1,7 +1,7 @@
 use buoyant::{
     app::{App, Harness as _},
-    event::EventResult,
-    focus::Role,
+    event::{Event, EventResult, Key},
+    focus::{FocusAction, Role},
     layout::Alignment,
     primitives::Size,
     render::ContentShape,
@@ -98,4 +98,52 @@ fn empty_overlay_skips_to_foreground() {
         harness.focus_forward().shape(),
         Some(ContentShape::Circle(_))
     ));
+}
+
+fn key_activatable_button<S>(
+    action: impl Fn(&mut State) + 'static,
+    shape: impl Fn() -> S + 'static,
+) -> impl View<(), State> + 'static
+where
+    S: View<(), State> + 'static,
+{
+    Button::new(action, move |_| shape()).map_event::<(), _>(move |event, ()| match event {
+        Event::KeyDown(Key::Character('\n')) => Some(Event::from(FocusAction::Select)),
+        Event::KeyUp(_) => None,
+        _ => Some(event.clone()),
+    })
+}
+
+fn key_aware_overlay_view(_: &State) -> impl View<(), State> + use<> {
+    key_activatable_button(|s: &mut State| s.foreground_tapped = true, || Circle).overlay(
+        Alignment::Center,
+        key_activatable_button(|s: &mut State| s.overlay_tapped = true, || Rectangle),
+    )
+}
+
+#[test]
+fn key_down_routes_to_focused_overlay_child() {
+    let state = State {
+        foreground_tapped: false,
+        overlay_tapped: false,
+    };
+    let mut harness =
+        App::new(state, Size::new(100, 100), key_aware_overlay_view).with_roles(Role::Button);
+
+    // Overlay receives focus first.
+    assert!(matches!(
+        harness.focus_forward().shape(),
+        Some(ContentShape::Rectangle(_))
+    ));
+    harness.key_down(Key::Character('\n'));
+    assert!(harness.state().overlay_tapped);
+    assert!(!harness.state().foreground_tapped);
+
+    // Move to foreground, key now activates foreground only.
+    assert!(matches!(
+        harness.next().shape(),
+        Some(ContentShape::Circle(_))
+    ));
+    harness.key_down(Key::Character('\n'));
+    assert!(harness.state().foreground_tapped);
 }

--- a/tests/focus/view/foreach.rs
+++ b/tests/focus/view/foreach.rs
@@ -1,7 +1,7 @@
 use buoyant::{
     app::{App, Harness as _},
-    event::EventResult,
-    focus::Role,
+    event::{Event, EventResult, Key},
+    focus::{FocusAction, Role},
     primitives::Size,
     render::ContentShape,
     view::prelude::*,
@@ -207,4 +207,36 @@ fn empty_list_end_focus_returns_deferred() {
     assert!(matches!(harness.focus_backward(), EventResult::Deferred));
     // closure shouldn't somehow magically be called, idk
     assert!(matches!(harness.select(), EventResult::Deferred));
+}
+
+fn key_aware_foreach(_: &State) -> impl View<(), State> + use<> {
+    ForEach::<3>::new_vertical(&THREE_ITEMS, |&item| {
+        let index = item as usize;
+        Button::new(move |s: &mut State| s.selected = Some(index), |_| Circle).map_event::<(), _>(
+            move |event, ()| match event {
+                Event::KeyDown(Key::Character('\n')) => Some(Event::from(FocusAction::Select)),
+                Event::KeyUp(_) => None,
+                _ => Some(event.clone()),
+            },
+        )
+    })
+}
+
+#[test]
+fn key_down_routes_only_to_focused_child() {
+    let mut harness =
+        App::new(State::default(), Size::new(100, 300), key_aware_foreach).with_roles(Role::Button);
+
+    // Focus the first item.
+    assert!(matches!(
+        harness.focus_forward().shape(),
+        Some(ContentShape::Circle(_))
+    ));
+    harness.key_down(Key::Character('\n'));
+    assert_eq!(harness.state().selected, Some(0));
+
+    // Move to the second item; the key should activate it, not the first.
+    harness.next();
+    harness.key_down(Key::Character('\n'));
+    assert_eq!(harness.state().selected, Some(1));
 }

--- a/tests/focus/view/hstack.rs
+++ b/tests/focus/view/hstack.rs
@@ -1,6 +1,7 @@
 use buoyant::{
     app::{App, Harness as _},
-    focus::Role,
+    event::{Event, EventResult, Key},
+    focus::{FocusAction, Role},
     primitives::Size,
     render::ContentShape,
     view::prelude::*,
@@ -115,4 +116,77 @@ fn focus_skips_leading_unfocusable() {
         harness.focus_forward().shape(),
         Some(ContentShape::Circle(_))
     ));
+}
+
+/// A button that activates on `KeyDown(Enter)` by mapping the key event to a
+/// `Select` focus action.
+fn key_activatable_button<S>(
+    action: impl Fn(&mut State) + 'static,
+    shape: impl Fn() -> S + 'static,
+) -> impl View<(), State> + 'static
+where
+    S: View<(), State> + 'static,
+{
+    Button::new(action, move |_| shape()).map_event::<(), _>(move |event, ()| match event {
+        Event::KeyDown(Key::Character('\n')) => Some(Event::from(FocusAction::Select)),
+        Event::KeyUp(_) => None,
+        _ => Some(event.clone()),
+    })
+}
+
+fn key_aware_hstack(_: &State) -> impl View<(), State> + use<> {
+    HStack::new((
+        key_activatable_button(|s: &mut State| s.a += 1, || Circle),
+        Rectangle,
+        key_activatable_button(|s: &mut State| s.b += 1, || RoundedRectangle::new(10)),
+    ))
+}
+
+#[test]
+fn key_down_routes_only_to_focused_child() {
+    let state = State { a: 0, b: 0, c: 0 };
+    let mut harness =
+        App::new(state, Size::new(100, 100), key_aware_hstack).with_roles(Role::Button);
+
+    // Acquire focus on the first button (a).
+    assert!(matches!(
+        harness.focus_forward().shape(),
+        Some(ContentShape::Circle(_))
+    ));
+
+    // A key down should activate only the focused button.
+    let result = harness.key_down(Key::Character('\n'));
+    assert!(result.is_handled());
+    assert_eq!(harness.state().a, 1);
+    assert_eq!(harness.state().b, 0);
+
+    // Move focus to the second button (b) and verify the key now activates b,
+    // leaving a untouched.
+    assert!(matches!(
+        harness.next().shape(),
+        Some(ContentShape::RoundedRectangle(_))
+    ));
+    harness.key_down(Key::Character('\n'));
+    assert_eq!(harness.state().a, 1);
+    assert_eq!(harness.state().b, 1);
+}
+
+#[test]
+fn key_up_is_eaten_by_map_event() {
+    let state = State { a: 0, b: 0, c: 0 };
+    let mut harness =
+        App::new(state, Size::new(100, 100), key_aware_hstack).with_roles(Role::Button);
+
+    harness.focus_forward();
+
+    let result = harness.key_up(Key::Character('\n'));
+    assert_eq!(result, EventResult::Deferred);
+    assert_eq!(harness.state().a, 0);
+
+    // A full key_press sends down then up; the down activates the button and
+    // the up is eaten, so the final result is Deferred but the side effect
+    // occurred.
+    let result = harness.key_press(Key::Character('\n'));
+    assert_eq!(result, EventResult::Deferred);
+    assert_eq!(harness.state().a, 1);
 }

--- a/tests/focus/view/vstack.rs
+++ b/tests/focus/view/vstack.rs
@@ -1,7 +1,7 @@
 use buoyant::{
     app::{App, Harness as _},
-    event::EventResult,
-    focus::Role,
+    event::{Event, EventResult, Key},
+    focus::{FocusAction, Role},
     primitives::Size,
     render::ContentShape,
     view::prelude::*,
@@ -146,4 +146,51 @@ fn no_focusable_elements_returns_deferred() {
         matches!(harness.focus_forward(), EventResult::Deferred),
         "No focusable elements should return Deferred"
     );
+}
+
+fn key_activatable_button<S>(
+    action: impl Fn(&mut State) + 'static,
+    shape: impl Fn() -> S + 'static,
+) -> impl View<(), State> + 'static
+where
+    S: View<(), State> + 'static,
+{
+    Button::new(action, move |_| shape()).map_event::<(), _>(move |event, ()| match event {
+        Event::KeyDown(Key::Character('\n')) => Some(Event::from(FocusAction::Select)),
+        Event::KeyUp(_) => None,
+        _ => Some(event.clone()),
+    })
+}
+
+fn key_aware_stack(_: &State) -> impl View<(), State> + use<> {
+    VStack::new((
+        key_activatable_button(|s: &mut State| s.a += 1, || Circle),
+        key_activatable_button(|s: &mut State| s.b += 1, || Rectangle),
+        key_activatable_button(|s: &mut State| s.c += 1, || RoundedRectangle::new(10)),
+    ))
+}
+
+#[test]
+fn key_down_routes_only_to_focused_child() {
+    let state = State { a: 0, b: 0, c: 0 };
+    let mut harness =
+        App::new(state, Size::new(100, 300), key_aware_stack).with_roles(Role::Button);
+
+    assert!(matches!(
+        harness.focus_forward().shape(),
+        Some(ContentShape::Circle(_))
+    ));
+    harness.key_down(Key::Character('\n'));
+    assert_eq!(harness.state().a, 1);
+    assert_eq!(harness.state().b, 0);
+    assert_eq!(harness.state().c, 0);
+
+    assert!(matches!(
+        harness.next().shape(),
+        Some(ContentShape::Rectangle(_))
+    ));
+    harness.key_down(Key::Character('\n'));
+    assert_eq!(harness.state().a, 1);
+    assert_eq!(harness.state().b, 1);
+    assert_eq!(harness.state().c, 0);
 }

--- a/tests/focus/view/zstack.rs
+++ b/tests/focus/view/zstack.rs
@@ -1,7 +1,7 @@
 use buoyant::{
     app::{App, Harness as _},
-    event::EventResult,
-    focus::Role,
+    event::{Event, EventResult, Key},
+    focus::{FocusAction, Role},
     primitives::Size,
     render::ContentShape,
     view::prelude::*,
@@ -268,4 +268,51 @@ fn single_item_focus() {
     // Next from only item should return Deferred
     let result = harness.next();
     assert_eq!(result, EventResult::Deferred);
+}
+
+fn key_activatable_button<S>(
+    action: impl Fn(&mut State) + 'static,
+    shape: impl Fn() -> S + 'static,
+) -> impl View<(), State> + 'static
+where
+    S: View<(), State> + 'static,
+{
+    Button::new(action, move |_| shape()).map_event::<(), _>(move |event, ()| match event {
+        Event::KeyDown(Key::Character('\n')) => Some(Event::from(FocusAction::Select)),
+        Event::KeyUp(_) => None,
+        _ => Some(event.clone()),
+    })
+}
+
+fn key_aware_stack(_: &State) -> impl View<(), State> + use<> {
+    ZStack::new((
+        key_activatable_button(|s: &mut State| s.a += 1, || Circle),
+        key_activatable_button(|s: &mut State| s.b += 1, || Rectangle),
+        key_activatable_button(|s: &mut State| s.c += 1, || RoundedRectangle::new(10)),
+    ))
+}
+
+#[test]
+fn key_down_routes_only_to_focused_child() {
+    let state = State { a: 0, b: 0, c: 0 };
+    let mut harness =
+        App::new(state, Size::new(100, 100), key_aware_stack).with_roles(Role::Button);
+
+    assert!(matches!(
+        harness.focus_forward().shape(),
+        Some(ContentShape::Circle(_))
+    ));
+    harness.key_down(Key::Character('\n'));
+    assert_eq!(harness.state().a, 1);
+    assert_eq!(harness.state().b, 0);
+    assert_eq!(harness.state().c, 0);
+
+    assert!(matches!(
+        harness.next().shape(),
+        Some(ContentShape::Rectangle(_))
+    ));
+    harness.key_down(Key::Character('\n'));
+    assert_eq!(harness.state().a, 1);
+    assert_eq!(harness.state().b, 1);
+    assert_eq!(harness.state().c, 0);
 }


### PR DESCRIPTION
Stacks should not move/search focus on key events
Other similar container views updated to route key events correctly