### PR TITLE
feat(view): add ScrollView::with_initial_pin_to_end

### DIFF
--- a/src/view/scroll_view.rs
+++ b/src/view/scroll_view.rs
@@ -124,6 +124,7 @@ pub struct ScrollView<Inner> {
     inner: Inner,
     bar_config: ScrollBarConfig,
     direction: ScrollDirection,
+    initial_pin_to_end: bool,
 }
 
 impl<Inner: ViewMarker> ScrollView<Inner> {
@@ -134,6 +135,7 @@ impl<Inner: ViewMarker> ScrollView<Inner> {
             inner,
             bar_config: ScrollBarConfig::default(),
             direction: ScrollDirection::default(),
+            initial_pin_to_end: false,
         }
     }
 
@@ -141,6 +143,17 @@ impl<Inner: ViewMarker> ScrollView<Inner> {
     #[must_use]
     pub fn with_direction(mut self, direction: ScrollDirection) -> Self {
         self.direction = direction;
+        self
+    }
+
+    /// Starts the scroll view pinned to the end of its content along the scroll axis.
+    ///
+    /// When enabled, a freshly built state renders its first frame scrolled to the
+    /// trailing edge (bottom for vertical, right for horizontal) and follows content
+    /// growth until the user scrolls away from the end.
+    #[must_use]
+    pub fn with_initial_pin_to_end(mut self, pin: bool) -> Self {
+        self.initial_pin_to_end = pin;
         self
     }
 
@@ -244,11 +257,21 @@ impl<Inner: ViewLayout<Captures>, Captures> ViewLayout<Captures> for ScrollView<
     }
 
     fn build_state(&self, captures: &mut Captures) -> Self::State {
+        let content_pinning = if self.initial_pin_to_end {
+            let (horizontal, vertical) = match self.direction {
+                ScrollDirection::Vertical => (false, true),
+                ScrollDirection::Horizontal => (true, false),
+                ScrollDirection::Both => (true, true),
+            };
+            ContentPinning::Pinned(horizontal, vertical)
+        } else {
+            ContentPinning::Floating
+        };
         Self::State {
             scroll_offset: Point::zero(),
             interaction: ScrollInteraction::Idle,
             inner_state: self.inner.build_state(captures),
-            content_pinning: ContentPinning::Floating,
+            content_pinning,
         }
     }
 

--- a/tests/scroll_view/pinning.rs
+++ b/tests/scroll_view/pinning.rs
@@ -21,6 +21,48 @@ fn log_viewer(text: &str) -> impl View<char, ()> {
         .padding(Edges::All, 1)
 }
 
+/// A scrolling log viewer that starts pinned to the bottom
+fn pinned_log_viewer(text: &str) -> impl View<char, ()> {
+    ScrollView::new(Text::new(text, &CharacterBufferFont))
+        .with_direction(ScrollDirection::Vertical)
+        .with_initial_pin_to_end(true)
+        .with_bar_visibility(buoyant::view::scroll_view::ScrollBarVisibility::Never)
+        .padding(Edges::All, 1)
+}
+
+#[test]
+fn initial_pin_to_end_renders_first_frame_at_bottom() {
+    let mut buffer = FixedTextBuffer::<12, 5>::default();
+    let size = Size::new(12, 5);
+
+    let text = "Line1\nLine2\nLine3\nLine4\nLine5\nLine6";
+    let mut captures = ();
+    let view = pinned_log_viewer(text);
+    let mut state = view.build_state(&mut captures);
+
+    let tree = helpers::tree(
+        &view,
+        &mut captures,
+        &mut state,
+        Duration::from_secs(1),
+        size,
+    );
+
+    tree.render(&mut buffer, &' ');
+
+    // First frame is already scrolled to the bottom
+    assert_str_grid_eq!(
+        [
+            "            ",
+            " Line4      ",
+            " Line5      ",
+            " Line6      ",
+            "            ",
+        ],
+        &buffer.text
+    );
+}
+
 #[test]
 fn scrolled_to_bottom_stays_at_bottom_with_longer_content() {
     let mut buffer = FixedTextBuffer::<12, 5>::default();


### PR DESCRIPTION
I noticed that when I wanted to display live logs, it will always jump down when I open the page with logs. It is because it will always start with the state where they're up and needs a frame to go down. This modifier fixes it.