### PR TITLE
Add on_blur option to popover

### DIFF
--- a/src/view.rs
+++ b/src/view.rs
@@ -39,6 +39,7 @@ pub use hstack::HStack;
 pub use image::Image;
 pub use modifier::aspect_ratio;
 pub use modifier::padding;
+pub use modifier::popover;
 pub use paginate::Paginate;
 pub use rotary::Rotary;
 pub use scroll_view::ScrollView;

--- a/src/view/modifier.rs
+++ b/src/view/modifier.rs
@@ -29,7 +29,8 @@ mod opacity;
 mod overlay;
 #[allow(missing_docs)]
 pub mod padding;
-mod popover;
+#[allow(missing_docs)]
+pub mod popover;
 mod priority;
 mod scale_effect;
 mod transition;

--- a/src/view/modifier/popover.rs
+++ b/src/view/modifier/popover.rs
@@ -6,15 +6,55 @@ use crate::{
     focus::{BoundaryBehavior, DefaultFocus, FocusAction, FocusDirection},
     layout::{HorizontalAlignment, ResolvedLayout, VerticalAlignment},
     primitives::Point,
-    render::{Animate, TransitionOption},
+    render::{Animate, IntrinsicShape, TransitionOption},
     view::{ViewLayout, ViewMarker},
 };
 
+/// The decision to either retain or dismiss the active popover on blur
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Dismissal {
+    /// Dismiss the popover, returning focus to the underlying view.
+    Dismiss,
+    /// Keep the overlay focused;
+    Retain,
+}
+
+/// A callback invoked when a popover's overlay receives a `Blur` event.
+///
+/// The handler may mutate captured state (e.g. clearing the value that drives
+/// the overlay's visibility) and then returns a [`Dismissal`] to indicate
+/// whether the overlay should actually be dismissed.
+pub trait OnBlur<Captures: ?Sized> {
+    /// Called when the overlay is blurred. Returns the dismissal decision.
+    fn on_blur(&self, captures: &mut Captures) -> Dismissal;
+}
+
+impl<C: ?Sized, F> OnBlur<C> for F
+where
+    F: Fn(&mut C) -> Dismissal,
+{
+    fn on_blur(&self, captures: &mut C) -> Dismissal {
+        (self)(captures)
+    }
+}
+
+/// An [`OnBlur`] implementation that does not dismiss on blur. This is the
+/// default behavior.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct NoDismiss;
+
+impl<C: ?Sized> OnBlur<C> for NoDismiss {
+    fn on_blur(&self, _captures: &mut C) -> Dismissal {
+        Dismissal::Retain
+    }
+}
+
 #[derive(Debug, Clone)]
-pub struct Popover<Inner, Overlay> {
+pub struct Popover<Inner, Overlay, Action = NoDismiss> {
     inner: Inner,
     overlay: Option<Overlay>,
     boundary_behavior: BoundaryBehavior,
+    on_blur: Action,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -47,7 +87,7 @@ impl<T: DefaultFocus, U: DefaultFocus> DefaultFocus for FocusTree<T, U> {
     }
 }
 
-impl<Inner, Overlay> Popover<Inner, Overlay>
+impl<Inner, Overlay> Popover<Inner, Overlay, NoDismiss>
 where
     Inner: ViewMarker,
     Overlay: ViewMarker,
@@ -63,18 +103,145 @@ where
             inner,
             overlay,
             boundary_behavior: BoundaryBehavior::Stop,
+            on_blur: NoDismiss,
         }
     }
+}
 
+impl<Inner, Overlay, Action> Popover<Inner, Overlay, Action>
+where
+    Inner: ViewMarker,
+    Overlay: ViewMarker,
+{
     /// Modifies the behavior when attempting to move focus beyond the ends of the overlay.
     #[must_use]
     pub fn with_boundary_behavior(mut self, behavior: BoundaryBehavior) -> Self {
         self.boundary_behavior = behavior;
         self
     }
+
+    /// Installs a callback invoked when the overlay receives a `Blur` event.
+    /// This should be used to update state backing the popover and decide whether
+    /// the overlay should be dismissed by the blur.
+    ///
+    /// Returning [`Dismissal::Dismiss`] drops the overlay's focus subtree and
+    /// requests a view rebuild; returning [`Dismissal::Retain`] keeps the
+    /// overlay mounted and focused.
+    ///
+    /// `Teardown` events do not invoke the callback: the overlay's focus tree
+    /// is simply dropped along with the rest of the stale focus tree.
+    #[must_use]
+    pub fn on_blur<F: Fn(&mut C) -> Dismissal, C>(self, on_blur: F) -> Popover<Inner, Overlay, F>
+    where
+        Self: ViewLayout<C>,
+    {
+        Popover {
+            inner: self.inner,
+            overlay: self.overlay,
+            boundary_behavior: self.boundary_behavior,
+            on_blur,
+        }
+    }
+
+    #[allow(clippy::too_many_arguments, clippy::type_complexity)]
+    fn handle_overlay_focus_event<Captures: ?Sized>(
+        &self,
+        overlay_view: &Overlay,
+        focus_event: FocusAction,
+        group: crate::focus::FocusGroup,
+        context: &EventContext,
+        render_tree: &mut <Self as ViewMarker>::Renderables,
+        captures: &mut Captures,
+        state: &mut PopoverState<Inner::State, Overlay::State>,
+        focus: &mut FocusTree<Inner::FocusTree, Overlay::FocusTree>,
+    ) -> EventResult
+    where
+        Inner: ViewLayout<Captures>,
+        Overlay: ViewLayout<Captures>,
+        Action: OnBlur<Captures>,
+        Inner::Renderables: IntrinsicShape,
+    {
+        // FIXME: We don't know when the overlay appears, so we don't get a chance to obtain initial focus
+        // Likely requires rethinking focus overall
+
+        let subfocus = focus
+            .overlay
+            .get_or_insert_with(DefaultFocus::default_first);
+        let overlay_state = state
+            .overlay_state
+            .get_or_insert_with(|| overlay_view.build_state(captures));
+
+        let TransitionOption::Some { subtree, .. } = &mut render_tree.1.subtree else {
+            // TODO: Popover is visible, but we don't have a render tree for it yet
+            return EventResult::Deferred;
+        };
+
+        let result = overlay_view.handle_event(
+            &Event::Focus {
+                action: focus_event,
+                group,
+            },
+            context,
+            subtree,
+            captures,
+            overlay_state,
+            subfocus,
+        );
+
+        if result != EventResult::Deferred {
+            return result;
+        }
+
+        // The overlay's focused subtree did not handle the event.
+        match focus_event {
+            FocusAction::Blur => {
+                match self.on_blur.on_blur(captures) {
+                    Dismissal::Dismiss => {
+                        // Drop the overlay focus subtree; focus returns to the
+                        // inner view.
+                        focus.overlay = None;
+                        context.request_view_rebuild();
+                        EventResult::handled_focused(render_tree.0.content_shape())
+                    }
+                    Dismissal::Retain => EventResult::handled_unfocused(),
+                }
+            }
+            FocusAction::Teardown => EventResult::Deferred,
+            _ => {
+                let is_forward = matches!(
+                    focus_event,
+                    FocusAction::Next | FocusAction::Focus(FocusDirection::Forward)
+                );
+
+                *subfocus = if is_forward {
+                    DefaultFocus::default_first()
+                } else {
+                    DefaultFocus::default_last()
+                };
+                let acquire_direction = if is_forward {
+                    FocusDirection::Forward
+                } else {
+                    FocusDirection::Backward
+                };
+                overlay_view.handle_event(
+                    &Event::Focus {
+                        action: FocusAction::Focus(acquire_direction),
+                        group,
+                    },
+                    context,
+                    subtree,
+                    captures,
+                    overlay_state,
+                    subfocus,
+                )
+            }
+        }
+    }
 }
 
-impl<Inner: ViewMarker, Overlay: ViewMarker> ViewMarker for Popover<Inner, Overlay> {
+impl<Inner: ViewMarker, Overlay: ViewMarker, Action> ViewMarker
+    for Popover<Inner, Overlay, Action>
+{
     type Renderables = (
         Inner::Renderables,
         Animate<TransitionOption<Overlay::Renderables, Overlay::Transition>, bool>,
@@ -83,11 +250,13 @@ impl<Inner: ViewMarker, Overlay: ViewMarker> ViewMarker for Popover<Inner, Overl
     type Transition = Inner::Transition;
 }
 
-impl<Captures, Inner, Overlay> ViewLayout<Captures> for Popover<Inner, Overlay>
+impl<Captures, Inner, Overlay, Action> ViewLayout<Captures> for Popover<Inner, Overlay, Action>
 where
     Captures: ?Sized,
     Inner: ViewLayout<Captures>,
     Overlay: ViewLayout<Captures>,
+    Action: OnBlur<Captures>,
+    Inner::Renderables: IntrinsicShape,
 {
     type State = PopoverState<Inner::State, Overlay::State>;
     type Sublayout = ResolvedLayout<Inner::Sublayout>;
@@ -198,69 +367,16 @@ where
         } = event
         {
             if let Some(overlay_view) = &self.overlay {
-                // Overlay is active - ensure we have overlay focus state
-
-                // FIXME: We don't know when the overlay appears, so we don't get a chance to obtain initial focus
-                // Likely requires rethinking focus overall
-
-                let subfocus = focus
-                    .overlay
-                    .get_or_insert_with(DefaultFocus::default_first);
-                let overlay_state = state
-                    .overlay_state
-                    .get_or_insert_with(|| overlay_view.build_state(captures));
-
-                if let TransitionOption::Some { subtree, .. } = &mut render_tree.1.subtree {
-                    let result = overlay_view.handle_event(
-                        &Event::Focus {
-                            action: *focus_event,
-                            group: *group,
-                        },
-                        context,
-                        subtree,
-                        captures,
-                        overlay_state,
-                        subfocus,
-                    );
-
-                    if result == EventResult::Deferred {
-                        // Determine if we were moving forward or backward
-                        let is_forward = matches!(
-                            focus_event,
-                            FocusAction::Next | FocusAction::Focus(FocusDirection::Forward)
-                        );
-
-                        // Wrap to the opposite end based on direction
-                        // Reset focus tree to the appropriate end
-                        *subfocus = if is_forward {
-                            DefaultFocus::default_first()
-                        } else {
-                            DefaultFocus::default_last()
-                        };
-                        // Acquire focus at the wrapped position (don't navigate again)
-                        let acquire_direction = if is_forward {
-                            FocusDirection::Forward
-                        } else {
-                            FocusDirection::Backward
-                        };
-                        return overlay_view.handle_event(
-                            &Event::Focus {
-                                action: FocusAction::Focus(acquire_direction),
-                                group: *group,
-                            },
-                            context,
-                            subtree,
-                            captures,
-                            overlay_state,
-                            subfocus,
-                        );
-                    }
-
-                    return result;
-                }
-                // TODO: Popover is visible, but we don't have a render tree for it yet
-                // Just dump all these events?
-                return EventResult::Deferred;
+                return self.handle_overlay_focus_event(
+                    overlay_view,
+                    *focus_event,
+                    *group,
+                    context,
+                    render_tree,
+                    captures,
+                    state,
+                    focus,
+                );
             }
             // Overlay is not active - clear overlay focus and use inner focus
             focus.overlay = None;

--- a/tests/focus/modifier/popover.rs
+++ b/tests/focus/modifier/popover.rs
@@ -1,9 +1,10 @@
 use buoyant::{
     app::{App, Harness as _},
-    focus::Role,
+    event::{Event, Key},
+    focus::{FocusAction, Role},
     primitives::Size,
     render::ContentShape,
-    view::prelude::*,
+    view::{popover::Dismissal, prelude::*},
 };
 
 fn test_view(state: &State) -> impl View<(), State> + use<> {
@@ -112,5 +113,219 @@ fn popover_wraps_focus_backward() {
         matches!(result.shape(), Some(ContentShape::RoundedRectangle(_))),
         "Should wrap to last element (RoundedRectangle) when moving backward from start, got {:?}",
         result.shape()
+    );
+}
+
+fn key_activatable_button<S>(
+    action: impl Fn(&mut State) + 'static,
+    shape: impl Fn() -> S + 'static,
+) -> impl View<(), State> + 'static
+where
+    S: View<(), State> + 'static,
+{
+    Button::new(action, move |_| shape()).map_event::<(), _>(move |event, ()| match event {
+        Event::KeyDown(Key::Character('\n')) => Some(Event::from(FocusAction::Select)),
+        Event::KeyUp(_) => None,
+        _ => Some(event.clone()),
+    })
+}
+
+fn key_aware_popover_view(state: &State) -> impl View<(), State> + use<> {
+    key_activatable_button(|s: &mut State| s.main_tapped = true, || Rectangle).popover(
+        state.popover_visible.as_ref(),
+        |()| {
+            VStack::new((
+                Rectangle,
+                key_activatable_button(|s: &mut State| s.popover_a_tapped = true, || Circle)
+                    .frame_sized(50, 50),
+                key_activatable_button(
+                    |s: &mut State| s.popover_b_tapped = true,
+                    || RoundedRectangle::new(5),
+                )
+                .frame_sized(50, 50),
+            ))
+        },
+    )
+}
+
+#[test]
+fn key_routes_to_overlay_when_present() {
+    let state = State::default().with_popover();
+    let mut harness =
+        App::new(state, Size::new(100, 100), key_aware_popover_view).with_roles(Role::Button);
+
+    // Focus enters the overlay which is initially visible
+    assert!(matches!(
+        harness.focus_forward().shape(),
+        Some(ContentShape::Circle(_))
+    ));
+    // A key event must reach the overlay's focused button, not the inner view.
+    harness.key_down(Key::Character('\n'));
+    assert!(harness.state().popover_a_tapped);
+    assert!(!harness.state().main_tapped);
+}
+
+#[test]
+fn key_routes_to_inner_when_overlay_absent() {
+    let state = State::default();
+    let mut harness =
+        App::new(state, Size::new(100, 100), key_aware_popover_view).with_roles(Role::Button);
+
+    assert!(matches!(
+        harness.focus_forward().shape(),
+        Some(ContentShape::Rectangle(_))
+    ));
+    harness.key_down(Key::Character('\n'));
+    assert!(harness.state().main_tapped);
+    assert!(!harness.state().popover_a_tapped);
+}
+
+fn dismissible_popover_view(state: &State) -> impl View<(), State> + use<> {
+    Button::new(|s: &mut State| s.main_tapped = true, |_| Rectangle)
+        .popover(state.popover_visible.as_ref(), |()| {
+            VStack::new((
+                Rectangle,
+                Button::new(|s: &mut State| s.popover_a_tapped = true, |_| Circle)
+                    .frame_sized(50, 50),
+            ))
+        })
+        .on_blur(|s: &mut State| {
+            s.popover_visible = None;
+            Dismissal::Dismiss
+        })
+}
+
+/// When the overlay's focused child defers a `Blur`, the popover consults the
+/// `on_blur` handler. Returning [`Dismissal::Dismiss`] drops the overlay's
+/// focus subtree and requests a view rebuild; the callback clears the state
+/// driving the overlay's visibility, so the next focus acquisition lands on
+/// the inner view.
+#[test]
+fn blur_releases_overlay_via_on_dismiss() {
+    let state = State::default().with_popover();
+    let mut harness =
+        App::new(state, Size::new(100, 100), dismissible_popover_view).with_roles(Role::Button);
+
+    // Overlay is active; focus is on the first overlay button.
+    assert!(matches!(
+        harness.focus_forward().shape(),
+        Some(ContentShape::Circle(_))
+    ));
+
+    // Blurring should dismiss the overlay. The result is handled with focus
+    // returned to the inner view (Rectangle).
+    let result = harness.blur();
+    assert!(result.is_handled());
+    assert!(
+        matches!(result.shape(), Some(ContentShape::Rectangle(_))),
+        "Focus should return to the inner view (Rectangle), got {:?}",
+        result.shape()
+    );
+
+    // The dismiss callback cleared the overlay visibility flag.
+    assert!(
+        harness.state().popover_visible.is_none(),
+        "on_blur should have cleared the overlay visibility flag"
+    );
+
+    // The view rebuild is pending (requested by the dismiss). Finalizing it
+    // rebuilds the view without the overlay and re-acquires focus, which must
+    // land on the inner view (Rectangle).
+    harness.finalize_view();
+    assert!(
+        matches!(harness.focus_shape(), ContentShape::Rectangle(_)),
+        "Focus should return to the inner view (Rectangle) after rebuild, got {:?}",
+        harness.focus_shape()
+    );
+}
+
+/// `Teardown` must not wrap focus within the overlay nor invoke the dismiss
+/// callback. The overlay focus subtree is simply dropped along with the rest
+/// of the stale focus tree.
+#[test]
+fn teardown_does_not_dismiss() {
+    let state = State::default().with_popover();
+    let mut harness =
+        App::new(state, Size::new(100, 100), dismissible_popover_view).with_roles(Role::Button);
+
+    assert!(matches!(
+        harness.focus_forward().shape(),
+        Some(ContentShape::Circle(_))
+    ));
+
+    // Send a Teardown event. The focused Button handles it by returning
+    // handled_unfocused (resetting its focused state); the popover proxies
+    // that result without wrapping or invoking on_blur.
+    let result = harness.send(FocusAction::Teardown);
+    assert!(
+        result.is_handled(),
+        "Teardown proxied to the focused child should be handled"
+    );
+    assert!(
+        harness.state().popover_visible.is_some(),
+        "on_blur must not fire for Teardown"
+    );
+}
+
+/// Without an `on_blur` handler, the default [`NoDismiss`] returns
+/// [`Dismissal::Retain`]: blur does not tear down the overlay.
+#[test]
+fn blur_retains_overlay_by_default() {
+    let state = State::default().with_popover();
+    let mut harness =
+        App::new(state, Size::new(100, 100), key_aware_popover_view).with_roles(Role::Button);
+
+    assert!(matches!(
+        harness.focus_forward().shape(),
+        Some(ContentShape::Circle(_))
+    ));
+
+    let result = harness.blur();
+    assert!(result.is_handled());
+    // No content shape for a retained blur.
+    assert!(
+        matches!(result.shape(), Some(ContentShape::Empty)),
+        "Retained blur should report an empty content shape, got {:?}",
+        result.shape()
+    );
+    assert!(
+        harness.state().popover_visible.is_some(),
+        "default NoDismiss should retain the overlay"
+    );
+}
+
+/// An explicit `on_blur` handler returning [`Dismissal::Retain`] keeps the
+/// overlay active
+#[test]
+fn blur_retains_overlay_via_on_blur_retain() {
+    let state = State::default().with_popover();
+    let view = |state: &State| {
+        Button::new(|s: &mut State| s.main_tapped = true, |_| Rectangle)
+            .popover(state.popover_visible.as_ref(), |()| {
+                VStack::new((
+                    Rectangle,
+                    Button::new(|s: &mut State| s.popover_a_tapped = true, |_| Circle)
+                        .frame_sized(50, 50),
+                ))
+            })
+            .on_blur(|_s: &mut State| Dismissal::Retain)
+    };
+    let mut harness = App::new(state, Size::new(100, 100), view).with_roles(Role::Button);
+
+    assert!(matches!(
+        harness.focus_forward().shape(),
+        Some(ContentShape::Circle(_))
+    ));
+
+    let result = harness.blur();
+    assert!(result.is_handled());
+    assert!(
+        matches!(result.shape(), Some(ContentShape::Empty)),
+        "Retained blur should report an empty content shape, got {:?}",
+        result.shape()
+    );
+    assert!(
+        harness.state().popover_visible.is_some(),
+        "Retain should keep the overlay mounted"
     );
 }


### PR DESCRIPTION
Adds `on_blur` option to allow dismissing popovers in response to blur events